### PR TITLE
Add explicit Pydantic response models for API endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,4 +55,5 @@
 - Keep API handlers in routers thin: parsing/validation only, no embedded SQL.
 - Put telemetry metric queries in `services/` to keep logic testable and reusable.
 - Align queries to production telemetry schema (`utc_time`, `metadata_`, `trace`).
+- Define explicit Pydantic response models for endpoints to keep OpenAPI and TypeScript client types stable.
 - Start with Python-managed SQL; add database views/materialized views only if query latency requires it.

--- a/nextflow_telemetry/models.py
+++ b/nextflow_telemetry/models.py
@@ -61,3 +61,148 @@ class Telemetry(BaseModel):
     timestamp: datetime.datetime = Field(..., alias="utcTime")
     metadata: Optional[Any] # Optional[Metadata]
     trace: Optional[Any] # Optional[Trace]
+
+
+class HealthResponse(BaseModel):
+    message: str
+    status: str
+    database: str
+
+
+class HealthErrorResponse(BaseModel):
+    detail: HealthResponse
+
+
+class ProcessSummaryCards(BaseModel):
+    process_completed_rows: int
+    distinct_runs: int
+    distinct_processes: int
+    success_rows: int
+    failure_rows: int
+    failure_pct: float
+    retried_rows: int
+    retry_pct: float
+    retry_success_pct: float
+    latest_process_completed_utc: Optional[datetime.datetime]
+
+
+class EventMixRow(BaseModel):
+    event: str
+    rows: int
+
+
+class TopFailureRow(BaseModel):
+    process: str
+    total_completed: int
+    failed: int
+    failure_pct: float
+
+
+class TopRetryRow(BaseModel):
+    process: str
+    total_completed: int
+    retried: int
+    retried_pct: float
+    retried_success: int
+    retried_failed: int
+
+
+class TopFailureExitCodeRow(BaseModel):
+    exit_code: str
+    failures: int
+
+
+class ProcessSummaryResponse(BaseModel):
+    generated_at_utc: datetime.datetime
+    window_days: Optional[int]
+    cards: ProcessSummaryCards
+    event_mix: list[EventMixRow]
+    top_failures: list[TopFailureRow]
+    top_retries: list[TopRetryRow]
+    top_failure_exit_codes: list[TopFailureExitCodeRow]
+
+
+class RetrySummary(BaseModel):
+    process_completed_rows: int
+    retried_rows: int
+    retried_pct: float
+    retry_success_rows: int
+    retry_failure_rows: int
+    retry_success_pct: float
+
+
+class RetryByAttemptRow(BaseModel):
+    attempt: int
+    rows: int
+    success: int
+    failed: int
+
+
+class RetryByProcessRow(BaseModel):
+    process: str
+    total_completed: int
+    retried: int
+    retried_pct: float
+    retried_success: int
+    retried_failed: int
+    max_attempt: int
+
+
+class ProcessRetriesResponse(BaseModel):
+    generated_at_utc: datetime.datetime
+    window_days: Optional[int]
+    summary: RetrySummary
+    by_attempt: list[RetryByAttemptRow]
+    by_process: list[RetryByProcessRow]
+
+
+class ResourceByAttemptRow(BaseModel):
+    process: str
+    attempt: int
+    rows: int
+    success: int
+    failed: int
+    avg_requested_cpus: Optional[float]
+    avg_requested_memory_gb: Optional[float]
+    avg_requested_time_min: Optional[float]
+    avg_pct_cpu: Optional[float]
+    p95_pct_cpu: Optional[float]
+    avg_pct_mem: Optional[float]
+    p95_pct_mem: Optional[float]
+    avg_peak_rss_gb: Optional[float]
+    p95_peak_rss_gb: Optional[float]
+    avg_read_gb: Optional[float]
+    avg_write_gb: Optional[float]
+
+
+class ProcessResourcesByAttemptResponse(BaseModel):
+    generated_at_utc: datetime.datetime
+    window_days: Optional[int]
+    rows: list[ResourceByAttemptRow]
+
+
+class ProcessFailuresRow(BaseModel):
+    process: str
+    total_completed: int
+    success: int
+    failed: int
+    failure_pct: float
+    modal_failure_exit_code: Optional[str]
+
+
+class ProcessFailuresResponse(BaseModel):
+    generated_at_utc: datetime.datetime
+    window_days: Optional[int]
+    rows: list[ProcessFailuresRow]
+
+
+class FailureSignatureRow(BaseModel):
+    process: str
+    exit_code: str
+    failures: int
+
+
+class ProcessFailureSignaturesResponse(BaseModel):
+    generated_at_utc: datetime.datetime
+    window_days: Optional[int]
+    rows: list[FailureSignatureRow]

