### PR TITLE
Add workflow/time/sample filters and timeline endpoint to process metrics

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(docker compose logs *)"
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,80 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Install dependencies
+just sync                  # uv sync --group dev
+
+# Run server locally (requires SQLALCHEMY_URI in env)
+just run                   # uvicorn with --reload on http://localhost:8000
+
+# Tests and type checks
+just test                  # pytest
+just typecheck             # mypy src/nextflow_telemetry
+just check                 # typecheck then test
+
+# Migrations
+just migrate               # alembic upgrade head
+
+# Seed sample data
+just seed                  # scripts/seed_from_tsv.py from ArtachoA_2021_sample.tsv
+
+# Run dispatch daemon locally
+just daemon                # nf-client daemon --config client-local.yaml --batch-size 10
+
+# Docker
+just up-all                # API + pgAdmin with external DB (uses SQLALCHEMY_URI from .env)
+just up-db                 # postgres only
+just down
+```
+
+Run a single test: `uv run pytest tests/test_api.py::test_name -v`
+
+## Architecture
+
+Two packages in one repo:
+
+- **`src/nextflow_telemetry/`** — FastAPI server (the telemetry/orchestration backend)
+- **`packages/nf_client/`** — CLI client (`nf-client`) that runs on HPC nodes to claim and submit jobs
+
+### Server layout
+
+- **`db.py`** — SQLAlchemy Core table definitions (`telemetry_tbl`, `samples_tbl`, `workflows_tbl`, `jobs_tbl`, `workflow_runs_tbl`, `dead_letter_tbl`). No ORM. Alembic imports `metadata` directly from here.
+- **`models.py`** — Pydantic v2 request/response models only (no SQLAlchemy).
+- **`config.py`** — Dataclass `Settings` loaded from env vars. `SQLALCHEMY_URI` auto-upgrades `postgresql://` → `postgresql+asyncpg://`.
+- **`main.py`** — Creates `AsyncEngine`, instantiates services, wires routers via factory functions.
+- **`routers/`** — Each module exports a `create_X_router(engine)` factory; the engine is injected so routers are testable without global state.
+- **`services/`** — Business logic as `@dataclass` classes holding an `AsyncEngine`. All DB work is done with `async with engine.begin() as conn`.
+- **`migrations/`** — Alembic async migrations. Name format: `YYYYMMDD_<hash>_<description>.py`.
+
+### Job lifecycle
+
+```
+pending → claimed → submitted → running → completed
+                                        ↘ failed → dead_letter
+```
+
+- `pending`: created by `reconcile_jobs()` (cross-product of samples × active workflows)
+- `claimed`: `POST /dispatch/batch` atomically selects jobs with `SELECT ... FOR UPDATE SKIP LOCKED` and creates a `workflow_run` record
+- `submitted`: `POST /dispatch/submitted` confirms the executor accepted the job
+- `running`: set when Nextflow sends a `started` weblog event to `POST /telemetry`
+- `completed`: set when Nextflow sends `process_completed` for the `MARK_COMPLETE` sentinel process with `status=COMPLETED`
+- On run `completed` event: `sweep_run_incomplete()` retries jobs within `max_retries` budget or routes to DLQ
+
+### nf-client
+
+Config via YAML (`ClientConfig`). Profile (e.g. `anvil`, `alpine`) lives in the client config — the same workflow runs on different HPC systems. Submission modes: `local`, `slurm`, `pbs`, `lsf`. SLURM template rendered via Jinja2 from `templates/`.
+
+### Tests
+
+Integration tests (`test_integration.py`, `test_e2e.py`) spin up a real Postgres via `testcontainers` — no mocking. The session-scoped fixture creates schema once; each test gets a fresh `AsyncEngine`. `test_api.py` uses unit-style mocking with `TELEMETRY_SKIP_DB_INIT=1`.
+
+## Key gotchas
+
+- **Pydantic v2**: `Optional[X]` fields require explicit `= None` default or the model will reject missing fields with a 422.
+- **Weblog auth**: Nextflow's `-with-weblog` does not support sending auth tokens. The `/telemetry` endpoint is intentionally unauthenticated.
+- **`MARK_COMPLETE` sentinel**: Per-sample completion is signalled by a Nextflow process named `MARK_COMPLETE` (checked via `.endswith("MARK_COMPLETE")`). The pipeline must emit this process with `status=COMPLETED` for a job to be marked complete.
+- **Server restart after code changes**: uvicorn caches modules at startup — always restart after a `git pull` on a deployed instance.

