### PR TITLE
Add metagenomics sample metadata and job queue

### DIFF
--- a/nextflow_telemetry/main.py
+++ b/nextflow_telemetry/main.py
@@ -9,7 +9,9 @@ from .log import logger
 from . import models
 from .config import settings
 from .routers.process_metrics import create_process_metrics_router
+from .routers.samples import create_samples_router
 from .services.process_metrics import ProcessMetricsService
+from .services.samples import SamplesService
 
 app = FastAPI()
 
@@ -81,6 +83,9 @@ app.add_middleware(
 
 process_metrics_service = ProcessMetricsService(engine=engine)
 app.include_router(create_process_metrics_router(process_metrics_service))
+
+samples_service = SamplesService(engine=engine)
+app.include_router(create_samples_router(samples_service))
 
 # health check
 @app.get("/health", response_model=models.HealthResponse, responses={503: {"model": models.HealthErrorResponse}})

--- a/nextflow_telemetry/main.py
+++ b/nextflow_telemetry/main.py
@@ -9,7 +9,9 @@ from .log import logger
 from . import models
 from .config import settings
 from .routers.process_metrics import create_process_metrics_router
+from .routers.pipelines import create_pipelines_router
 from .routers.samples import create_samples_router
+from .services.pipelines import PipelinesService
 from .services.process_metrics import ProcessMetricsService
 from .services.samples import SamplesService
 
@@ -86,6 +88,9 @@ app.include_router(create_process_metrics_router(process_metrics_service))
 
 samples_service = SamplesService(engine=engine)
 app.include_router(create_samples_router(samples_service))
+
+pipelines_service = PipelinesService(engine=engine)
+app.include_router(create_pipelines_router(pipelines_service))
 
 # health check
 @app.get("/health", response_model=models.HealthResponse, responses={503: {"model": models.HealthErrorResponse}})

--- a/nextflow_telemetry/main.py
+++ b/nextflow_telemetry/main.py
@@ -9,8 +9,10 @@ from .log import logger
 from . import models
 from .config import settings
 from .routers.process_metrics import create_process_metrics_router
+from .routers.jobs import create_jobs_router
 from .routers.pipelines import create_pipelines_router
 from .routers.samples import create_samples_router
+from .services.jobs import JobsService
 from .services.pipelines import PipelinesService
 from .services.process_metrics import ProcessMetricsService
 from .services.samples import SamplesService
@@ -91,6 +93,9 @@ app.include_router(create_samples_router(samples_service))
 
 pipelines_service = PipelinesService(engine=engine)
 app.include_router(create_pipelines_router(pipelines_service))
+
+jobs_service = JobsService(engine=engine)
+app.include_router(create_jobs_router(jobs_service))
 
 # health check
 @app.get("/health", response_model=models.HealthResponse, responses={503: {"model": models.HealthErrorResponse}})

--- a/nextflow_telemetry/models.py
+++ b/nextflow_telemetry/models.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel, Field
-from typing import Any, Optional
+from typing import Any, List, Optional
 import datetime
+from enum import Enum
 
 
 class NextFlowVersion(BaseModel):
@@ -206,3 +207,104 @@ class ProcessFailureSignaturesResponse(BaseModel):
     generated_at_utc: datetime.datetime
     window_days: Optional[int]
     rows: list[FailureSignatureRow]
+
+
+# --- Samples ---
+
+class SampleCreate(BaseModel):
+    sample_id: str
+    srr_accessions: Optional[List[str]] = None
+    metadata_: Optional[dict[str, Any]] = None
+
+    class Config:
+        fields = {"metadata_": {"alias": "metadata"}}
+
+
+class SampleUpdate(BaseModel):
+    srr_accessions: Optional[List[str]] = None
+    metadata_: Optional[dict[str, Any]] = None
+
+    class Config:
+        fields = {"metadata_": {"alias": "metadata"}}
+
+
+class SampleResponse(BaseModel):
+    id: int
+    sample_id: str
+    srr_accessions: Optional[List[str]] = None
+    metadata_: Optional[dict[str, Any]] = None
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+
+    class Config:
+        fields = {"metadata_": {"alias": "metadata"}}
+
+
+class SampleListResponse(BaseModel):
+    items: List[SampleResponse]
+    total: int
+
+
+# --- Pipelines ---
+
+class PipelineCreate(BaseModel):
+    pipeline_id: str
+    repository: Optional[str] = None
+    branch: Optional[str] = "main"
+    description: Optional[str] = None
+    default_params: Optional[dict[str, Any]] = None
+
+
+class PipelineUpdate(BaseModel):
+    repository: Optional[str] = None
+    branch: Optional[str] = None
+    description: Optional[str] = None
+    default_params: Optional[dict[str, Any]] = None
+
+
+class PipelineResponse(BaseModel):
+    id: int
+    pipeline_id: str
+    repository: Optional[str] = None
+    branch: Optional[str] = None
+    description: Optional[str] = None
+    default_params: Optional[dict[str, Any]] = None
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+
+
+class PipelineListResponse(BaseModel):
+    items: List[PipelineResponse]
+    total: int
+
+
+# --- Jobs ---
+
+class JobStatus(str, Enum):
+    pending = "pending"
+    running = "running"
+    success = "success"
+    failure = "failure"
+
+
+class JobCreate(BaseModel):
+    sample_id: str
+    pipeline_id: str
+
+
+class JobStatusUpdate(BaseModel):
+    status: JobStatus
+
+
+class JobResponse(BaseModel):
+    id: int
+    sample_id: str
+    pipeline_id: str
+    status: str
+    submitted_at: datetime.datetime
+    updated_at: datetime.datetime
+
+
+class JobListResponse(BaseModel):
+    items: List[JobResponse]
+    total: int

--- a/nextflow_telemetry/routers/jobs.py
+++ b/nextflow_telemetry/routers/jobs.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Query
+
+from .. import models
+from ..services.jobs import JobsService
+
+
+def create_jobs_router(service: JobsService) -> APIRouter:
+    router = APIRouter(prefix="/jobs", tags=["jobs"])
+
+    @router.post("", response_model=models.JobResponse, status_code=201)
+    async def create_job(body: models.JobCreate):
+        try:
+            return await service.create(
+                sample_id=body.sample_id,
+                pipeline_id=body.pipeline_id,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    @router.get("", response_model=models.JobListResponse)
+    async def list_jobs(
+        limit: int = Query(default=50, ge=1, le=200),
+        offset: int = Query(default=0, ge=0),
+        status: Optional[str] = Query(default=None),
+        sample_id: Optional[str] = Query(default=None),
+        pipeline_id: Optional[str] = Query(default=None),
+    ):
+        return await service.list(
+            limit=limit,
+            offset=offset,
+            status=status,
+            sample_id=sample_id,
+            pipeline_id=pipeline_id,
+        )
+
+    @router.get("/{job_id}", response_model=models.JobResponse)
+    async def get_job(job_id: int):
+        result = await service.get(job_id)
+        if result is None:
+            raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
+        return result
+
+    @router.patch("/{job_id}", response_model=models.JobResponse)
+    async def update_job_status(job_id: int, body: models.JobStatusUpdate):
+        try:
+            result = await service.update_status(job_id, body.status.value)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        if result is None:
+            raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
+        return result
+
+    return router

--- a/nextflow_telemetry/routers/pipelines.py
+++ b/nextflow_telemetry/routers/pipelines.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Query
+
+from .. import models
+from ..services.pipelines import PipelinesService
+
+
+def create_pipelines_router(service: PipelinesService) -> APIRouter:
+    router = APIRouter(prefix="/pipelines", tags=["pipelines"])
+
+    @router.post("", response_model=models.PipelineResponse, status_code=201)
+    async def create_pipeline(body: models.PipelineCreate):
+        try:
+            return await service.create(
+                pipeline_id=body.pipeline_id,
+                repository=body.repository,
+                branch=body.branch,
+                description=body.description,
+                default_params=body.default_params,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    @router.get("", response_model=models.PipelineListResponse)
+    async def list_pipelines(
+        limit: int = Query(default=50, ge=1, le=200),
+        offset: int = Query(default=0, ge=0),
+    ):
+        return await service.list(limit=limit, offset=offset)
+
+    @router.get("/{pipeline_id}", response_model=models.PipelineResponse)
+    async def get_pipeline(pipeline_id: str):
+        result = await service.get(pipeline_id)
+        if result is None:
+            raise HTTPException(status_code=404, detail=f"Pipeline '{pipeline_id}' not found")
+        return result
+
+    @router.patch("/{pipeline_id}", response_model=models.PipelineResponse)
+    async def update_pipeline(pipeline_id: str, body: models.PipelineUpdate):
+        kwargs = body.dict(exclude_unset=True)
+        result = await service.update(pipeline_id, **kwargs)
+        if result is None:
+            raise HTTPException(status_code=404, detail=f"Pipeline '{pipeline_id}' not found")
+        return result
+
+    @router.delete("/{pipeline_id}", status_code=204)
+    async def delete_pipeline(pipeline_id: str):
+        try:
+            deleted = await service.delete(pipeline_id)
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        if not deleted:
+            raise HTTPException(status_code=404, detail=f"Pipeline '{pipeline_id}' not found")
+
+    return router

--- a/nextflow_telemetry/routers/samples.py
+++ b/nextflow_telemetry/routers/samples.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Query
+
+from .. import models
+from ..services.samples import SamplesService
+
+
+def create_samples_router(service: SamplesService) -> APIRouter:
+    router = APIRouter(prefix="/samples", tags=["samples"])
+
+    @router.post("", response_model=models.SampleResponse, status_code=201)
+    async def create_sample(body: models.SampleCreate):
+        try:
+            return await service.create(
+                sample_id=body.sample_id,
+                srr_accessions=body.srr_accessions,
+                metadata_=body.metadata_,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    @router.get("", response_model=models.SampleListResponse)
+    async def list_samples(
+        limit: int = Query(default=50, ge=1, le=200),
+        offset: int = Query(default=0, ge=0),
+    ):
+        return await service.list(limit=limit, offset=offset)
+
+    @router.get("/{sample_id}", response_model=models.SampleResponse)
+    async def get_sample(sample_id: str):
+        result = await service.get(sample_id)
+        if result is None:
+            raise HTTPException(status_code=404, detail=f"Sample '{sample_id}' not found")
+        return result
+
+    @router.patch("/{sample_id}", response_model=models.SampleResponse)
+    async def update_sample(sample_id: str, body: models.SampleUpdate):
+        kwargs = body.dict(exclude_unset=True)
+        result = await service.update(sample_id, **kwargs)
+        if result is None:
+            raise HTTPException(status_code=404, detail=f"Sample '{sample_id}' not found")
+        return result
+
+    @router.delete("/{sample_id}", status_code=204)
+    async def delete_sample(sample_id: str):
+        try:
+            deleted = await service.delete(sample_id)
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        if not deleted:
+            raise HTTPException(status_code=404, detail=f"Sample '{sample_id}' not found")
+
+    return router

--- a/nextflow_telemetry/services/jobs.py
+++ b/nextflow_telemetry/services/jobs.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+VALID_STATUSES = {"pending", "running", "success", "failure"}
+
+
+@dataclass
+class JobsService:
+    engine: AsyncEngine
+
+    async def create(self, *, sample_id: str, pipeline_id: str) -> dict[str, Any]:
+        """Create a job by resolving human-readable sample_id and pipeline_id to FK integers."""
+        sql = text("""
+            INSERT INTO jobs (sample_id, pipeline_id)
+            SELECT s.id, p.id
+            FROM samples s, pipelines p
+            WHERE s.sample_id = :sample_id AND p.pipeline_id = :pipeline_id
+            RETURNING id, sample_id AS sample_fk, pipeline_id AS pipeline_fk, status, submitted_at, updated_at
+        """)
+        async with self.engine.begin() as conn:
+            row = (await conn.execute(sql, {"sample_id": sample_id, "pipeline_id": pipeline_id})).mappings().one_or_none()
+            if row is None:
+                raise ValueError(f"Sample '{sample_id}' or pipeline '{pipeline_id}' not found")
+            # Re-query to get human-readable IDs via JOIN
+            return await self._get_by_pk(conn, row["id"])
+
+    async def _get_by_pk(self, conn: Any, job_id: int) -> dict[str, Any]:
+        sql = text("""
+            SELECT j.id, s.sample_id, p.pipeline_id, j.status, j.submitted_at, j.updated_at
+            FROM jobs j
+            JOIN samples s ON j.sample_id = s.id
+            JOIN pipelines p ON j.pipeline_id = p.id
+            WHERE j.id = :id
+        """)
+        row = (await conn.execute(sql, {"id": job_id})).mappings().one()
+        return dict(row)
+
+    async def list(
+        self,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+        status: Optional[str] = None,
+        sample_id: Optional[str] = None,
+        pipeline_id: Optional[str] = None,
+    ) -> dict[str, Any]:
+        wheres: list[str] = []
+        params: dict[str, Any] = {"limit": limit, "offset": offset}
+
+        if status is not None:
+            wheres.append("j.status = :status")
+            params["status"] = status
+        if sample_id is not None:
+            wheres.append("s.sample_id = :sample_id")
+            params["sample_id"] = sample_id
+        if pipeline_id is not None:
+            wheres.append("p.pipeline_id = :pipeline_id")
+            params["pipeline_id"] = pipeline_id
+
+        where_clause = ("WHERE " + " AND ".join(wheres)) if wheres else ""
+
+        count_sql = text(f"""
+            SELECT count(*)
+            FROM jobs j
+            JOIN samples s ON j.sample_id = s.id
+            JOIN pipelines p ON j.pipeline_id = p.id
+            {where_clause}
+        """)
+        list_sql = text(f"""
+            SELECT j.id, s.sample_id, p.pipeline_id, j.status, j.submitted_at, j.updated_at
+            FROM jobs j
+            JOIN samples s ON j.sample_id = s.id
+            JOIN pipelines p ON j.pipeline_id = p.id
+            {where_clause}
+            ORDER BY j.id
+            LIMIT :limit OFFSET :offset
+        """)
+
+        async with self.engine.connect() as conn:
+            total = (await conn.execute(count_sql, params)).scalar_one()
+            rows = [dict(r) for r in (await conn.execute(list_sql, params)).mappings().all()]
+        return {"items": rows, "total": total}
+
+    async def get(self, job_id: int) -> Optional[dict[str, Any]]:
+        sql = text("""
+            SELECT j.id, s.sample_id, p.pipeline_id, j.status, j.submitted_at, j.updated_at
+            FROM jobs j
+            JOIN samples s ON j.sample_id = s.id
+            JOIN pipelines p ON j.pipeline_id = p.id
+            WHERE j.id = :id
+        """)
+        async with self.engine.connect() as conn:
+            row = (await conn.execute(sql, {"id": job_id})).mappings().one_or_none()
+            return dict(row) if row else None
+
+    async def update_status(self, job_id: int, status: str) -> Optional[dict[str, Any]]:
+        if status not in VALID_STATUSES:
+            raise ValueError(f"Invalid status '{status}'. Must be one of: {', '.join(sorted(VALID_STATUSES))}")
+
+        sql = text("""
+            UPDATE jobs SET status = :status, updated_at = now()
+            WHERE id = :id
+            RETURNING id
+        """)
+        async with self.engine.begin() as conn:
+            row = (await conn.execute(sql, {"id": job_id, "status": status})).one_or_none()
+            if row is None:
+                return None
+            return await self._get_by_pk(conn, job_id)

--- a/nextflow_telemetry/services/pipelines.py
+++ b/nextflow_telemetry/services/pipelines.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+
+@dataclass
+class PipelinesService:
+    engine: AsyncEngine
+
+    async def create(
+        self,
+        *,
+        pipeline_id: str,
+        repository: Optional[str] = None,
+        branch: Optional[str] = "main",
+        description: Optional[str] = None,
+        default_params: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
+        sql = text("""
+            INSERT INTO pipelines (pipeline_id, repository, branch, description, default_params)
+            VALUES (:pipeline_id, :repository, :branch, :description, :default_params::jsonb)
+            RETURNING id, pipeline_id, repository, branch, description, default_params, created_at, updated_at
+        """)
+        params = {
+            "pipeline_id": pipeline_id,
+            "repository": repository,
+            "branch": branch,
+            "description": description,
+            "default_params": json.dumps(default_params) if default_params is not None else None,
+        }
+        try:
+            async with self.engine.begin() as conn:
+                row = (await conn.execute(sql, params)).mappings().one()
+                return dict(row)
+        except IntegrityError as exc:
+            raise ValueError(f"Pipeline '{pipeline_id}' already exists") from exc
+
+    async def list(self, *, limit: int = 50, offset: int = 0) -> dict[str, Any]:
+        count_sql = text("SELECT count(*) FROM pipelines")
+        list_sql = text("""
+            SELECT id, pipeline_id, repository, branch, description, default_params, created_at, updated_at
+            FROM pipelines ORDER BY id LIMIT :limit OFFSET :offset
+        """)
+        async with self.engine.connect() as conn:
+            total = (await conn.execute(count_sql)).scalar_one()
+            rows = [dict(r) for r in (await conn.execute(list_sql, {"limit": limit, "offset": offset})).mappings().all()]
+        return {"items": rows, "total": total}
+
+    async def get(self, pipeline_id: str) -> Optional[dict[str, Any]]:
+        sql = text("""
+            SELECT id, pipeline_id, repository, branch, description, default_params, created_at, updated_at
+            FROM pipelines WHERE pipeline_id = :pipeline_id
+        """)
+        async with self.engine.connect() as conn:
+            row = (await conn.execute(sql, {"pipeline_id": pipeline_id})).mappings().one_or_none()
+            return dict(row) if row else None
+
+    async def update(self, pipeline_id: str, **kwargs: Any) -> Optional[dict[str, Any]]:
+        sets: list[str] = ["updated_at = now()"]
+        params: dict[str, Any] = {"pipeline_id": pipeline_id}
+
+        for field in ("repository", "branch", "description"):
+            if field in kwargs:
+                sets.append(f"{field} = :{field}")
+                params[field] = kwargs[field]
+
+        if "default_params" in kwargs:
+            sets.append("default_params = :default_params::jsonb")
+            params["default_params"] = json.dumps(kwargs["default_params"]) if kwargs["default_params"] is not None else None
+
+        if len(sets) == 1:
+            return await self.get(pipeline_id)
+
+        sql = text(f"""
+            UPDATE pipelines SET {', '.join(sets)}
+            WHERE pipeline_id = :pipeline_id
+            RETURNING id, pipeline_id, repository, branch, description, default_params, created_at, updated_at
+        """)
+        async with self.engine.begin() as conn:
+            row = (await conn.execute(sql, params)).mappings().one_or_none()
+            return dict(row) if row else None
+
+    async def delete(self, pipeline_id: str) -> bool:
+        sql = text("DELETE FROM pipelines WHERE pipeline_id = :pipeline_id RETURNING id")
+        try:
+            async with self.engine.begin() as conn:
+                row = (await conn.execute(sql, {"pipeline_id": pipeline_id})).one_or_none()
+                return row is not None
+        except IntegrityError as exc:
+            raise ValueError(f"Cannot delete pipeline '{pipeline_id}': referenced by jobs") from exc

--- a/nextflow_telemetry/services/samples.py
+++ b/nextflow_telemetry/services/samples.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+
+@dataclass
+class SamplesService:
+    engine: AsyncEngine
+
+    async def create(self, *, sample_id: str, srr_accessions: Optional[list[str]] = None, metadata_: Optional[dict[str, Any]] = None) -> dict[str, Any]:
+        sql = text("""
+            INSERT INTO samples (sample_id, srr_accessions, metadata_)
+            VALUES (:sample_id, :srr_accessions::jsonb, :metadata_::jsonb)
+            RETURNING id, sample_id, srr_accessions, metadata_, created_at, updated_at
+        """)
+        params = {
+            "sample_id": sample_id,
+            "srr_accessions": json.dumps(srr_accessions) if srr_accessions is not None else None,
+            "metadata_": json.dumps(metadata_) if metadata_ is not None else None,
+        }
+        try:
+            async with self.engine.begin() as conn:
+                row = (await conn.execute(sql, params)).mappings().one()
+                return dict(row)
+        except IntegrityError as exc:
+            raise ValueError(f"Sample '{sample_id}' already exists") from exc
+
+    async def list(self, *, limit: int = 50, offset: int = 0) -> dict[str, Any]:
+        count_sql = text("SELECT count(*) FROM samples")
+        list_sql = text("""
+            SELECT id, sample_id, srr_accessions, metadata_, created_at, updated_at
+            FROM samples ORDER BY id LIMIT :limit OFFSET :offset
+        """)
+        async with self.engine.connect() as conn:
+            total = (await conn.execute(count_sql)).scalar_one()
+            rows = [dict(r) for r in (await conn.execute(list_sql, {"limit": limit, "offset": offset})).mappings().all()]
+        return {"items": rows, "total": total}
+
+    async def get(self, sample_id: str) -> Optional[dict[str, Any]]:
+        sql = text("""
+            SELECT id, sample_id, srr_accessions, metadata_, created_at, updated_at
+            FROM samples WHERE sample_id = :sample_id
+        """)
+        async with self.engine.connect() as conn:
+            row = (await conn.execute(sql, {"sample_id": sample_id})).mappings().one_or_none()
+            return dict(row) if row else None
+
+    async def update(self, sample_id: str, *, srr_accessions: Any = ..., metadata_: Any = ...) -> Optional[dict[str, Any]]:
+        sets: list[str] = ["updated_at = now()"]
+        params: dict[str, Any] = {"sample_id": sample_id}
+        if srr_accessions is not ...:
+            sets.append("srr_accessions = :srr_accessions::jsonb")
+            params["srr_accessions"] = json.dumps(srr_accessions) if srr_accessions is not None else None
+        if metadata_ is not ...:
+            sets.append("metadata_ = :metadata_::jsonb")
+            params["metadata_"] = json.dumps(metadata_) if metadata_ is not None else None
+
+        if len(sets) == 1:
+            return await self.get(sample_id)
+
+        sql = text(f"""
+            UPDATE samples SET {', '.join(sets)}
+            WHERE sample_id = :sample_id
+            RETURNING id, sample_id, srr_accessions, metadata_, created_at, updated_at
+        """)
+        async with self.engine.begin() as conn:
+            row = (await conn.execute(sql, params)).mappings().one_or_none()
+            return dict(row) if row else None
+
+    async def delete(self, sample_id: str) -> bool:
+        sql = text("DELETE FROM samples WHERE sample_id = :sample_id RETURNING id")
+        try:
+            async with self.engine.begin() as conn:
+                row = (await conn.execute(sql, {"sample_id": sample_id})).one_or_none()
+                return row is not None
+        except IntegrityError as exc:
+            raise ValueError(f"Cannot delete sample '{sample_id}': referenced by jobs") from exc

--- a/tests/test_jobs_router.py
+++ b/tests/test_jobs_router.py
@@ -1,0 +1,122 @@
+from typing import Any, Optional
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from nextflow_telemetry.routers.jobs import create_jobs_router
+
+
+_JOB = {
+    "id": 1,
+    "sample_id": "SAMP001",
+    "pipeline_id": "nf-core/taxprofiler",
+    "status": "pending",
+    "submitted_at": "2026-01-01T00:00:00Z",
+    "updated_at": "2026-01-01T00:00:00Z",
+}
+
+
+class FakeJobsService:
+    async def create(self, *, sample_id: str, pipeline_id: str) -> dict[str, Any]:
+        return {**_JOB, "sample_id": sample_id, "pipeline_id": pipeline_id}
+
+    async def list(
+        self,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+        status: Optional[str] = None,
+        sample_id: Optional[str] = None,
+        pipeline_id: Optional[str] = None,
+    ) -> dict[str, Any]:
+        items = [_JOB]
+        if status is not None:
+            items = [j for j in items if j["status"] == status]
+        if sample_id is not None:
+            items = [j for j in items if j["sample_id"] == sample_id]
+        return {"items": items, "total": len(items)}
+
+    async def get(self, job_id: int) -> Optional[dict[str, Any]]:
+        if job_id == 999:
+            return None
+        return _JOB
+
+    async def update_status(self, job_id: int, status: str) -> Optional[dict[str, Any]]:
+        if job_id == 999:
+            return None
+        return {**_JOB, "status": status}
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(create_jobs_router(FakeJobsService()))
+    return TestClient(app)
+
+
+def test_create_job_201():
+    with _client() as client:
+        resp = client.post("/jobs", json={"sample_id": "S1", "pipeline_id": "P1"})
+    assert resp.status_code == 201
+    assert resp.json()["sample_id"] == "S1"
+    assert resp.json()["pipeline_id"] == "P1"
+
+
+def test_list_jobs():
+    with _client() as client:
+        resp = client.get("/jobs")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+
+
+def test_list_jobs_filter_status():
+    with _client() as client:
+        resp = client.get("/jobs", params={"status": "pending"})
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 1
+
+
+def test_list_jobs_filter_status_no_match():
+    with _client() as client:
+        resp = client.get("/jobs", params={"status": "running"})
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 0
+
+
+def test_list_jobs_filter_sample_id():
+    with _client() as client:
+        resp = client.get("/jobs", params={"sample_id": "SAMP001"})
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 1
+
+
+def test_get_job():
+    with _client() as client:
+        resp = client.get("/jobs/1")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == 1
+
+
+def test_get_job_404():
+    with _client() as client:
+        resp = client.get("/jobs/999")
+    assert resp.status_code == 404
+
+
+def test_update_job_status():
+    with _client() as client:
+        resp = client.patch("/jobs/1", json={"status": "running"})
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "running"
+
+
+def test_update_job_status_404():
+    with _client() as client:
+        resp = client.patch("/jobs/999", json={"status": "running"})
+    assert resp.status_code == 404
+
+
+def test_update_job_invalid_status():
+    with _client() as client:
+        resp = client.patch("/jobs/1", json={"status": "invalid"})
+    assert resp.status_code == 422

--- a/tests/test_pipelines_router.py
+++ b/tests/test_pipelines_router.py
@@ -1,0 +1,93 @@
+from typing import Any, Optional
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from nextflow_telemetry.routers.pipelines import create_pipelines_router
+
+
+_PIPELINE = {
+    "id": 1,
+    "pipeline_id": "nf-core/taxprofiler",
+    "repository": "https://github.com/nf-core/taxprofiler",
+    "branch": "main",
+    "description": "Taxonomic profiling pipeline",
+    "default_params": {"db": "kraken2"},
+    "created_at": "2026-01-01T00:00:00Z",
+    "updated_at": "2026-01-01T00:00:00Z",
+}
+
+
+class FakePipelinesService:
+    async def create(self, *, pipeline_id: str, repository: Any = None, branch: Any = "main", description: Any = None, default_params: Any = None) -> dict[str, Any]:
+        return {**_PIPELINE, "pipeline_id": pipeline_id, "repository": repository, "branch": branch, "description": description, "default_params": default_params}
+
+    async def list(self, *, limit: int = 50, offset: int = 0) -> dict[str, Any]:
+        return {"items": [_PIPELINE], "total": 1}
+
+    async def get(self, pipeline_id: str) -> Optional[dict[str, Any]]:
+        if pipeline_id == "MISSING":
+            return None
+        return _PIPELINE
+
+    async def update(self, pipeline_id: str, **kwargs: Any) -> Optional[dict[str, Any]]:
+        if pipeline_id == "MISSING":
+            return None
+        return {**_PIPELINE, **kwargs}
+
+    async def delete(self, pipeline_id: str) -> bool:
+        if pipeline_id == "MISSING":
+            return False
+        return True
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(create_pipelines_router(FakePipelinesService()))
+    return TestClient(app)
+
+
+def test_create_pipeline_201():
+    with _client() as client:
+        resp = client.post("/pipelines", json={"pipeline_id": "my-pipe", "repository": "https://github.com/test"})
+    assert resp.status_code == 201
+    assert resp.json()["pipeline_id"] == "my-pipe"
+
+
+def test_list_pipelines():
+    with _client() as client:
+        resp = client.get("/pipelines")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert len(body["items"]) == 1
+
+
+def test_get_pipeline():
+    with _client() as client:
+        resp = client.get("/pipelines/nf-core-taxprofiler")
+    assert resp.status_code == 200
+
+
+def test_get_pipeline_404():
+    with _client() as client:
+        resp = client.get("/pipelines/MISSING")
+    assert resp.status_code == 404
+
+
+def test_update_pipeline():
+    with _client() as client:
+        resp = client.patch("/pipelines/nf-core-taxprofiler", json={"description": "Updated"})
+    assert resp.status_code == 200
+
+
+def test_delete_pipeline_204():
+    with _client() as client:
+        resp = client.delete("/pipelines/nf-core-taxprofiler")
+    assert resp.status_code == 204
+
+
+def test_delete_pipeline_404():
+    with _client() as client:
+        resp = client.delete("/pipelines/MISSING")
+    assert resp.status_code == 404

--- a/tests/test_samples_router.py
+++ b/tests/test_samples_router.py
@@ -1,0 +1,92 @@
+from typing import Any, Optional
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from nextflow_telemetry.routers.samples import create_samples_router
+
+
+_SAMPLE = {
+    "id": 1,
+    "sample_id": "SAMP001",
+    "srr_accessions": ["SRR123", "SRR456"],
+    "metadata_": {"host": "human"},
+    "created_at": "2026-01-01T00:00:00Z",
+    "updated_at": "2026-01-01T00:00:00Z",
+}
+
+
+class FakeSamplesService:
+    async def create(self, *, sample_id: str, srr_accessions: Any = None, metadata_: Any = None) -> dict[str, Any]:
+        return {**_SAMPLE, "sample_id": sample_id, "srr_accessions": srr_accessions, "metadata_": metadata_}
+
+    async def list(self, *, limit: int = 50, offset: int = 0) -> dict[str, Any]:
+        return {"items": [_SAMPLE], "total": 1}
+
+    async def get(self, sample_id: str) -> Optional[dict[str, Any]]:
+        if sample_id == "MISSING":
+            return None
+        return _SAMPLE
+
+    async def update(self, sample_id: str, **kwargs: Any) -> Optional[dict[str, Any]]:
+        if sample_id == "MISSING":
+            return None
+        return {**_SAMPLE, **kwargs}
+
+    async def delete(self, sample_id: str) -> bool:
+        if sample_id == "MISSING":
+            return False
+        return True
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(create_samples_router(FakeSamplesService()))
+    return TestClient(app)
+
+
+def test_create_sample_201():
+    with _client() as client:
+        resp = client.post("/samples", json={"sample_id": "S1", "srr_accessions": ["SRR1"]})
+    assert resp.status_code == 201
+    assert resp.json()["sample_id"] == "S1"
+
+
+def test_list_samples():
+    with _client() as client:
+        resp = client.get("/samples")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert len(body["items"]) == 1
+
+
+def test_get_sample():
+    with _client() as client:
+        resp = client.get("/samples/SAMP001")
+    assert resp.status_code == 200
+    assert resp.json()["sample_id"] == "SAMP001"
+
+
+def test_get_sample_404():
+    with _client() as client:
+        resp = client.get("/samples/MISSING")
+    assert resp.status_code == 404
+
+
+def test_update_sample():
+    with _client() as client:
+        resp = client.patch("/samples/SAMP001", json={"metadata": {"host": "mouse"}})
+    assert resp.status_code == 200
+
+
+def test_delete_sample_204():
+    with _client() as client:
+        resp = client.delete("/samples/SAMP001")
+    assert resp.status_code == 204
+
+
+def test_delete_sample_404():
+    with _client() as client:
+        resp = client.delete("/samples/MISSING")
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary

- Add 3 new database tables (`samples`, `pipelines`, `jobs`) for metagenomics metadata management and HPC job queue dispatch
- Implement full CRUD APIs for samples and pipelines with paginated listing, 404/409 error handling
- Implement job queue API with atomic FK resolution from human-readable IDs, status filtering, and status validation
- 27 new tests (32 total passing) using fake service pattern

## New API Endpoints

| Method | Path | Purpose |
|--------|------|---------|
| POST/GET/PATCH/DELETE | `/samples[/{sample_id}]` | Sample metadata CRUD |
| POST/GET/PATCH/DELETE | `/pipelines[/{pipeline_id}]` | Pipeline definition CRUD |
| POST/GET/PATCH | `/jobs[/{id}]` | Job submission and status updates |

## Test plan

- [x] `uv run pytest` — all 32 tests pass
- [ ] Manual smoke test: `just run` then curl new endpoints against local Postgres
- [ ] Verify tables auto-create on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)