--- a/nextflow_telemetry/routers/process_metrics.py
+++ b/nextflow_telemetry/routers/process_metrics.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException, Query
 
+from .. import models
 from ..services.process_metrics import ProcessMetricsService
 
 
 def create_process_metrics_router(service: ProcessMetricsService) -> APIRouter:
     router = APIRouter(prefix="/metrics/processes", tags=["process-metrics"])
 
-    @router.get("/summary")
+    @router.get("/summary", response_model=models.ProcessSummaryResponse)
     async def process_summary(
         window_days: int | None = Query(default=None, ge=1),
         min_samples: int = Query(default=50, ge=1),
@@ -19,7 +20,7 @@ def create_process_metrics_router(service: ProcessMetricsService) -> APIRouter:
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    @router.get("/retries")
+    @router.get("/retries", response_model=models.ProcessRetriesResponse)
     async def process_retries(
         window_days: int | None = Query(default=None, ge=1),
         min_samples: int = Query(default=50, ge=1),
@@ -30,7 +31,7 @@ def create_process_metrics_router(service: ProcessMetricsService) -> APIRouter:
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    @router.get("/resources-by-attempt")
+    @router.get("/resources-by-attempt", response_model=models.ProcessResourcesByAttemptResponse)
     async def process_resources_by_attempt(
         window_days: int | None = Query(default=None, ge=1),
         min_samples: int = Query(default=50, ge=1),
@@ -41,7 +42,7 @@ def create_process_metrics_router(service: ProcessMetricsService) -> APIRouter:
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    @router.get("/failures")
+    @router.get("/failures", response_model=models.ProcessFailuresResponse)
     async def process_failures(
         window_days: int | None = Query(default=None, ge=1),
         min_samples: int = Query(default=50, ge=1),
@@ -52,7 +53,7 @@ def create_process_metrics_router(service: ProcessMetricsService) -> APIRouter:
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    @router.get("/failure-signatures")
+    @router.get("/failure-signatures", response_model=models.ProcessFailureSignaturesResponse)
     async def process_failure_signatures(
         window_days: int | None = Query(default=None, ge=1),
         limit: int = Query(default=100, ge=1, le=1000),

--- a/tests/test_process_metrics_router.py
+++ b/tests/test_process_metrics_router.py
@@ -7,30 +7,111 @@ from nextflow_telemetry.routers.process_metrics import create_process_metrics_ro
 class FakeProcessMetricsService:
     async def summary(self, *, window_days=None, min_samples=50, limit=10):
         return {
+            "generated_at_utc": "2026-01-01T00:00:00Z",
             "window_days": window_days,
-            "cards": {"process_completed_rows": 123, "failure_pct": 4.2},
+            "cards": {
+                "process_completed_rows": 123,
+                "distinct_runs": 4,
+                "distinct_processes": 2,
+                "success_rows": 118,
+                "failure_rows": 5,
+                "failure_pct": 4.2,
+                "retried_rows": 11,
+                "retry_pct": 8.9,
+                "retry_success_pct": 30.0,
+                "latest_process_completed_utc": "2026-01-01T00:00:00Z",
+            },
             "event_mix": [{"event": "process_completed", "rows": 123}],
-            "top_failures": [{"process": "kneaddata", "failed": 3}],
-            "top_retries": [{"process": "kneaddata", "retried": 8}],
+            "top_failures": [
+                {"process": "kneaddata", "total_completed": 50, "failed": 3, "failure_pct": 6.0}
+            ],
+            "top_retries": [
+                {
+                    "process": "kneaddata",
+                    "total_completed": 50,
+                    "retried": 8,
+                    "retried_pct": 16.0,
+                    "retried_success": 2,
+                    "retried_failed": 6,
+                }
+            ],
             "top_failure_exit_codes": [{"exit_code": "1", "failures": 10}],
         }
 
     async def retries(self, *, window_days=None, min_samples=50, limit=50):
         return {
+            "generated_at_utc": "2026-01-01T00:00:00Z",
             "window_days": window_days,
-            "summary": {"process_completed_rows": 10},
-            "by_attempt": [],
-            "by_process": [],
+            "summary": {
+                "process_completed_rows": 10,
+                "retried_rows": 2,
+                "retried_pct": 20.0,
+                "retry_success_rows": 1,
+                "retry_failure_rows": 1,
+                "retry_success_pct": 50.0,
+            },
+            "by_attempt": [{"attempt": 1, "rows": 8, "success": 8, "failed": 0}],
+            "by_process": [
+                {
+                    "process": "kneaddata",
+                    "total_completed": 10,
+                    "retried": 2,
+                    "retried_pct": 20.0,
+                    "retried_success": 1,
+                    "retried_failed": 1,
+                    "max_attempt": 2,
+                }
+            ],
         }
 
     async def resources_by_attempt(self, *, window_days=None, min_samples=50, limit=100):
-        return {"window_days": window_days, "rows": [{"process": "kneaddata", "attempt": 1}]}
+        return {
+            "generated_at_utc": "2026-01-01T00:00:00Z",
+            "window_days": window_days,
+            "rows": [
+                {
+                    "process": "kneaddata",
+                    "attempt": 1,
+                    "rows": 10,
+                    "success": 9,
+                    "failed": 1,
+                    "avg_requested_cpus": 8.0,
+                    "avg_requested_memory_gb": 32.0,
+                    "avg_requested_time_min": 180.0,
+                    "avg_pct_cpu": 300.0,
+                    "p95_pct_cpu": 500.0,
+                    "avg_pct_mem": 3.2,
+                    "p95_pct_mem": 4.1,
+                    "avg_peak_rss_gb": 10.0,
+                    "p95_peak_rss_gb": 12.0,
+                    "avg_read_gb": 1.1,
+                    "avg_write_gb": 0.9,
+                }
+            ],
+        }
 
     async def failures(self, *, window_days=None, min_samples=50, limit=50):
-        return {"window_days": window_days, "rows": [{"process": "kneaddata", "failed": 2}]}
+        return {
+            "generated_at_utc": "2026-01-01T00:00:00Z",
+            "window_days": window_days,
+            "rows": [
+                {
+                    "process": "kneaddata",
+                    "total_completed": 10,
+                    "success": 8,
+                    "failed": 2,
+                    "failure_pct": 20.0,
+                    "modal_failure_exit_code": "1",
+                }
+            ],
+        }
 
     async def failure_signatures(self, *, window_days=None, limit=100):
-        return {"window_days": window_days, "rows": [{"process": "kneaddata", "exit_code": "1"}]}
+        return {
+            "generated_at_utc": "2026-01-01T00:00:00Z",
+            "window_days": window_days,
+            "rows": [{"process": "kneaddata", "exit_code": "1", "failures": 2}],
+        }
 
 
 def _client() -> TestClient:


### PR DESCRIPTION
## Summary
This PR adds explicit Pydantic response models to API endpoints to improve OpenAPI documentation quality and provide a stable typed contract for TypeScript frontend generation.

## What changed
- Added response schemas in `nextflow_telemetry/models.py` for:
  - health endpoint responses
  - process metrics endpoints (`summary`, `retries`, `resources-by-attempt`, `failures`, `failure-signatures`)
- Wired `response_model=` declarations on endpoints:
  - `nextflow_telemetry/main.py`
  - `nextflow_telemetry/routers/process_metrics.py`
- Updated telemetry ingest endpoint to accept typed `models.Telemetry` request input and return typed response model.
- Added architecture/design note in `AGENTS.md`:
  - explicit response models are a design point for stable OpenAPI and TS client types.
- Updated router tests to satisfy stricter response validation shapes:
  - `tests/test_process_metrics_router.py`

## Why
- Improves Swagger/OpenAPI docs with concrete schemas instead of generic objects.
- Reduces frontend-backend contract drift by making response shapes explicit.
- Makes code generation / typed API clients for React/TypeScript more reliable.

## Validation
- `just ci`
  - mypy: pass
  - pytest: 8 passed