--- a/src/nextflow_telemetry/models.py
+++ b/src/nextflow_telemetry/models.py
@@ -235,6 +235,22 @@ class ProcessFailureSignaturesResponse(BaseModel):
     rows: list[FailureSignatureRow]
 
 
+class TimelineRow(BaseModel):
+    """Success/failure counts for a single time bucket."""
+    bucket_start: datetime.datetime
+    total: int
+    success: int
+    failed: int
+    failure_pct: float
+
+
+class ProcessTimelineResponse(BaseModel):
+    """Response from GET /metrics/processes/timeline."""
+    generated_at_utc: datetime.datetime
+    bucket: str
+    rows: list[TimelineRow]
+
+
 # ---------------------------------------------------------------------------
 # Workflow job-summary model
 # ---------------------------------------------------------------------------

--- a/src/nextflow_telemetry/routers/process_metrics.py
+++ b/src/nextflow_telemetry/routers/process_metrics.py
@@ -1,13 +1,23 @@
 """Process-level analytics derived from the raw telemetry event stream."""
 from __future__ import annotations
 
+import datetime as dt
+from typing import Literal
+
 from fastapi import APIRouter, HTTPException, Query
 
 from .. import models
 from ..services.process_metrics import ProcessMetricsService
 
-_WINDOW_DESC = "Limit results to events in the last N days. Omit for all-time."
-_MIN_SAMPLES_DESC = "Minimum number of completed events a process must have to appear in ranked lists."
+_WINDOW_DAYS_DESC = "Limit results to events in the last N days. Cannot be combined with window_hours, since, or until."
+_WINDOW_HOURS_DESC = "Limit results to events in the last N hours. Cannot be combined with window_days."
+_SINCE_DESC = "Inclusive lower bound (UTC ISO-8601). Can be combined with until."
+_UNTIL_DESC = "Inclusive upper bound (UTC ISO-8601). Can be combined with since."
+_WORKFLOW_ID_DESC = "Filter to a specific workflow (e.g. 'cmgd_nextflow')."
+_WORKFLOW_VERSION_DESC = "Filter to a specific workflow version. Only meaningful with workflow_id."
+_RUN_NAME_DESC = "Filter to a single Nextflow run_name."
+_SAMPLE_ID_DESC = "Filter to a single sample_id."
+_MIN_SAMPLES_DESC = "Minimum completed events a process must have to appear in ranked lists. Set to 1 to see all processes."
 _LIMIT_DESC = "Maximum number of rows to return in ranked lists."
 
 
@@ -38,12 +48,25 @@ def create_process_metrics_router(service: ProcessMetricsService) -> APIRouter:
         ),
     )
     async def process_summary(
-        window_days: int | None = Query(default=None, ge=1, description=_WINDOW_DESC),
-        min_samples: int = Query(default=50, ge=1, description=_MIN_SAMPLES_DESC),
+        window_days: int | None = Query(default=None, ge=1, description=_WINDOW_DAYS_DESC),
+        window_hours: int | None = Query(default=None, ge=1, description=_WINDOW_HOURS_DESC),
+        since: dt.datetime | None = Query(default=None, description=_SINCE_DESC),
+        until: dt.datetime | None = Query(default=None, description=_UNTIL_DESC),
+        workflow_id: str | None = Query(default=None, description=_WORKFLOW_ID_DESC),
+        workflow_version: str | None = Query(default=None, description=_WORKFLOW_VERSION_DESC),
+        run_name: str | None = Query(default=None, description=_RUN_NAME_DESC),
+        sample_id: str | None = Query(default=None, description=_SAMPLE_ID_DESC),
+        min_samples: int = Query(default=5, ge=1, description=_MIN_SAMPLES_DESC),
         limit: int = Query(default=10, ge=1, le=200, description=_LIMIT_DESC),
     ):
         try:
-            return await service.summary(window_days=window_days, min_samples=min_samples, limit=limit)
+            return await service.summary(
+                window_days=window_days, window_hours=window_hours,
+                since=since, until=until,
+                workflow_id=workflow_id, workflow_version=workflow_version,
+                run_name=run_name, sample_id=sample_id,
+                min_samples=min_samples, limit=limit,
+            )
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -58,12 +81,25 @@ def create_process_metrics_router(service: ProcessMetricsService) -> APIRouter:
         ),
     )
     async def process_retries(
-        window_days: int | None = Query(default=None, ge=1, description=_WINDOW_DESC),
-        min_samples: int = Query(default=50, ge=1, description=_MIN_SAMPLES_DESC),
+        window_days: int | None = Query(default=None, ge=1, description=_WINDOW_DAYS_DESC),
+        window_hours: int | None = Query(default=None, ge=1, description=_WINDOW_HOURS_DESC),
+        since: dt.datetime | None = Query(default=None, description=_SINCE_DESC),
+        until: dt.datetime | None = Query(default=None, description=_UNTIL_DESC),
+        workflow_id: str | None = Query(default=None, description=_WORKFLOW_ID_DESC),
+        workflow_version: str | None = Query(default=None, description=_WORKFLOW_VERSION_DESC),
+        run_name: str | None = Query(default=None, description=_RUN_NAME_DESC),
+        sample_id: str | None = Query(default=None, description=_SAMPLE_ID_DESC),
+        min_samples: int = Query(default=5, ge=1, description=_MIN_SAMPLES_DESC),
         limit: int = Query(default=50, ge=1, le=500, description=_LIMIT_DESC),
     ):
         try:
