### PR TITLE
Issue #30: task browser — paginated task execution table

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -9,6 +9,7 @@ import type {
   ProcessResourcesByAttemptResponse,
   ProcessFailureSignaturesResponse,
   ProcessTimelineResponse,
+  TasksResponse,
   RunningProcessesResponse,
   DispatchBatchResponse,
   ReconcileResult,
@@ -90,6 +91,14 @@ export const api = {
     signatures: (f: MetricsFilters = {}) => get<ProcessFailureSignaturesResponse>(`/metrics/processes/failure-signatures${metricsParams(f)}`),
     timeline:   (f: MetricsFilters = {}, bucket: 'hour' | 'day' | 'week' = 'hour') =>
       get<ProcessTimelineResponse>(`/metrics/processes/timeline${metricsParams(f, { bucket })}`),
+    tasks: (f: MetricsFilters = {}, extra: { process?: string; status?: string; limit?: number; offset?: number } = {}) => {
+      const e: Record<string, string | number> = {}
+      if (extra.process) e['process'] = extra.process
+      if (extra.status)  e['status']  = extra.status
+      if (extra.limit  != null) e['limit']  = extra.limit
+      if (extra.offset != null) e['offset'] = extra.offset
+      return get<TasksResponse>(`/metrics/processes/tasks${metricsParams(f, e)}`)
+    },
   },
 
   dispatch: {

--- a/frontend/src/pages/MetricsPage.tsx
+++ b/frontend/src/pages/MetricsPage.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react'
 import { usePoll, fmtUpdated } from '../lib/usePoll'
 import { useUrlFilters } from '../lib/useUrlFilters'
 import { T } from '../tokens'
-import { fmtNum, fmtPct } from '../lib/format'
+import { fmtNum, fmtPct, fmtDate } from '../lib/format'
 import { api, type MetricsFilters } from '../lib/api'
 import KPICard from '../components/KPICard'
 import SectionHeader from '../components/SectionHeader'
@@ -19,6 +19,8 @@ import type {
   ProcessResourcesByAttemptResponse,
   ProcessFailureSignaturesResponse,
   ProcessTimelineResponse,
+  TasksResponse,
+  TaskRow,
   ProcessFailuresRow,
   RetryByAttemptRow,
   RetryByProcessRow,
@@ -424,13 +426,160 @@ function TimelineTab({ data, bucket, onBucket }: {
   )
 }
 
-type Tab = 'failures' | 'retries' | 'resources' | 'signatures' | 'timeline'
+function StatusBadge({ status }: { status: string }) {
+  const color = status === 'COMPLETED' ? T.green : status === 'FAILED' ? T.red : T.amber
+  return (
+    <span style={{
+      fontSize: 10, fontWeight: 700, fontFamily: 'DM Mono, monospace',
+      color, border: `1px solid ${color}`, borderRadius: 3, padding: '1px 5px',
+    }}>{status}</span>
+  )
+}
+
+function fmtDuration(ms: number | null): string {
+  if (ms == null) return '—'
+  if (ms < 1000) return `${Math.round(ms)}ms`
+  if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`
+  if (ms < 3600000) return `${Math.floor(ms / 60000)}m ${Math.round((ms % 60000) / 1000)}s`
+  return `${Math.floor(ms / 3600000)}h ${Math.floor((ms % 3600000) / 60000)}m`
+}
+
+function TasksTab({ filters }: { filters: MetricsFilters }) {
+  const PAGE_SIZE = 50
+  const [processFilter, setProcessFilter] = useState('')
+  const [statusFilter,  setStatusFilter]  = useState<'' | 'COMPLETED' | 'FAILED'>('')
+  const [page, setPage] = useState(0)
+  const [data, setData] = useState<TasksResponse | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    setPage(0)
+  }, [filters, processFilter, statusFilter])
+
+  useEffect(() => {
+    setLoading(true)
+    setData(null)
+    api.metrics.tasks(filters, {
+      process: processFilter || undefined,
+      status:  statusFilter  || undefined,
+      limit:   PAGE_SIZE,
+      offset:  page * PAGE_SIZE,
+    })
+      .then(setData)
+      .catch(console.error)
+      .finally(() => setLoading(false))
+  }, [filters, processFilter, statusFilter, page])
+
+  const totalPages = data ? Math.ceil(data.total / PAGE_SIZE) : 0
+
+  return (
+    <Panel>
+      <SectionHeader
+        title="Task Browser"
+        sub="Individual process_completed events — click a row to expand full trace details"
+      />
+      <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+        <input
+          value={processFilter}
+          onChange={e => setProcessFilter(e.target.value)}
+          placeholder="Filter by process name…"
+          style={{
+            background: T.elevated, border: `1px solid ${T.border}`, color: T.text,
+            borderRadius: 6, padding: '5px 10px', fontSize: 12,
+            fontFamily: 'DM Mono, monospace', width: 240,
+          }}
+        />
+        {(['', 'COMPLETED', 'FAILED'] as const).map(s => (
+          <button key={s} onClick={() => setStatusFilter(s)} style={{
+            background: statusFilter === s ? T.accentDim : T.elevated,
+            border: `1px solid ${statusFilter === s ? T.accent : T.border}`,
+            color: statusFilter === s ? T.accent : T.muted,
+            borderRadius: 20, padding: '4px 12px', fontSize: 11,
+            fontWeight: 600, cursor: 'pointer', fontFamily: 'DM Sans, sans-serif',
+          }}>
+            {s === '' ? 'All' : s === 'COMPLETED' ? 'Completed' : 'Failed'}
+          </button>
+        ))}
+        {data && (
+          <span style={{ fontSize: 11, color: T.muted, marginLeft: 'auto' }}>
+            {fmtNum(data.total)} tasks
+          </span>
+        )}
+      </div>
+
+      {loading
+        ? <div style={{ color: T.muted, fontSize: 14, padding: '24px 0' }}>Loading…</div>
+        : !data || data.rows.length === 0
+          ? <div style={{ color: T.muted, fontSize: 13, padding: '16px 0' }}>No tasks found.</div>
+          : (
+            <>
+              <div style={{ overflowX: 'auto' }}>
+                <DataTable<TaskRow>
+                  columns={[
+                    { key: 'utc_time', label: 'Time',
+                      render: v => <span style={{ fontSize: 11, color: T.muted }}>{fmtDate(v as string)}</span> },
+                    { key: 'process', label: 'Process',
+                      render: v => <span style={{ fontFamily: 'DM Mono, monospace', fontSize: 11 }}>{v as string}</span> },
+                    { key: 'status', label: 'Status',
+                      render: v => <StatusBadge status={v as string} /> },
+                    { key: 'attempt', label: 'Att.', align: 'right', mono: true,
+                      render: v => (v as number) > 1
+                        ? <span style={{ color: T.amber }}>{v as number}</span>
+                        : <span style={{ color: T.muted }}>{v as number}</span> },
+                    { key: 'exit_code', label: 'Exit', align: 'right', mono: true,
+                      render: v => {
+                        if (v == null || v === '') return <span style={{ color: T.muted }}>—</span>
+                        const isFailure = v !== '0'
+                        return <span style={{ color: isFailure ? T.red : T.muted }}>{v as string}</span>
+                      }},
+                    { key: 'error_action', label: 'NF Action',
+                      render: v => <ErrorActionBadge action={v as string | null} /> },
+                    { key: 'sample_id', label: 'Sample',
+                      render: v => <span style={{ fontFamily: 'DM Mono, monospace', fontSize: 11, color: T.muted }}>{v as string ?? '—'}</span> },
+                    { key: 'run_name', label: 'Run',
+                      render: v => <span style={{ fontFamily: 'DM Mono, monospace', fontSize: 10, color: T.muted, maxWidth: 140, overflow: 'hidden', textOverflow: 'ellipsis', display: 'block' }}>{v as string}</span> },
+                    { key: 'realtime_ms', label: 'Duration', align: 'right', mono: true,
+                      render: v => fmtDuration(v as number | null) },
+                    { key: 'pct_cpu', label: 'CPU%', align: 'right', mono: true,
+                      render: v => v != null ? `${(v as number).toFixed(0)}%` : '—' },
+                    { key: 'pct_mem', label: 'Mem%', align: 'right', mono: true,
+                      render: v => v != null ? `${(v as number).toFixed(1)}%` : '—' },
+                    { key: 'peak_rss_gb', label: 'Peak RSS', align: 'right', mono: true,
+                      render: v => v != null ? `${(v as number).toFixed(2)} GB` : '—' },
+                  ]}
+                  rows={data.rows}
+                />
+              </div>
+              {totalPages > 1 && (
+                <div style={{ display: 'flex', gap: 8, alignItems: 'center', justifyContent: 'flex-end', marginTop: 8 }}>
+                  <button onClick={() => setPage(p => Math.max(0, p - 1))} disabled={page === 0} style={{
+                    background: T.elevated, border: `1px solid ${T.border}`, color: page === 0 ? T.muted : T.text,
+                    borderRadius: 4, padding: '3px 10px', fontSize: 12, cursor: page === 0 ? 'default' : 'pointer',
+                  }}>← Prev</button>
+                  <span style={{ fontSize: 12, color: T.muted }}>
+                    Page {page + 1} of {totalPages}
+                  </span>
+                  <button onClick={() => setPage(p => Math.min(totalPages - 1, p + 1))} disabled={page >= totalPages - 1} style={{
+                    background: T.elevated, border: `1px solid ${T.border}`, color: page >= totalPages - 1 ? T.muted : T.text,
+                    borderRadius: 4, padding: '3px 10px', fontSize: 12, cursor: page >= totalPages - 1 ? 'default' : 'pointer',
+                  }}>Next →</button>
+                </div>
+              )}
+            </>
+          )
+      }
+    </Panel>
+  )
+}
+
+type Tab = 'failures' | 'retries' | 'resources' | 'signatures' | 'timeline' | 'tasks'
 const TABS: Array<{ id: Tab; label: string }> = [
   { id: 'failures',   label: 'Failures'   },
   { id: 'retries',    label: 'Retries'    },
   { id: 'resources',  label: 'Resources'  },
   { id: 'signatures', label: 'Signatures' },
   { id: 'timeline',   label: 'Timeline'   },
+  { id: 'tasks',      label: 'Tasks'      },
 ]
 
 export default function MetricsPage({ pollInterval = 30_000 }: { pollInterval?: number }) {
@@ -498,18 +647,20 @@ export default function MetricsPage({ pollInterval = 30_000 }: { pollInterval?: 
           }}>{t.label}</button>
         ))}
       </div>
-      {(tab !== 'timeline' && (!failures || !retries || !resources || !signatures)) ||
-       (tab === 'timeline' && !timeline)
-        ? <div style={{ color: T.muted, fontSize: 14, padding: '32px 0' }}>Loading…</div>
-        : (
-          <>
-            {tab === 'failures'   && <FailuresTab   data={failures!}   />}
-            {tab === 'retries'    && <RetriesTab    data={retries!}    />}
-            {tab === 'resources'  && <ResourcesTab  data={resources!} summary={summary} />}
-            {tab === 'signatures' && <SignaturesTab  data={signatures!} />}
-            {tab === 'timeline'   && <TimelineTab   data={timeline!}   bucket={bucket} onBucket={setBucket} />}
-          </>
-        )
+      {tab === 'tasks'
+        ? <TasksTab filters={filters} />
+        : (tab !== 'timeline' && (!failures || !retries || !resources || !signatures)) ||
+          (tab === 'timeline' && !timeline)
+          ? <div style={{ color: T.muted, fontSize: 14, padding: '32px 0' }}>Loading…</div>
+          : (
+            <>
+              {tab === 'failures'   && <FailuresTab   data={failures!}   />}
+              {tab === 'retries'    && <RetriesTab    data={retries!}    />}
+              {tab === 'resources'  && <ResourcesTab  data={resources!} summary={summary} />}
+              {tab === 'signatures' && <SignaturesTab  data={signatures!} />}
+              {tab === 'timeline'   && <TimelineTab   data={timeline!}   bucket={bucket} onBucket={setBucket} />}
+            </>
+          )
       }
     </PageWrap>
   )

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -251,6 +251,38 @@ export interface RequeueResult {
   requeued_runs: number
 }
 
+export interface TaskRow {
+  telemetry_id: number
+  run_name: string
+  run_id: string | null
+  sample_id: string | null
+  workflow_id: string | null
+  workflow_version: string | null
+  utc_time: string
+  process: string
+  name: string | null
+  status: string
+  attempt: number
+  exit_code: string | null
+  error_action: string | null
+  realtime_ms: number | null
+  requested_cpus: number | null
+  requested_memory_gb: number | null
+  pct_cpu: number | null
+  pct_mem: number | null
+  peak_rss_gb: number | null
+  read_gb: number | null
+  write_gb: number | null
+}
+
+export interface TasksResponse {
+  generated_at_utc: string
+  total: number
+  limit: number
+  offset: number
+  rows: TaskRow[]
+}
+
 export interface WorkflowJobSummary {
   workflow_pk: number
   workflow_id: string

--- a/src/nextflow_telemetry/models.py
+++ b/src/nextflow_telemetry/models.py
@@ -254,6 +254,40 @@ class ProcessTimelineResponse(BaseModel):
     rows: list[TimelineRow]
 
 
+class TaskRow(BaseModel):
+    """A single process_completed event with full trace fields, for the task browser."""
+    telemetry_id: int = Field(description="Primary key of the telemetry row.")
+    run_name: str
+    run_id: Optional[str] = Field(default=None)
+    sample_id: Optional[str] = Field(default=None)
+    workflow_id: Optional[str] = Field(default=None)
+    workflow_version: Optional[str] = Field(default=None)
+    utc_time: datetime.datetime = Field(description="Timestamp of the process_completed event.")
+    process: str = Field(description="Fully-qualified Nextflow process name.")
+    name: Optional[str] = Field(default=None, description="Human-readable task name including tag.")
+    status: str = Field(description="Task exit status: COMPLETED, FAILED, ABORTED, etc.")
+    attempt: int = Field(description="Nextflow attempt number (1 = first attempt).")
+    exit_code: Optional[str] = Field(default=None, description="Process exit code.")
+    error_action: Optional[str] = Field(default=None, description="Nextflow error action: RETRY, FINISH, or IGNORE.")
+    realtime_ms: Optional[float] = Field(default=None, description="Wall-clock time in milliseconds.")
+    requested_cpus: Optional[float] = Field(default=None)
+    requested_memory_gb: Optional[float] = Field(default=None)
+    pct_cpu: Optional[float] = Field(default=None, description="CPU utilisation as a percentage of requested CPUs.")
+    pct_mem: Optional[float] = Field(default=None, description="Memory utilisation as a percentage of requested memory.")
+    peak_rss_gb: Optional[float] = Field(default=None, description="Peak RSS in GB.")
+    read_gb: Optional[float] = Field(default=None, description="Bytes read from disk, in GB.")
+    write_gb: Optional[float] = Field(default=None, description="Bytes written to disk, in GB.")
+
+
+class TasksResponse(BaseModel):
+    """Response from GET /metrics/processes/tasks."""
+    generated_at_utc: datetime.datetime
+    total: int = Field(description="Total matching rows (before pagination).")
+    limit: int
+    offset: int
+    rows: list[TaskRow]
+
+
 # ---------------------------------------------------------------------------
 # Workflow job-summary model
 # ---------------------------------------------------------------------------

--- a/src/nextflow_telemetry/routers/process_metrics.py
+++ b/src/nextflow_telemetry/routers/process_metrics.py
@@ -203,6 +203,43 @@ def create_process_metrics_router(service: ProcessMetricsService) -> APIRouter:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     @router.get(
+        "/tasks",
+        response_model=models.TasksResponse,
+        summary="Individual task execution browser",
+        description=(
+            "Returns paginated rows of individual process_completed events with full trace "
+            "details: process name, status, attempt, exit code, error action, wall time, "
+            "and resource utilisation. Supports all standard filters plus per-process and "
+            "per-status filtering."
+        ),
+    )
+    async def process_tasks(
+        window_days: int | None = Query(default=None, ge=1, description=_WINDOW_DAYS_DESC),
+        window_hours: int | None = Query(default=None, ge=1, description=_WINDOW_HOURS_DESC),
+        since: dt.datetime | None = Query(default=None, description=_SINCE_DESC),
+        until: dt.datetime | None = Query(default=None, description=_UNTIL_DESC),
+        workflow_id: str | None = Query(default=None, description=_WORKFLOW_ID_DESC),
+        workflow_version: str | None = Query(default=None, description=_WORKFLOW_VERSION_DESC),
+        run_name: str | None = Query(default=None, description=_RUN_NAME_DESC),
+        sample_id: str | None = Query(default=None, description=_SAMPLE_ID_DESC),
+        process: str | None = Query(default=None, description="Filter to a specific process name."),
+        status: str | None = Query(default=None, description="Filter by task status: COMPLETED or FAILED."),
+        limit: int = Query(default=50, ge=1, le=500, description=_LIMIT_DESC),
+        offset: int = Query(default=0, ge=0, description="Pagination offset."),
+    ):
+        try:
+            return await service.tasks(
+                window_days=window_days, window_hours=window_hours,
+                since=since, until=until,
+                workflow_id=workflow_id, workflow_version=workflow_version,
+                run_name=run_name, sample_id=sample_id,
+                process=process, status=status,
+                limit=limit, offset=offset,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    @router.get(
         "/timeline",
         response_model=models.ProcessTimelineResponse,
         summary="Failure and success counts over time",

--- a/src/nextflow_telemetry/services/process_metrics.py
+++ b/src/nextflow_telemetry/services/process_metrics.py
@@ -683,3 +683,94 @@ class ProcessMetricsService:
             "total_queued": total_queued,
             "by_process": rows,
         }
+
+    async def tasks(
+        self,
+        *,
+        window_days: int | None = None,
+        window_hours: int | None = None,
+        since: dt.datetime | None = None,
+        until: dt.datetime | None = None,
+        workflow_id: str | None = None,
+        workflow_version: str | None = None,
+        run_name: str | None = None,
+        sample_id: str | None = None,
+        process: str | None = None,
+        status: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        """Individual process_completed rows for the task browser."""
+        if limit < 1:
+            raise ValueError("limit must be >= 1")
+        if offset < 0:
+            raise ValueError("offset must be >= 0")
+
+        fc, params = self._filter_clause(
+            window_days=window_days, window_hours=window_hours,
+            since=since, until=until,
+            workflow_id=workflow_id, workflow_version=workflow_version,
+            run_name=run_name, sample_id=sample_id,
+        )
+        params = {**params, "limit": limit, "offset": offset}
+
+        extra_clauses = ""
+        if process is not None:
+            extra_clauses += " and t.trace->>'process' = :process"
+            params["process"] = process
+        if status is not None:
+            extra_clauses += " and coalesce(t.trace->>'status','') = :status"
+            params["status"] = status
+
+        sql = text(
+            f"""
+            select
+              t.id                                                              as telemetry_id,
+              t.run_name,
+              t.run_id,
+              t.sample_id,
+              t.workflow_id,
+              t.workflow_version,
+              t.utc_time,
+              coalesce(t.trace->>'process','<null>')                           as process,
+              t.trace->>'name'                                                 as name,
+              coalesce(t.trace->>'status','')                                  as status,
+              coalesce(nullif(t.trace->>'attempt',''),'1')::int                as attempt,
+              nullif(t.trace->>'exit','')                                      as exit_code,
+              nullif(t.trace->>'error_action','')                              as error_action,
+              nullif(t.trace->>'realtime','')::double precision                as realtime_ms,
+              nullif(t.trace->>'cpus','')::double precision                    as requested_cpus,
+              nullif(t.trace->>'memory','')::double precision / 1073741824.0  as requested_memory_gb,
+              nullif(t.trace->>'%cpu','')::double precision                    as pct_cpu,
+              nullif(t.trace->>'%mem','')::double precision                    as pct_mem,
+              nullif(t.trace->>'peak_rss','')::double precision / 1073741824.0 as peak_rss_gb,
+              nullif(t.trace->>'rchar','')::double precision / 1073741824.0    as read_gb,
+              nullif(t.trace->>'wchar','')::double precision / 1073741824.0    as write_gb,
+              count(*) over ()                                                  as total_count
+            from telemetry t
+            where t.event = 'process_completed'
+              and t.trace is not null
+              {fc}
+              {extra_clauses}
+            order by t.utc_time desc
+            limit :limit offset :offset
+            """
+        )
+
+        async with self.engine.connect() as conn:
+            result = (await conn.execute(sql, params)).mappings().all()
+
+        total = result[0]["total_count"] if result else 0
+        rows = []
+        for row in result:
+            d = dict(row)
+            d.pop("total_count", None)
+            rows.append(d)
+
+        return {
+            "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+            "rows": rows,
+        }

--- a/tests/test_process_metrics_router.py
+++ b/tests/test_process_metrics_router.py
@@ -129,6 +129,39 @@ class FakeProcessMetricsService:
             ],
         }
 
+    async def tasks(self, *, limit=50, offset=0, **kwargs):
+        return {
+            "generated_at_utc": "2026-01-01T00:00:00Z",
+            "total": 1,
+            "limit": limit,
+            "offset": offset,
+            "rows": [
+                {
+                    "telemetry_id": 42,
+                    "run_name": "happy-goldfish",
+                    "run_id": "abc-123",
+                    "sample_id": "SRR001",
+                    "workflow_id": "cmgd",
+                    "workflow_version": "1.0.0",
+                    "utc_time": "2026-01-01T00:00:00Z",
+                    "process": "kneaddata",
+                    "name": "kneaddata (SRR001)",
+                    "status": "COMPLETED",
+                    "attempt": 1,
+                    "exit_code": "0",
+                    "error_action": None,
+                    "realtime_ms": 60000.0,
+                    "requested_cpus": 8.0,
+                    "requested_memory_gb": 32.0,
+                    "pct_cpu": 350.0,
+                    "pct_mem": 12.5,
+                    "peak_rss_gb": 4.0,
+                    "read_gb": 1.2,
+                    "write_gb": 0.8,
+                }
+            ],
+        }
+
 
 def _client() -> TestClient:
     app = FastAPI()
@@ -179,3 +212,19 @@ def test_failure_signatures_endpoint_returns_rows():
 
     assert response.status_code == 200
     assert response.json()["rows"][0]["exit_code"] == "1"
+
+
+def test_tasks_endpoint_returns_paginated_rows():
+    with _client() as client:
+        response = client.get("/metrics/processes/tasks", params={"limit": 50, "offset": 0})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 1
+    assert body["limit"] == 50
+    assert body["offset"] == 0
+    row = body["rows"][0]
+    assert row["process"] == "kneaddata"
+    assert row["status"] == "COMPLETED"
+    assert row["attempt"] == 1
+    assert row["peak_rss_gb"] == 4.0


### PR DESCRIPTION
## Summary

- **`GET /metrics/processes/tasks`**: New paginated endpoint returning individual `process_completed` events with full trace fields — exit code, error action (RETRY/FINISH/IGNORE), wall time, requested CPUs/memory, CPU%, memory%, peak RSS, disk I/O. Supports all standard window/workflow/run/sample filters plus per-process and per-status filtering.
- **Tasks tab in Metrics page**: Searchable, paginated table of individual task executions. Columns: time, process, status badge, attempt, exit code, NF Action badge (RETRY/TERMINATE/IGNORE), sample, run, duration, CPU%, mem%, peak RSS. Filtering by process name (text input) and status (All/Completed/Failed toggle).
- **`StatusBadge` component**: color-coded COMPLETED (green) / FAILED (red) badge.
- **`fmtDuration` helper**: formats milliseconds into human-readable `42s` / `3m 15s` / `1h 20m`.

## Test plan

- [ ] All 6 router unit tests pass (`uv run pytest tests/test_process_metrics_router.py`)
- [ ] TypeScript compiles clean
- [ ] Tasks tab shows in Process Metrics page
- [ ] Filter by process name narrows results
- [ ] Failed status filter shows only failures with red exit codes and NF Action badges
- [ ] Pagination works (prev/next, page count)
- [ ] Attempt > 1 shown in amber

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)