### PR TITLE
Issue #29: retry/failure analytics — error_action, memory efficiency KPI, re-queue labeling

### DIFF
--- a/frontend/src/pages/MetricsPage.tsx
+++ b/frontend/src/pages/MetricsPage.tsx
@@ -13,6 +13,7 @@ import PageWrap from '../components/PageWrap'
 import Btn from '../components/Btn'
 import Select from '../components/Select'
 import type {
+  ProcessSummaryResponse,
   ProcessFailuresResponse,
   ProcessRetriesResponse,
   ProcessResourcesByAttemptResponse,
@@ -85,10 +86,28 @@ function FilterBar({
   )
 }
 
+const ERROR_ACTION_COLOR: Record<string, string> = {
+  RETRY:  '#2563eb',
+  FINISH: '#dc2626',
+  IGNORE: '#d97706',
+}
+
+function ErrorActionBadge({ action }: { action: string | null }) {
+  if (!action) return <span style={{ color: T.border }}>—</span>
+  const color = ERROR_ACTION_COLOR[action] ?? T.muted
+  return (
+    <span style={{
+      display: 'inline-block', padding: '1px 6px', borderRadius: 3,
+      fontSize: 10, fontWeight: 700, letterSpacing: '0.04em',
+      background: color + '22', color, border: `1px solid ${color}44`,
+    }}>{action}</span>
+  )
+}
+
 function FailuresTab({ data }: { data: ProcessFailuresResponse }) {
   return (
     <Panel>
-      <SectionHeader title="Failure Rate by Process" sub="Ranked by total failures" />
+      <SectionHeader title="Failure Rate by Process" sub="Ranked by total failures · error_action = what Nextflow did on failure" />
       {data.rows.length === 0
         ? <div style={{ color: T.muted, fontSize: 13 }}>No failures recorded.</div>
         : (
@@ -109,6 +128,8 @@ function FailuresTab({ data }: { data: ProcessFailuresResponse }) {
                 render: v => v != null
                   ? <span style={{ color: T.muted, fontSize: 12 }}>exit {v as string}</span>
                   : <span style={{ color: T.border }}>—</span> },
+              { key: 'modal_error_action', label: 'NF Action',
+                render: v => <ErrorActionBadge action={v as string | null} /> },
             ]}
             rows={data.rows}
           />
@@ -122,12 +143,16 @@ function RetriesTab({ data }: { data: ProcessRetriesResponse }) {
   const { summary, by_attempt, by_process } = data
   return (
     <>
+      <div style={{ fontSize: 11, color: T.muted, padding: '4px 0 8px' }}>
+        These are <strong>Nextflow-level retries</strong> (attempt &gt; 1 within a single pipeline run),
+        not pipeline re-queues managed by this server.
+      </div>
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(168px,1fr))', gap: 12 }}>
-        <KPICard label="Retried Tasks"   value={fmtNum(summary.retried_rows)}
+        <KPICard label="NF-Retried Tasks"  value={fmtNum(summary.retried_rows)}
           sub={`${fmtPct(summary.retried_pct)} of completions`} accent={T.amber} />
-        <KPICard label="Retry Successes" value={fmtNum(summary.retry_success_rows)} sub="Eventually passed"  accent={T.green} />
-        <KPICard label="Retry Failures"  value={fmtNum(summary.retry_failure_rows)} sub="Went to DLQ"        accent={T.red} />
-        <KPICard label="Retry Win Rate"  value={fmtPct(summary.retry_success_pct)}  sub="Success after retry" accent={T.green} />
+        <KPICard label="Retry Recoveries" value={fmtNum(summary.retry_success_rows)} sub="Retried → succeeded"  accent={T.green} />
+        <KPICard label="Retry Exhausted"  value={fmtNum(summary.retry_failure_rows)} sub="Retried → still failed" accent={T.red} />
+        <KPICard label="Retry Win Rate"   value={fmtPct(summary.retry_success_pct)}  sub="Success after retry"   accent={T.green} />
       </div>
       <div style={{ display: 'grid', gridTemplateColumns: '300px 1fr', gap: 16 }}>
         <Panel>
@@ -170,13 +195,25 @@ function RetriesTab({ data }: { data: ProcessRetriesResponse }) {
   )
 }
 
-function ResourcesTab({ data }: { data: ProcessResourcesByAttemptResponse }) {
+function ResourcesTab({ data, summary }: { data: ProcessResourcesByAttemptResponse; summary: ProcessSummaryResponse | null }) {
   const [filterProcess, setFilterProcess] = useState('')
   const processes = [...new Set(data.rows.map(r => r.process))]
   const rows = data.rows.filter(r => !filterProcess || r.process === filterProcess)
 
+  const memEff = summary?.cards.memory_efficiency_pct ?? null
+
   return (
     <>
+      {memEff !== null && (
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(168px,1fr))', gap: 12, marginBottom: 4 }}>
+          <KPICard
+            label="Memory Efficiency"
+            value={`${memEff.toFixed(1)}%`}
+            sub="avg peak_rss / requested — low = over-provisioned"
+            accent={memEff < 20 ? T.amber : memEff < 50 ? T.accent : T.green}
+          />
+        </div>
+      )}
       <div style={{ display: 'flex', gap: 12, alignItems: 'flex-end' }}>
         <div style={{ width: 280 }}>
           <Select label="Filter by process" value={filterProcess} onChange={setFilterProcess}
@@ -247,13 +284,15 @@ function SignaturesTab({ data }: { data: ProcessFailureSignaturesResponse }) {
   }
 
   const max = Math.max(...rows.map(r => r.failures))
+  // Key heatmap columns on "exit_code|error_action" so RETRY and FINISH variants are distinct
+  const colKey = (r: FailureSignatureRow) => `${r.exit_code}|${r.error_action ?? ''}`
   type ProcessMap = Record<string, Record<string, number>>
   const byProcess = rows.reduce<ProcessMap>((acc, r) => {
     if (!acc[r.process]) acc[r.process] = {}
-    acc[r.process]![r.exit_code] = r.failures
+    acc[r.process]![colKey(r)] = r.failures
     return acc
   }, {})
-  const exitCodes = [...new Set(rows.map(r => r.exit_code))].sort()
+  const cols = [...new Set(rows.map(colKey))].sort()
   const procs = Object.keys(byProcess)
 
   const cellColor = (v: number): string => {
@@ -274,12 +313,16 @@ function SignaturesTab({ data }: { data: ProcessFailureSignaturesResponse }) {
             <tr>
               <th style={{ padding: '6px 12px', textAlign: 'left', color: T.muted, fontWeight: 600,
                 borderBottom: `1px solid ${T.border}`, whiteSpace: 'nowrap' }}>Process</th>
-              {exitCodes.map(ec => (
-                <th key={ec} style={{ padding: '6px 10px', textAlign: 'center', color: T.muted,
-                  fontWeight: 600, borderBottom: `1px solid ${T.border}`, whiteSpace: 'nowrap' }}>
-                  exit {ec}
-                </th>
-              ))}
+              {cols.map(col => {
+                const [ec, action] = col.split('|')
+                return (
+                  <th key={col} style={{ padding: '6px 10px', textAlign: 'center', color: T.muted,
+                    fontWeight: 600, borderBottom: `1px solid ${T.border}`, whiteSpace: 'nowrap' }}>
+                    <div>exit {ec}</div>
+                    {action && <ErrorActionBadge action={action} />}
+                  </th>
+                )
+              })}
               <th style={{ padding: '6px 10px', textAlign: 'right', color: T.muted, fontWeight: 600,
                 borderBottom: `1px solid ${T.border}` }}>Total</th>
             </tr>
@@ -292,10 +335,10 @@ function SignaturesTab({ data }: { data: ProcessFailureSignaturesResponse }) {
                   onMouseEnter={e => (e.currentTarget.style.background = T.elevated)}
                   onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}>
                   <td style={{ padding: '8px 12px', color: T.text, whiteSpace: 'nowrap' }}>{p}</td>
-                  {exitCodes.map(ec => {
-                    const v = byProcess[p]![ec]
+                  {cols.map(col => {
+                    const v = byProcess[p]![col]
                     return (
-                      <td key={ec} style={{ padding: '6px 10px', textAlign: 'center' }}>
+                      <td key={col} style={{ padding: '6px 10px', textAlign: 'center' }}>
                         {v ? (
                           <span style={{
                             display: 'inline-block', minWidth: 52, padding: '2px 6px',
@@ -396,6 +439,7 @@ export default function MetricsPage({ pollInterval = 30_000 }: { pollInterval?: 
   const [bucket, setBucket]   = useState<'hour' | 'day' | 'week'>('hour')
   const [workflows, setWorkflows] = useState<string[]>([])
 
+  const [summary,    setSummary]    = useState<ProcessSummaryResponse | null>(null)
   const [failures,   setFailures]   = useState<ProcessFailuresResponse | null>(null)
   const [retries,    setRetries]    = useState<ProcessRetriesResponse | null>(null)
   const [resources,  setResources]  = useState<ProcessResourcesByAttemptResponse | null>(null)
@@ -412,7 +456,8 @@ export default function MetricsPage({ pollInterval = 30_000 }: { pollInterval?: 
   }, [])
 
   useEffect(() => {
-    setFailures(null); setRetries(null); setResources(null); setSignatures(null); setTimeline(null)
+    setSummary(null); setFailures(null); setRetries(null); setResources(null); setSignatures(null); setTimeline(null)
+    api.metrics.summary(filters).then(setSummary).catch(console.error)
     api.metrics.failures(filters).then(setFailures).catch(console.error)
     api.metrics.retries(filters).then(setRetries).catch(console.error)
     api.metrics.resources(filters).then(setResources).catch(console.error)
@@ -460,7 +505,7 @@ export default function MetricsPage({ pollInterval = 30_000 }: { pollInterval?: 
           <>
             {tab === 'failures'   && <FailuresTab   data={failures!}   />}
             {tab === 'retries'    && <RetriesTab    data={retries!}    />}
-            {tab === 'resources'  && <ResourcesTab  data={resources!}  />}
+            {tab === 'resources'  && <ResourcesTab  data={resources!} summary={summary} />}
             {tab === 'signatures' && <SignaturesTab  data={signatures!} />}
             {tab === 'timeline'   && <TimelineTab   data={timeline!}   bucket={bucket} onBucket={setBucket} />}
           </>

--- a/frontend/src/pages/WorkflowsPage.tsx
+++ b/frontend/src/pages/WorkflowsPage.tsx
@@ -63,7 +63,7 @@ function WorkflowFormModal({
         </div>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
           <label style={{ fontSize: 11, color: T.muted, fontWeight: 600,
-            letterSpacing: '0.05em', textTransform: 'uppercase' }}>Max Retries</label>
+            letterSpacing: '0.05em', textTransform: 'uppercase' }}>Max Pipeline Re-queues</label>
           <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
             <input type="range" min={0} max={10} value={form.max_retries}
               onChange={e => set('max_retries', +e.target.value)}
@@ -118,9 +118,9 @@ function JobSummaryBar({ summary }: { summary: WorkflowJobSummary }) {
           <span style={{ fontSize: 10, color: T.amber }}>{fmtNum(pending + claimed)} pending</span>
         )}
         {running > 0 && <span style={{ fontSize: 10, color: T.blue }}>{fmtNum(running)} running</span>}
-        {failed  > 0 && <span style={{ fontSize: 10, color: T.red  }}>{fmtNum(failed)} failed</span>}
+        {failed  > 0 && <span style={{ fontSize: 10, color: T.red  }} title="Exhausted all pipeline re-queues">{fmtNum(failed)} perm. failed</span>}
         {dead_letter > 0 && (
-          <span style={{ fontSize: 10, color: T.muted }}>{fmtNum(dead_letter)} DLQ</span>
+          <span style={{ fontSize: 10, color: T.muted }} title="Dead-letter queue">{fmtNum(dead_letter)} DLQ</span>
         )}
       </div>
     </div>
@@ -186,7 +186,7 @@ function WorkflowCard({
               ['Repository',  wf.repository_url],
               ['Revision',    wf.revision],
               ['Profile',     wf.profile],
-              ['Max Retries', String(wf.max_retries)],
+              ['Max Re-queues', String(wf.max_retries)],
               ['Registered',  fmtDate(wf.created_at)],
               ['Updated',     fmtAgo(wf.updated_at)],
             ] as [string, string][]).map(([k, v]) => (

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -58,6 +58,7 @@ export interface ProcessSummaryCards {
   retried_rows: number
   retry_pct: number
   retry_success_pct: number
+  memory_efficiency_pct: number
   latest_process_completed_utc: string | null
 }
 
@@ -104,6 +105,7 @@ export interface ProcessFailuresRow {
   failed: number
   failure_pct: number
   modal_failure_exit_code: string | null
+  modal_error_action: string | null
 }
 
 export interface ProcessFailuresResponse {
@@ -174,6 +176,7 @@ export interface ProcessResourcesByAttemptResponse {
 export interface FailureSignatureRow {
   process: string
   exit_code: string
+  error_action: string | null
   failures: number
 }
 

--- a/src/nextflow_telemetry/models.py
+++ b/src/nextflow_telemetry/models.py
@@ -92,9 +92,10 @@ class ProcessSummaryCards(BaseModel):
     success_rows: int = Field(description="Events where the task exited successfully.")
     failure_rows: int = Field(description="Events where the task failed.")
     failure_pct: float = Field(description="Failure rate as a percentage (0–100).")
-    retried_rows: int = Field(description="Events that were retried at least once.")
+    retried_rows: int = Field(description="Events that were retried at least once (Nextflow attempt > 1).")
     retry_pct: float = Field(description="Retry rate as a percentage (0–100).")
-    retry_success_pct: float = Field(description="Percentage of retried tasks that eventually succeeded.")
+    retry_success_pct: float = Field(description="Percentage of Nextflow-retried tasks that eventually succeeded.")
+    memory_efficiency_pct: float = Field(description="Average memory efficiency (peak_rss / requested_memory × 100). Low values indicate over-provisioned memory requests.")
     latest_process_completed_utc: Optional[datetime.datetime] = Field(description="Timestamp of the most recent process_completed event.")
 
 
@@ -212,6 +213,7 @@ class ProcessFailuresRow(BaseModel):
     failed: int
     failure_pct: float
     modal_failure_exit_code: Optional[str] = Field(description="Most common exit code among failed tasks for this process.")
+    modal_error_action: Optional[str] = Field(default=None, description="Most common error_action (RETRY/FINISH/IGNORE) among failed tasks for this process.")
 
 
 class ProcessFailuresResponse(BaseModel):
@@ -222,9 +224,10 @@ class ProcessFailuresResponse(BaseModel):
 
 
 class FailureSignatureRow(BaseModel):
-    """Count of failures grouped by (process, exit_code) pair."""
+    """Count of failures grouped by (process, exit_code, error_action) triple."""
     process: str
     exit_code: str
+    error_action: Optional[str] = Field(default=None, description="Nextflow error strategy action taken: RETRY, FINISH, or IGNORE.")
     failures: int
 
 

--- a/src/nextflow_telemetry/services/process_metrics.py
+++ b/src/nextflow_telemetry/services/process_metrics.py
@@ -108,7 +108,9 @@ class ProcessMetricsService:
                 t.utc_time,
                 coalesce(t.trace->>'process','<null>') as process,
                 coalesce(t.trace->>'status','') as status,
-                coalesce(nullif(t.trace->>'attempt',''),'0')::int as attempt
+                coalesce(nullif(t.trace->>'attempt',''),'0')::int as attempt,
+                nullif(t.trace->>'peak_rss','')::double precision as peak_rss,
+                nullif(t.trace->>'memory','')::double precision as requested_memory_bytes
               from telemetry t
               where t.event = 'process_completed'
                 and t.trace is not null
@@ -125,6 +127,9 @@ class ProcessMetricsService:
               coalesce(round(100.0 * count(*) filter (where attempt > 1)::numeric / nullif(count(*), 0), 2), 0) as retry_pct,
               coalesce(round(100.0 * count(*) filter (where attempt > 1 and status = 'COMPLETED')::numeric /
                     nullif(count(*) filter (where attempt > 1), 0), 2), 0) as retry_success_pct,
+              coalesce(round(100.0 * avg(peak_rss / nullif(requested_memory_bytes, 0))
+                    filter (where peak_rss is not null and requested_memory_bytes is not null and requested_memory_bytes > 0)::numeric, 2), 0)
+                as memory_efficiency_pct,
               max(utc_time) as latest_process_completed_utc
             from x
             """
@@ -447,7 +452,8 @@ class ProcessMetricsService:
               select
                 coalesce(t.trace->>'process','<null>') as process,
                 coalesce(t.trace->>'status','') as status,
-                coalesce(t.trace->>'exit','<null>') as exit_code
+                coalesce(t.trace->>'exit','<null>') as exit_code,
+                nullif(t.trace->>'error_action', '') as error_action
               from telemetry t
               where t.event = 'process_completed'
                 and t.trace is not null
@@ -474,6 +480,18 @@ class ProcessMetricsService:
               from x
               where status in ('FAILED', 'ABORTED')
               group by process, exit_code
+            ),
+            fail_action as (
+              select
+                process,
+                error_action,
+                row_number() over (
+                  partition by process
+                  order by count(*) desc, error_action
+                ) as rn
+              from x
+              where status in ('FAILED', 'ABORTED') and error_action is not null
+              group by process, error_action
             )
             select
               g.process,
@@ -481,10 +499,11 @@ class ProcessMetricsService:
               g.success,
               g.failed,
               round(100.0 * g.failed::numeric / nullif(g.total_completed, 0), 2) as failure_pct,
-              f.exit_code as modal_failure_exit_code
+              f.exit_code as modal_failure_exit_code,
+              a.error_action as modal_error_action
             from grouped g
-            left join fail_exit f
-              on f.process = g.process and f.rn = 1
+            left join fail_exit f on f.process = g.process and f.rn = 1
+            left join fail_action a on a.process = g.process and a.rn = 1
             order by g.failed desc, failure_pct desc, g.total_completed desc
             limit :limit
             """
@@ -528,13 +547,14 @@ class ProcessMetricsService:
             select
               coalesce(t.trace->>'process','<null>') as process,
               coalesce(t.trace->>'exit','<null>') as exit_code,
+              nullif(t.trace->>'error_action', '') as error_action,
               count(*) as failures
             from telemetry t
             where t.event = 'process_completed'
               and t.trace is not null
               and coalesce(t.trace->>'status','') in ('FAILED', 'ABORTED')
               {fc}
-            group by process, exit_code
+            group by process, exit_code, error_action
             order by failures desc, process, exit_code
             limit :limit
             """

--- a/tests/test_process_metrics_router.py
+++ b/tests/test_process_metrics_router.py
@@ -25,6 +25,7 @@ class FakeProcessMetricsService:
                 "retried_rows": 11,
                 "retry_pct": 8.9,
                 "retry_success_pct": 30.0,
+                "memory_efficiency_pct": 45.2,
                 "latest_process_completed_utc": "2026-01-01T00:00:00Z",
             },
             "event_mix": [{"event": "process_completed", "rows": 123}],


### PR DESCRIPTION
## Summary

- **`error_action` in failure analytics**: The `error_action` field (RETRY/FINISH/IGNORE) from Nextflow's trace JSONB is now extracted and surfaced in the `/metrics/processes/failures` and `/metrics/processes/failure-signatures` endpoints. Frontend shows color-coded `ErrorActionBadge` in the Failures and Signatures tabs.
- **Memory efficiency KPI**: `summary()` now computes `memory_efficiency_pct` (avg `peak_rss / requested_memory × 100`) across all process_completed events. Shown as a KPI card in the Resources tab (amber <20%, accent <50%, green ≥50%).
- **Clarified Nextflow retries vs API re-queues**: UI labels updated throughout — "Max Retries" → "Max Pipeline Re-queues", `failed` → `perm. failed` with tooltip, explanatory note in RetriesTab distinguishing Nextflow-level retries (attempt > 1) from orchestration-level re-queues.

## Test plan

- [ ] All 5 router unit tests pass (`uv run pytest tests/test_process_metrics_router.py`)
- [ ] TypeScript compiles clean (`npx tsc --noEmit`)
- [ ] Failures tab shows "NF Action" column with color-coded badge
- [ ] Signatures tab groups by (process, exit_code, error_action) triple
- [ ] Resources tab shows memory efficiency KPI card
- [ ] WorkflowsPage shows "Max Pipeline Re-queues" label

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)