-            return await service.retries(window_days=window_days, min_samples=min_samples, limit=limit)
+            return await service.retries(
+                window_days=window_days, window_hours=window_hours,
+                since=since, until=until,
+                workflow_id=workflow_id, workflow_version=workflow_version,
+                run_name=run_name, sample_id=sample_id,
+                min_samples=min_samples, limit=limit,
+            )
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -79,12 +115,25 @@ def create_process_metrics_router(service: ProcessMetricsService) -> APIRouter:
         ),
     )
     async def process_resources_by_attempt(
-        window_days: int | None = Query(default=None, ge=1, description=_WINDOW_DESC),
-        min_samples: int = Query(default=50, ge=1, description=_MIN_SAMPLES_DESC),
+        window_days: int | None = Query(default=None, ge=1, description=_WINDOW_DAYS_DESC),
+        window_hours: int | None = Query(default=None, ge=1, description=_WINDOW_HOURS_DESC),
+        since: dt.datetime | None = Query(default=None, description=_SINCE_DESC),
+        until: dt.datetime | None = Query(default=None, description=_UNTIL_DESC),
+        workflow_id: str | None = Query(default=None, description=_WORKFLOW_ID_DESC),
+        workflow_version: str | None = Query(default=None, description=_WORKFLOW_VERSION_DESC),
+        run_name: str | None = Query(default=None, description=_RUN_NAME_DESC),
+        sample_id: str | None = Query(default=None, description=_SAMPLE_ID_DESC),
+        min_samples: int = Query(default=5, ge=1, description=_MIN_SAMPLES_DESC),
         limit: int = Query(default=100, ge=1, le=1000, description=_LIMIT_DESC),
     ):
         try:
-            return await service.resources_by_attempt(window_days=window_days, min_samples=min_samples, limit=limit)
+            return await service.resources_by_attempt(
+                window_days=window_days, window_hours=window_hours,
+                since=since, until=until,
+                workflow_id=workflow_id, workflow_version=workflow_version,
+                run_name=run_name, sample_id=sample_id,
+                min_samples=min_samples, limit=limit,
+            )
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -99,12 +148,25 @@ def create_process_metrics_router(service: ProcessMetricsService) -> APIRouter:
         ),
     )
     async def process_failures(
-        window_days: int | None = Query(default=None, ge=1, description=_WINDOW_DESC),
-        min_samples: int = Query(default=50, ge=1, description=_MIN_SAMPLES_DESC),
+        window_days: int | None = Query(default=None, ge=1, description=_WINDOW_DAYS_DESC),
+        window_hours: int | None = Query(default=None, ge=1, description=_WINDOW_HOURS_DESC),
+        since: dt.datetime | None = Query(default=None, description=_SINCE_DESC),
+        until: dt.datetime | None = Query(default=None, description=_UNTIL_DESC),
+        workflow_id: str | None = Query(default=None, description=_WORKFLOW_ID_DESC),
+        workflow_version: str | None = Query(default=None, description=_WORKFLOW_VERSION_DESC),
+        run_name: str | None = Query(default=None, description=_RUN_NAME_DESC),
+        sample_id: str | None = Query(default=None, description=_SAMPLE_ID_DESC),
+        min_samples: int = Query(default=5, ge=1, description=_MIN_SAMPLES_DESC),
         limit: int = Query(default=50, ge=1, le=500, description=_LIMIT_DESC),
     ):
         try:
-            return await service.failures(window_days=window_days, min_samples=min_samples, limit=limit)
+            return await service.failures(
+                window_days=window_days, window_hours=window_hours,
+                since=since, until=until,
+                workflow_id=workflow_id, workflow_version=workflow_version,
+                run_name=run_name, sample_id=sample_id,
+                min_samples=min_samples, limit=limit,
+            )
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -119,11 +181,56 @@ def create_process_metrics_router(service: ProcessMetricsService) -> APIRouter:
         ),
     )
     async def process_failure_signatures(
-        window_days: int | None = Query(default=None, ge=1, description=_WINDOW_DESC),
+        window_days: int | None = Query(default=None, ge=1, description=_WINDOW_DAYS_DESC),
+        window_hours: int | None = Query(default=None, ge=1, description=_WINDOW_HOURS_DESC),
+        since: dt.datetime | None = Query(default=None, description=_SINCE_DESC),
+        until: dt.datetime | None = Query(default=None, description=_UNTIL_DESC),
+        workflow_id: str | None = Query(default=None, description=_WORKFLOW_ID_DESC),
+        workflow_version: str | None = Query(default=None, description=_WORKFLOW_VERSION_DESC),
+        run_name: str | None = Query(default=None, description=_RUN_NAME_DESC),
+        sample_id: str | None = Query(default=None, description=_SAMPLE_ID_DESC),
         limit: int = Query(default=100, ge=1, le=1000, description=_LIMIT_DESC),
     ):
         try:
-            return await service.failure_signatures(window_days=window_days, limit=limit)
+            return await service.failure_signatures(
+                window_days=window_days, window_hours=window_hours,
+                since=since, until=until,
+                workflow_id=workflow_id, workflow_version=workflow_version,
+                run_name=run_name, sample_id=sample_id,
+                limit=limit,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    @router.get(
+        "/timeline",
+        response_model=models.ProcessTimelineResponse,
+        summary="Failure and success counts over time",
+        description=(
+            "Groups process_completed events into time buckets (hour/day/week) and returns "
+            "success/failure counts per bucket. Use this to see whether failures are a recent "
+            "regression or long-running background noise, and to correlate failure spikes with "
+            "deployments. Supports the same workflow, time-window, and process filters as other endpoints."
+        ),
+    )
+    async def process_timeline(
+        bucket: Literal["hour", "day", "week"] = Query(default="hour", description="Time bucket size."),
+        window_days: int | None = Query(default=None, ge=1, description=_WINDOW_DAYS_DESC),
+        window_hours: int | None = Query(default=None, ge=1, description=_WINDOW_HOURS_DESC),
+        since: dt.datetime | None = Query(default=None, description=_SINCE_DESC),
+        until: dt.datetime | None = Query(default=None, description=_UNTIL_DESC),
+        workflow_id: str | None = Query(default=None, description=_WORKFLOW_ID_DESC),
+        workflow_version: str | None = Query(default=None, description=_WORKFLOW_VERSION_DESC),
+        process: str | None = Query(default=None, description="Filter to a specific process name."),
+    ):
+        try:
+            return await service.timeline(
+                bucket=bucket,
+                window_days=window_days, window_hours=window_hours,
+                since=since, until=until,
+                workflow_id=workflow_id, workflow_version=workflow_version,
+                process=process,
+            )
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 

--- a/src/nextflow_telemetry/services/process_metrics.py
+++ b/src/nextflow_telemetry/services/process_metrics.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import datetime as dt
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Literal
 
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine
@@ -12,27 +13,91 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 class ProcessMetricsService:
     engine: AsyncEngine
 
-    @staticmethod
-    def _normalize_window_days(window_days: int | None) -> int | None:
-        if window_days is None:
-            return None
-        if window_days < 1:
-            raise ValueError("window_days must be >= 1")
-        return window_days
+    def _filter_clause(
+        self,
+        *,
+        window_days: int | None = None,
+        window_hours: int | None = None,
+        since: dt.datetime | None = None,
+        until: dt.datetime | None = None,
+        workflow_id: str | None = None,
+        workflow_version: str | None = None,
+        run_name: str | None = None,
+        sample_id: str | None = None,
+        table_alias: str = "t",
+    ) -> tuple[str, dict[str, Any]]:
+        """Build a composable WHERE fragment and bind-params dict for telemetry queries."""
+        clauses: list[str] = []
+        params: dict[str, Any] = {}
+        a = table_alias
 
-    def _window_clause(self, window_days: int | None) -> tuple[str, dict[str, Any]]:
-        normalized = self._normalize_window_days(window_days)
-        if normalized is None:
-            return "", {}
-        return " and t.utc_time >= now() - make_interval(days => :window_days)", {"window_days": normalized}
+        if window_days is not None and window_hours is not None:
+            raise ValueError("Provide only one of window_days or window_hours, not both.")
 
-    async def summary(self, *, window_days: int | None = None, min_samples: int = 50, limit: int = 10) -> dict[str, Any]:
+        if window_days is not None:
+            if window_days < 1:
+                raise ValueError("window_days must be >= 1")
+            clauses.append(f"{a}.utc_time >= now() - make_interval(days => :window_days)")
+            params["window_days"] = window_days
+
+        if window_hours is not None:
+            if window_hours < 1:
+                raise ValueError("window_hours must be >= 1")
+            clauses.append(f"{a}.utc_time >= now() - make_interval(hours => :window_hours)")
+            params["window_hours"] = window_hours
+
+        if since is not None:
+            clauses.append(f"{a}.utc_time >= :since")
+            params["since"] = since
+
+        if until is not None:
+            clauses.append(f"{a}.utc_time <= :until")
+            params["until"] = until
+
+        if workflow_id is not None:
+            clauses.append(f"{a}.workflow_id = :workflow_id")
+            params["workflow_id"] = workflow_id
+
+        if workflow_version is not None:
+            clauses.append(f"{a}.workflow_version = :workflow_version")
+            params["workflow_version"] = workflow_version
+
+        if run_name is not None:
+            clauses.append(f"{a}.run_name = :run_name")
+            params["run_name"] = run_name
+
+        if sample_id is not None:
+            clauses.append(f"{a}.sample_id = :sample_id")
+            params["sample_id"] = sample_id
+
+        fragment = (" and " + " and ".join(clauses)) if clauses else ""
+        return fragment, params
+
+    async def summary(
+        self,
+        *,
+        window_days: int | None = None,
+        window_hours: int | None = None,
+        since: dt.datetime | None = None,
+        until: dt.datetime | None = None,
+        workflow_id: str | None = None,
+        workflow_version: str | None = None,
+        run_name: str | None = None,
+        sample_id: str | None = None,
+        min_samples: int = 5,
+        limit: int = 10,
+    ) -> dict[str, Any]:
         if min_samples < 1:
             raise ValueError("min_samples must be >= 1")
         if limit < 1:
             raise ValueError("limit must be >= 1")
 
-        window_clause, params = self._window_clause(window_days)
+        fc, params = self._filter_clause(
+            window_days=window_days, window_hours=window_hours,
+            since=since, until=until,
+            workflow_id=workflow_id, workflow_version=workflow_version,
+            run_name=run_name, sample_id=sample_id,
+        )
         params = {**params, "min_samples": min_samples, "limit": limit}
 
         cards_sql = text(
@@ -47,7 +112,7 @@ class ProcessMetricsService:
               from telemetry t
               where t.event = 'process_completed'
                 and t.trace is not null
-                {window_clause}
+                {fc}
             )
             select
               count(*) as process_completed_rows,
@@ -74,7 +139,7 @@ class ProcessMetricsService:
               from telemetry t
               where t.event = 'process_completed'
                 and t.trace is not null
-                {window_clause}
+                {fc}
             )
             select
               process,
@@ -99,7 +164,7 @@ class ProcessMetricsService:
               from telemetry t
               where t.event = 'process_completed'
                 and t.trace is not null
-                {window_clause}
+                {fc}
             )
             select
               process,
@@ -125,7 +190,7 @@ class ProcessMetricsService:
             where t.event = 'process_completed'
               and t.trace is not null
               and coalesce(t.trace->>'status','') in ('FAILED', 'ABORTED')
-              {window_clause}
+              {fc}
             group by exit_code
             order by failures desc, exit_code
             limit :limit
@@ -137,7 +202,7 @@ class ProcessMetricsService:
             select t.event, count(*) as rows
             from telemetry t
             where true
-              {window_clause}
+              {fc}
             group by t.event
             order by rows desc, t.event
             """
@@ -160,13 +225,31 @@ class ProcessMetricsService:
             "top_failure_exit_codes": top_exit_codes,
         }
 
-    async def retries(self, *, window_days: int | None = None, min_samples: int = 50, limit: int = 50) -> dict[str, Any]:
+    async def retries(
+        self,
+        *,
+        window_days: int | None = None,
+        window_hours: int | None = None,
+        since: dt.datetime | None = None,
+        until: dt.datetime | None = None,
+        workflow_id: str | None = None,
+        workflow_version: str | None = None,
+        run_name: str | None = None,
+        sample_id: str | None = None,
+        min_samples: int = 5,
+        limit: int = 50,
+    ) -> dict[str, Any]:
         if min_samples < 1:
             raise ValueError("min_samples must be >= 1")
         if limit < 1:
             raise ValueError("limit must be >= 1")
 
-        window_clause, params = self._window_clause(window_days)
+        fc, params = self._filter_clause(
+            window_days=window_days, window_hours=window_hours,
+            since=since, until=until,
+            workflow_id=workflow_id, workflow_version=workflow_version,
+            run_name=run_name, sample_id=sample_id,
+        )
         params = {**params, "min_samples": min_samples, "limit": limit}
 
         summary_sql = text(
@@ -178,7 +261,7 @@ class ProcessMetricsService:
               from telemetry t
               where t.event = 'process_completed'
                 and t.trace is not null
-                {window_clause}
+                {fc}
             )
             select
               count(*) as process_completed_rows,
@@ -202,7 +285,7 @@ class ProcessMetricsService:
               from telemetry t
               where t.event = 'process_completed'
                 and t.trace is not null
-                {window_clause}
+                {fc}
             )
             select
               process,
@@ -230,7 +313,7 @@ class ProcessMetricsService:
             from telemetry t
             where t.event = 'process_completed'
               and t.trace is not null
-              {window_clause}
+              {fc}
             group by attempt
             order by attempt
             """
@@ -253,7 +336,14 @@ class ProcessMetricsService:
         self,
         *,
         window_days: int | None = None,
-        min_samples: int = 50,
+        window_hours: int | None = None,
+        since: dt.datetime | None = None,
+        until: dt.datetime | None = None,
+        workflow_id: str | None = None,
+        workflow_version: str | None = None,
+        run_name: str | None = None,
+        sample_id: str | None = None,
+        min_samples: int = 5,
         limit: int = 100,
     ) -> dict[str, Any]:
         if min_samples < 1:
@@ -261,7 +351,12 @@ class ProcessMetricsService:
         if limit < 1:
             raise ValueError("limit must be >= 1")
 
-        window_clause, params = self._window_clause(window_days)
+        fc, params = self._filter_clause(
+            window_days=window_days, window_hours=window_hours,
+            since=since, until=until,
+            workflow_id=workflow_id, workflow_version=workflow_version,
+            run_name=run_name, sample_id=sample_id,
+        )
         params = {**params, "min_samples": min_samples, "limit": limit}
 
         sql = text(
@@ -283,7 +378,7 @@ class ProcessMetricsService:
               where t.event = 'process_completed'
                 and t.trace is not null
                 and t.trace->>'process' is not null
-                {window_clause}
+                {fc}
             )
             select
               process,
@@ -319,13 +414,31 @@ class ProcessMetricsService:
             "rows": rows,
         }
 
-    async def failures(self, *, window_days: int | None = None, min_samples: int = 50, limit: int = 50) -> dict[str, Any]:
+    async def failures(
+        self,
+        *,
+        window_days: int | None = None,
+        window_hours: int | None = None,
+        since: dt.datetime | None = None,
+        until: dt.datetime | None = None,
+        workflow_id: str | None = None,
+        workflow_version: str | None = None,
+        run_name: str | None = None,
+        sample_id: str | None = None,
+        min_samples: int = 5,
+        limit: int = 50,
+    ) -> dict[str, Any]:
         if min_samples < 1:
             raise ValueError("min_samples must be >= 1")
         if limit < 1:
             raise ValueError("limit must be >= 1")
 
-        window_clause, params = self._window_clause(window_days)
+        fc, params = self._filter_clause(
+            window_days=window_days, window_hours=window_hours,
+            since=since, until=until,
+            workflow_id=workflow_id, workflow_version=workflow_version,
+            run_name=run_name, sample_id=sample_id,
+        )
         params = {**params, "min_samples": min_samples, "limit": limit}
 
         sql = text(
@@ -338,7 +451,7 @@ class ProcessMetricsService:
               from telemetry t
               where t.event = 'process_completed'
                 and t.trace is not null
-                {window_clause}
+                {fc}
             ),
             grouped as (
               select
@@ -386,14 +499,115 @@ class ProcessMetricsService:
             "rows": rows,
         }
 
-    async def running(self) -> dict[str, Any]:
-        """Tasks currently in flight across all active Nextflow runs.
+    async def failure_signatures(
+        self,
+        *,
+        window_days: int | None = None,
+        window_hours: int | None = None,
+        since: dt.datetime | None = None,
+        until: dt.datetime | None = None,
+        workflow_id: str | None = None,
+        workflow_version: str | None = None,
+        run_name: str | None = None,
+        sample_id: str | None = None,
+        limit: int = 100,
+    ) -> dict[str, Any]:
+        if limit < 1:
+            raise ValueError("limit must be >= 1")
 
-        Derives live state from the event stream:
-        - queued:  process_submitted but no process_started yet
-        - running: process_started but no process_completed yet
-        Only considers runs where workflow_runs.status = 'running'.
-        """
+        fc, params = self._filter_clause(
+            window_days=window_days, window_hours=window_hours,
+            since=since, until=until,
+            workflow_id=workflow_id, workflow_version=workflow_version,
+            run_name=run_name, sample_id=sample_id,
+        )
+        params = {**params, "limit": limit}
+
+        sql = text(
+            f"""
+            select
+              coalesce(t.trace->>'process','<null>') as process,
+              coalesce(t.trace->>'exit','<null>') as exit_code,
+              count(*) as failures
+            from telemetry t
+            where t.event = 'process_completed'
+              and t.trace is not null
+              and coalesce(t.trace->>'status','') in ('FAILED', 'ABORTED')
+              {fc}
+            group by process, exit_code
+            order by failures desc, process, exit_code
+            limit :limit
+            """
+        )
+
+        async with self.engine.connect() as conn:
+            rows = [dict(row) for row in (await conn.execute(sql, params)).mappings().all()]
+
+        return {
+            "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+            "window_days": window_days,
+            "rows": rows,
+        }
+
+    async def timeline(
+        self,
+        *,
+        bucket: Literal["hour", "day", "week"] = "hour",
+        window_days: int | None = None,
+        window_hours: int | None = None,
+        since: dt.datetime | None = None,
+        until: dt.datetime | None = None,
+        workflow_id: str | None = None,
+        workflow_version: str | None = None,
+        process: str | None = None,
+    ) -> dict[str, Any]:
+        if bucket not in ("hour", "day", "week"):
+            raise ValueError("bucket must be 'hour', 'day', or 'week'")
+
+        fc, params = self._filter_clause(
+            window_days=window_days, window_hours=window_hours,
+            since=since, until=until,
+            workflow_id=workflow_id, workflow_version=workflow_version,
+        )
+        params = {**params, "bucket": bucket}
+
+        process_clause = ""
+        if process is not None:
+            process_clause = "and t.trace->>'process' = :process"
+            params["process"] = process
+
+        sql = text(
+            f"""
+            select
+              date_trunc(:bucket, t.utc_time) as bucket_start,
+              count(*) as total,
+              count(*) filter (where coalesce(t.trace->>'status','') = 'COMPLETED') as success,
+              count(*) filter (where coalesce(t.trace->>'status','') in ('FAILED','ABORTED')) as failed,
+              coalesce(round(
+                100.0 * count(*) filter (where coalesce(t.trace->>'status','') in ('FAILED','ABORTED'))::numeric
+                / nullif(count(*), 0), 2
+              ), 0) as failure_pct
+            from telemetry t
+            where t.event = 'process_completed'
+              and t.trace is not null
+              {fc}
+              {process_clause}
+            group by bucket_start
+            order by bucket_start
+            """
+        )
+
+        async with self.engine.connect() as conn:
+            rows = [dict(row) for row in (await conn.execute(sql, params)).mappings().all()]
+
+        return {
+            "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+            "bucket": bucket,
+            "rows": rows,
+        }
+
+    async def running(self) -> dict[str, Any]:
+        """Tasks currently in flight across all active Nextflow runs."""
         sql = text(
             """
             with active_runs as (
@@ -448,37 +662,4 @@ class ProcessMetricsService:
             "total_running": total_running,
             "total_queued": total_queued,
             "by_process": rows,
-        }
-
-    async def failure_signatures(self, *, window_days: int | None = None, limit: int = 100) -> dict[str, Any]:
-        if limit < 1:
-            raise ValueError("limit must be >= 1")
-
-        window_clause, params = self._window_clause(window_days)
-        params = {**params, "limit": limit}
-
-        sql = text(
-            f"""
-            select
-              coalesce(t.trace->>'process','<null>') as process,
-              coalesce(t.trace->>'exit','<null>') as exit_code,
-              count(*) as failures
-            from telemetry t
-            where t.event = 'process_completed'
-              and t.trace is not null
-              and coalesce(t.trace->>'status','') in ('FAILED', 'ABORTED')
-              {window_clause}
-            group by process, exit_code
-            order by failures desc, process, exit_code
-            limit :limit
-            """
-        )
-
-        async with self.engine.connect() as conn:
-            rows = [dict(row) for row in (await conn.execute(sql, params)).mappings().all()]
-
-        return {
-            "generated_at_utc": datetime.now(timezone.utc).isoformat(),
-            "window_days": window_days,
-            "rows": rows,
         }

--- a/tests/test_process_metrics_router.py
+++ b/tests/test_process_metrics_router.py
@@ -4,11 +4,17 @@ from fastapi.testclient import TestClient
 from nextflow_telemetry.routers.process_metrics import create_process_metrics_router
 
 
+_FILTER_KWARGS = {
+    "window_days": None, "window_hours": None, "since": None, "until": None,
+    "workflow_id": None, "workflow_version": None, "run_name": None, "sample_id": None,
+}
+
+
 class FakeProcessMetricsService:
-    async def summary(self, *, window_days=None, min_samples=50, limit=10):
+    async def summary(self, *, min_samples=5, limit=10, **kwargs):
         return {
             "generated_at_utc": "2026-01-01T00:00:00Z",
-            "window_days": window_days,
+            "window_days": kwargs.get("window_days"),
             "cards": {
                 "process_completed_rows": 123,
                 "distinct_runs": 4,
@@ -38,10 +44,10 @@ class FakeProcessMetricsService:
             "top_failure_exit_codes": [{"exit_code": "1", "failures": 10}],
         }
 
-    async def retries(self, *, window_days=None, min_samples=50, limit=50):
+    async def retries(self, *, min_samples=5, limit=50, **kwargs):
         return {
             "generated_at_utc": "2026-01-01T00:00:00Z",
-            "window_days": window_days,
+            "window_days": kwargs.get("window_days"),
             "summary": {
                 "process_completed_rows": 10,
                 "retried_rows": 2,
@@ -64,10 +70,10 @@ class FakeProcessMetricsService:
             ],
         }
 
-    async def resources_by_attempt(self, *, window_days=None, min_samples=50, limit=100):
+    async def resources_by_attempt(self, *, min_samples=5, limit=100, **kwargs):
         return {
             "generated_at_utc": "2026-01-01T00:00:00Z",
-            "window_days": window_days,
+            "window_days": kwargs.get("window_days"),
             "rows": [
                 {
                     "process": "kneaddata",
@@ -90,10 +96,10 @@ class FakeProcessMetricsService:
             ],
         }
 
-    async def failures(self, *, window_days=None, min_samples=50, limit=50):
+    async def failures(self, *, min_samples=5, limit=50, **kwargs):
         return {
             "generated_at_utc": "2026-01-01T00:00:00Z",
-            "window_days": window_days,
+            "window_days": kwargs.get("window_days"),
             "rows": [
                 {
                     "process": "kneaddata",
@@ -106,11 +112,20 @@ class FakeProcessMetricsService:
             ],
         }
 
-    async def failure_signatures(self, *, window_days=None, limit=100):
+    async def failure_signatures(self, *, limit=100, **kwargs):
         return {
             "generated_at_utc": "2026-01-01T00:00:00Z",
-            "window_days": window_days,
+            "window_days": kwargs.get("window_days"),
             "rows": [{"process": "kneaddata", "exit_code": "1", "failures": 2}],
+        }
+
+    async def timeline(self, *, bucket="hour", **kwargs):
+        return {
+            "generated_at_utc": "2026-01-01T00:00:00Z",
+            "bucket": bucket,
+            "rows": [
+                {"bucket_start": "2026-01-01T00:00:00Z", "total": 10, "success": 8, "failed": 2, "failure_pct": 20.0}
+            ],
         }
 
 


### PR DESCRIPTION
## Summary

- Replaces the single `window_days` filter with a composable `_filter_clause` helper supporting `workflow_id`, `workflow_version`, `run_name`, `sample_id`, `window_hours`, `since`, and `until` on all `/metrics/processes/*` endpoints
- Adds `GET /metrics/processes/timeline` — bucket process completions by hour/day/week with the full filter set
- Lowers `min_samples` default from 50 → 5 so newly-introduced processes are visible during active development

Closes #22, #23, #24, #25, #26

## Example queries now possible

```
# v1.6.0 failures in the last 2 hours
GET /metrics/processes/failures?workflow_version=1.6.0&window_hours=2&min_samples=1

# All-time summary scoped to cmgd_nextflow
GET /metrics/processes/summary?workflow_id=cmgd_nextflow

# Hourly failure trend since a specific deploy
GET /metrics/processes/timeline?since=2026-05-04T14:00:00Z&workflow_id=cmgd_nextflow

# Drill into a single run
GET /metrics/processes/failure-signatures?run_name=r069f7f9b-c732-7767-8000-d2fe2f3aedb0
```

## Test plan

- [x] `uv run mypy src/nextflow_telemetry` — clean (pre-existing uuid_extensions stub warning only)
- [x] `uv run pytest tests/test_api.py tests/test_integration.py tests/test_process_metrics_router.py` — 30 passed
- [x] Smoke-tested new filters against live server with real Anvil telemetry data

🤖 Generated with [Claude Code](https://claude.ai/claude-code)