### PR TITLE
Issue #31: log capture — task_logs table, nf-client upload-logs, log viewer

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -10,6 +10,7 @@ import type {
   ProcessFailureSignaturesResponse,
   ProcessTimelineResponse,
   TasksResponse,
+  TaskLogsResponse,
   RunningProcessesResponse,
   DispatchBatchResponse,
   ReconcileResult,
@@ -91,6 +92,8 @@ export const api = {
     signatures: (f: MetricsFilters = {}) => get<ProcessFailureSignaturesResponse>(`/metrics/processes/failure-signatures${metricsParams(f)}`),
     timeline:   (f: MetricsFilters = {}, bucket: 'hour' | 'day' | 'week' = 'hour') =>
       get<ProcessTimelineResponse>(`/metrics/processes/timeline${metricsParams(f, { bucket })}`),
+    taskLogs: (runName: string, taskHash: string) =>
+      get<TaskLogsResponse>(`/task-logs/${encodeURIComponent(runName)}/${taskHash}`),
     tasks: (f: MetricsFilters = {}, extra: { process?: string; status?: string; limit?: number; offset?: number } = {}) => {
       const e: Record<string, string | number> = {}
       if (extra.process) e['process'] = extra.process

--- a/frontend/src/pages/MetricsPage.tsx
+++ b/frontend/src/pages/MetricsPage.tsx
@@ -21,6 +21,7 @@ import type {
   ProcessTimelineResponse,
   TasksResponse,
   TaskRow,
+  TaskLogsResponse,
   ProcessFailuresRow,
   RetryByAttemptRow,
   RetryByProcessRow,
@@ -444,6 +445,55 @@ function fmtDuration(ms: number | null): string {
   return `${Math.floor(ms / 3600000)}h ${Math.floor((ms % 3600000) / 60000)}m`
 }
 
+function TaskLogViewer({ runName, taskHash }: { runName: string; taskHash: string }) {
+  const [logs, setLogs] = useState<TaskLogsResponse | null>(null)
+  const [activeLog, setActiveLog] = useState<'command_sh' | 'command_err'>('command_err')
+
+  useEffect(() => {
+    api.metrics.taskLogs(runName, taskHash).then(setLogs).catch(console.error)
+  }, [runName, taskHash])
+
+  if (!logs) return <div style={{ color: T.muted, fontSize: 12, padding: 8 }}>Loading logs…</div>
+  if (logs.logs.length === 0) {
+    return (
+      <div style={{ color: T.muted, fontSize: 12, padding: '8px 0' }}>
+        No logs captured for this task. Run <code>nf-client upload-logs</code> after the pipeline completes.
+      </div>
+    )
+  }
+
+  const logTypes = logs.logs.map(l => l.log_type)
+  const current = logs.logs.find(l => l.log_type === activeLog) ?? logs.logs[0]
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <div style={{ display: 'flex', gap: 4 }}>
+        {(['command_err', 'command_sh'] as const).map(lt => (
+          logTypes.includes(lt) && (
+            <button key={lt} onClick={() => setActiveLog(lt)} style={{
+              background: activeLog === lt ? T.accentDim : T.elevated,
+              border: `1px solid ${activeLog === lt ? T.accent : T.border}`,
+              color: activeLog === lt ? T.accent : T.muted,
+              borderRadius: 4, padding: '2px 10px', fontSize: 11,
+              fontWeight: 600, cursor: 'pointer', fontFamily: 'DM Mono, monospace',
+            }}>{lt === 'command_err' ? '.command.err' : '.command.sh'}</button>
+          )
+        ))}
+      </div>
+      {current && (
+        <pre style={{
+          background: '#0a0f1a', border: `1px solid ${T.border}`, borderRadius: 6,
+          padding: 12, fontSize: 11, fontFamily: 'DM Mono, monospace', color: T.text,
+          maxHeight: 300, overflowY: 'auto', whiteSpace: 'pre-wrap', wordBreak: 'break-all',
+          margin: 0,
+        }}>
+          {current.content || '(empty)'}
+        </pre>
+      )}
+    </div>
+  )
+}
+
 function TasksTab({ filters }: { filters: MetricsFilters }) {
   const PAGE_SIZE = 50
   const [processFilter, setProcessFilter] = useState('')
@@ -451,14 +501,17 @@ function TasksTab({ filters }: { filters: MetricsFilters }) {
   const [page, setPage] = useState(0)
   const [data, setData] = useState<TasksResponse | null>(null)
   const [loading, setLoading] = useState(false)
+  const [expandedId, setExpandedId] = useState<number | null>(null)
 
   useEffect(() => {
     setPage(0)
+    setExpandedId(null)
   }, [filters, processFilter, statusFilter])
 
   useEffect(() => {
     setLoading(true)
     setData(null)
+    setExpandedId(null)
     api.metrics.tasks(filters, {
       process: processFilter || undefined,
       status:  statusFilter  || undefined,
@@ -472,11 +525,20 @@ function TasksTab({ filters }: { filters: MetricsFilters }) {
 
   const totalPages = data ? Math.ceil(data.total / PAGE_SIZE) : 0
 
+  const COL_STYLE: React.CSSProperties = {
+    padding: '7px 10px', fontSize: 12, borderBottom: `1px solid ${T.border}`,
+    verticalAlign: 'middle',
+  }
+  const TH_STYLE: React.CSSProperties = {
+    ...COL_STYLE, fontSize: 10, color: T.muted, fontWeight: 700,
+    letterSpacing: '0.06em', textTransform: 'uppercase', background: T.elevated,
+  }
+
   return (
     <Panel>
       <SectionHeader
         title="Task Browser"
-        sub="Individual process_completed events — click a row to expand full trace details"
+        sub="Individual process_completed events — click a row to view logs"
       />
       <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
         <input
@@ -514,41 +576,70 @@ function TasksTab({ filters }: { filters: MetricsFilters }) {
           : (
             <>
               <div style={{ overflowX: 'auto' }}>
-                <DataTable<TaskRow>
-                  columns={[
-                    { key: 'utc_time', label: 'Time',
-                      render: v => <span style={{ fontSize: 11, color: T.muted }}>{fmtDate(v as string)}</span> },
-                    { key: 'process', label: 'Process',
-                      render: v => <span style={{ fontFamily: 'DM Mono, monospace', fontSize: 11 }}>{v as string}</span> },
-                    { key: 'status', label: 'Status',
-                      render: v => <StatusBadge status={v as string} /> },
-                    { key: 'attempt', label: 'Att.', align: 'right', mono: true,
-                      render: v => (v as number) > 1
-                        ? <span style={{ color: T.amber }}>{v as number}</span>
-                        : <span style={{ color: T.muted }}>{v as number}</span> },
-                    { key: 'exit_code', label: 'Exit', align: 'right', mono: true,
-                      render: v => {
-                        if (v == null || v === '') return <span style={{ color: T.muted }}>—</span>
-                        const isFailure = v !== '0'
-                        return <span style={{ color: isFailure ? T.red : T.muted }}>{v as string}</span>
-                      }},
-                    { key: 'error_action', label: 'NF Action',
-                      render: v => <ErrorActionBadge action={v as string | null} /> },
-                    { key: 'sample_id', label: 'Sample',
-                      render: v => <span style={{ fontFamily: 'DM Mono, monospace', fontSize: 11, color: T.muted }}>{v as string ?? '—'}</span> },
-                    { key: 'run_name', label: 'Run',
-                      render: v => <span style={{ fontFamily: 'DM Mono, monospace', fontSize: 10, color: T.muted, maxWidth: 140, overflow: 'hidden', textOverflow: 'ellipsis', display: 'block' }}>{v as string}</span> },
-                    { key: 'realtime_ms', label: 'Duration', align: 'right', mono: true,
-                      render: v => fmtDuration(v as number | null) },
-                    { key: 'pct_cpu', label: 'CPU%', align: 'right', mono: true,
-                      render: v => v != null ? `${(v as number).toFixed(0)}%` : '—' },
-                    { key: 'pct_mem', label: 'Mem%', align: 'right', mono: true,
-                      render: v => v != null ? `${(v as number).toFixed(1)}%` : '—' },
-                    { key: 'peak_rss_gb', label: 'Peak RSS', align: 'right', mono: true,
-                      render: v => v != null ? `${(v as number).toFixed(2)} GB` : '—' },
-                  ]}
-                  rows={data.rows}
-                />
+                <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+                  <thead>
+                    <tr>
+                      {['Time', 'Process', 'Status', 'Att.', 'Exit', 'NF Action', 'Sample', 'Run', 'Duration', 'CPU%', 'Mem%', 'Peak RSS'].map(h => (
+                        <th key={h} style={{ ...TH_STYLE, textAlign: ['Att.','Exit','Duration','CPU%','Mem%','Peak RSS'].includes(h) ? 'right' : 'left' }}>{h}</th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.rows.map(row => (
+                      <>
+                        <tr
+                          key={row.telemetry_id}
+                          onClick={() => setExpandedId(id => id === row.telemetry_id ? null : row.telemetry_id)}
+                          style={{ cursor: 'pointer', background: expandedId === row.telemetry_id ? T.elevated : 'transparent' }}
+                        >
+                          <td style={COL_STYLE}><span style={{ fontSize: 11, color: T.muted }}>{fmtDate(row.utc_time)}</span></td>
+                          <td style={COL_STYLE}><span style={{ fontFamily: 'DM Mono, monospace', fontSize: 11 }}>{row.process}</span></td>
+                          <td style={COL_STYLE}><StatusBadge status={row.status} /></td>
+                          <td style={{ ...COL_STYLE, textAlign: 'right' }}>
+                            <span style={{ color: row.attempt > 1 ? T.amber : T.muted, fontFamily: 'DM Mono, monospace' }}>{row.attempt}</span>
+                          </td>
+                          <td style={{ ...COL_STYLE, textAlign: 'right' }}>
+                            {row.exit_code == null || row.exit_code === ''
+                              ? <span style={{ color: T.muted }}>—</span>
+                              : <span style={{ color: row.exit_code !== '0' ? T.red : T.muted, fontFamily: 'DM Mono, monospace' }}>{row.exit_code}</span>}
+                          </td>
+                          <td style={COL_STYLE}><ErrorActionBadge action={row.error_action} /></td>
+                          <td style={COL_STYLE}><span style={{ fontFamily: 'DM Mono, monospace', fontSize: 11, color: T.muted }}>{row.sample_id ?? '—'}</span></td>
+                          <td style={COL_STYLE}><span style={{ fontFamily: 'DM Mono, monospace', fontSize: 10, color: T.muted, maxWidth: 140, overflow: 'hidden', textOverflow: 'ellipsis', display: 'block' }}>{row.run_name}</span></td>
+                          <td style={{ ...COL_STYLE, textAlign: 'right', fontFamily: 'DM Mono, monospace', fontSize: 11 }}>{fmtDuration(row.realtime_ms)}</td>
+                          <td style={{ ...COL_STYLE, textAlign: 'right', fontFamily: 'DM Mono, monospace', fontSize: 11 }}>{row.pct_cpu != null ? `${row.pct_cpu.toFixed(0)}%` : '—'}</td>
+                          <td style={{ ...COL_STYLE, textAlign: 'right', fontFamily: 'DM Mono, monospace', fontSize: 11 }}>{row.pct_mem != null ? `${row.pct_mem.toFixed(1)}%` : '—'}</td>
+                          <td style={{ ...COL_STYLE, textAlign: 'right', fontFamily: 'DM Mono, monospace', fontSize: 11 }}>{row.peak_rss_gb != null ? `${row.peak_rss_gb.toFixed(2)} GB` : '—'}</td>
+                        </tr>
+                        {expandedId === row.telemetry_id && (
+                          <tr key={`${row.telemetry_id}-detail`}>
+                            <td colSpan={12} style={{ padding: '8px 16px 16px 16px', background: T.elevated, borderBottom: `1px solid ${T.border}` }}>
+                              <div style={{ display: 'flex', gap: 24, flexWrap: 'wrap', marginBottom: 10 }}>
+                                {[
+                                  ['Task hash', row.task_hash ?? '—'],
+                                  ['Name', row.name ?? '—'],
+                                  ['Read', row.read_gb != null ? `${row.read_gb.toFixed(2)} GB` : '—'],
+                                  ['Write', row.write_gb != null ? `${row.write_gb.toFixed(2)} GB` : '—'],
+                                  ['Requested CPUs', row.requested_cpus != null ? String(row.requested_cpus) : '—'],
+                                  ['Requested mem', row.requested_memory_gb != null ? `${row.requested_memory_gb.toFixed(1)} GB` : '—'],
+                                ].map(([k, v]) => (
+                                  <div key={k}>
+                                    <div style={{ fontSize: 10, color: T.muted, fontWeight: 700, letterSpacing: '0.05em', textTransform: 'uppercase', marginBottom: 2 }}>{k}</div>
+                                    <div style={{ fontSize: 12, fontFamily: 'DM Mono, monospace', color: T.text }}>{v}</div>
+                                  </div>
+                                ))}
+                              </div>
+                              {row.task_hash
+                                ? <TaskLogViewer runName={row.run_name} taskHash={row.task_hash} />
+                                : <div style={{ color: T.muted, fontSize: 12 }}>No task hash available — logs cannot be retrieved.</div>
+                              }
+                            </td>
+                          </tr>
+                        )}
+                      </>
+                    ))}
+                  </tbody>
+                </table>
               </div>
               {totalPages > 1 && (
                 <div style={{ display: 'flex', gap: 8, alignItems: 'center', justifyContent: 'flex-end', marginTop: 8 }}>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -251,6 +251,21 @@ export interface RequeueResult {
   requeued_runs: number
 }
 
+export interface TaskLogEntry {
+  id: number
+  run_name: string
+  task_hash: string
+  log_type: string
+  content: string
+  uploaded_at: string
+}
+
+export interface TaskLogsResponse {
+  run_name: string
+  task_hash: string
+  logs: TaskLogEntry[]
+}
+
 export interface TaskRow {
   telemetry_id: number
   run_name: string
@@ -263,6 +278,7 @@ export interface TaskRow {
   name: string | null
   status: string
   attempt: number
+  task_hash: string | null
   exit_code: string | null
   error_action: string | null
   realtime_ms: number | null

--- a/packages/nf_client/src/nf_client/cli.py
+++ b/packages/nf_client/src/nf_client/cli.py
@@ -5,9 +5,10 @@ Looping, resource-awareness, and scheduling are left to the operator
 (cron, Airflow, site-specific daemon).
 
 Usage:
-    nf-client submit --config client-hpc.yaml [--dry-run]
-    nf-client fetch  --config client-hpc.yaml
-    nf-client daemon --config client-local.yaml [--batch-size 10]
+    nf-client submit      --config client-hpc.yaml [--dry-run]
+    nf-client fetch       --config client-hpc.yaml
+    nf-client daemon      --config client-local.yaml [--batch-size 10]
+    nf-client upload-logs --config client-hpc.yaml --run-name <name> --work-dir /path/to/work
 """
 from __future__ import annotations
 
@@ -248,3 +249,94 @@ def daemon(
                 typer.echo(f"  WARN: failed to report submitted: {e}", err=True)
 
     typer.echo(f"\nDaemon finished after {run_number} run(s).")
+
+
+@app.command(name="upload-logs")
+def upload_logs(
+    config: Path = config_option,
+    run_name: str = typer.Option(..., "--run-name", "-r", help="Nextflow run name (value passed to -name)."),
+    work_dir: Path = typer.Option(..., "--work-dir", "-w", help="Nextflow work directory (contains task subdirs)."),
+    max_size_kb: int = typer.Option(512, "--max-size-kb", help="Skip files larger than this many KB (default 512)."),
+    dry_run: bool = dry_run_option,
+) -> None:
+    """Walk a Nextflow work directory and upload .command.sh and .command.err for each task.
+
+    The Nextflow work directory structure is:
+
+        work/<2-char-prefix>/<rest-of-hash>/
+            .command.sh
+            .command.err
+
+    This command reconstructs the task_hash as "<prefix>/<rest>" and uploads both
+    files to the server as log_type "command_sh" and "command_err" respectively.
+
+    Intended to be called after a Nextflow run completes, typically from the SLURM
+    job script or a Nextflow afterScript hook. Idempotent — safe to re-run.
+    """
+    _LOG_FILES = {
+        ".command.sh":  "command_sh",
+        ".command.err": "command_err",
+    }
+    max_bytes = max_size_kb * 1024
+
+    if not work_dir.is_dir():
+        typer.echo(f"ERROR: work-dir does not exist: {work_dir}", err=True)
+        raise typer.Exit(1)
+
+    # Discover all task directories: work/<2chars>/<rest>/
+    tasks: list[tuple[str, Path]] = []
+    for prefix_dir in sorted(work_dir.iterdir()):
+        if not prefix_dir.is_dir() or len(prefix_dir.name) != 2:
+            continue
+        for task_dir in sorted(prefix_dir.iterdir()):
+            if not task_dir.is_dir():
+                continue
+            task_hash = f"{prefix_dir.name}/{task_dir.name}"
+            tasks.append((task_hash, task_dir))
+
+    if not tasks:
+        typer.echo(f"No task directories found in {work_dir}")
+        return
+
+    typer.echo(f"Found {len(tasks)} task directories in {work_dir}")
+
+    if dry_run:
+        for task_hash, task_dir in tasks:
+            for fname in _LOG_FILES:
+                fpath = task_dir / fname
+                if fpath.exists():
+                    size_kb = fpath.stat().st_size // 1024
+                    typer.echo(f"  would upload {task_hash}/{fname} ({size_kb} KB)")
+        return
+
+    cfg = ClientConfig.from_yaml(config)
+    uploaded = skipped = errors = 0
+
+    async def _upload_all() -> None:
+        nonlocal uploaded, skipped, errors
+        async with JobClient(cfg) as client:
+            for task_hash, task_dir in tasks:
+                for fname, log_type in _LOG_FILES.items():
+                    fpath = task_dir / fname
+                    if not fpath.exists():
+                        continue
+                    size = fpath.stat().st_size
+                    if size > max_bytes:
+                        typer.echo(f"  SKIP {task_hash}/{fname} ({size // 1024} KB > {max_size_kb} KB limit)")
+                        skipped += 1
+                        continue
+                    content = fpath.read_text(errors="replace")
+                    try:
+                        await client.upload_task_log(
+                            run_name=run_name,
+                            task_hash=task_hash,
+                            log_type=log_type,
+                            content=content,
+                        )
+                        uploaded += 1
+                    except Exception as exc:
+                        typer.echo(f"  ERROR {task_hash}/{fname}: {exc}", err=True)
+                        errors += 1
+
+    asyncio.run(_upload_all())
+    typer.echo(f"Done — uploaded: {uploaded}, skipped (too large): {skipped}, errors: {errors}")

--- a/packages/nf_client/src/nf_client/client.py
+++ b/packages/nf_client/src/nf_client/client.py
@@ -70,6 +70,28 @@ class JobClient:
         response.raise_for_status()
         return DispatchBatchResponse.model_validate(response.json())
 
+    async def upload_task_log(
+        self,
+        *,
+        run_name: str,
+        task_hash: str,
+        log_type: str,
+        content: str,
+    ) -> None:
+        """Upload a single task log file (.command.sh or .command.err) to the server.
+
+        Idempotent: re-uploading the same (run_name, task_hash, log_type) replaces
+        the previous content.
+        """
+        payload = {
+            "run_name": run_name,
+            "task_hash": task_hash,
+            "log_type": log_type,
+            "content": content,
+        }
+        response = await self._client.post("/task-logs", json=payload)
+        response.raise_for_status()
+
     async def report_submitted(
         self,
         run_name: str,

--- a/src/nextflow_telemetry/db.py
+++ b/src/nextflow_telemetry/db.py
@@ -131,6 +131,22 @@ workflow_runs_tbl = Table(
 )
 
 # ---------------------------------------------------------------------------
+# Task logs — .command.sh and .command.err uploaded by nf-client post-run
+# ---------------------------------------------------------------------------
+task_logs_tbl = Table(
+    "task_logs",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("run_name", String, nullable=False),
+    Column("task_hash", String, nullable=False),   # e.g. "ab/1234ef5678..."
+    Column("log_type", String, nullable=False),    # "command_sh" or "command_err"
+    Column("content", Text, nullable=False),
+    Column("uploaded_at", DateTime(timezone=True), nullable=False),
+    UniqueConstraint("run_name", "task_hash", "log_type", name="uq_task_log"),
+    Index("ix_task_logs_run_hash", "run_name", "task_hash"),
+)
+
+# ---------------------------------------------------------------------------
 # Dead letter queue — populated when a run completes without MARK_COMPLETE
 # ---------------------------------------------------------------------------
 dead_letter_tbl = Table(

--- a/src/nextflow_telemetry/main.py
+++ b/src/nextflow_telemetry/main.py
@@ -12,6 +12,7 @@ from .routers.admin import create_admin_router
 from .routers.dispatch import create_dispatch_router
 from .routers.process_metrics import create_process_metrics_router
 from .routers.samples import create_samples_router
+from .routers.task_logs import create_task_logs_router
 from .routers.workflows import create_workflows_router
 from .services.process_metrics import ProcessMetricsService
 from .services.telemetry import TelemetryService
@@ -55,6 +56,7 @@ app.include_router(create_dispatch_router(engine))
 app.include_router(create_samples_router(engine))
 app.include_router(create_workflows_router(engine))
 app.include_router(create_admin_router(engine))
+app.include_router(create_task_logs_router(engine))
 
 
 @app.get(

--- a/src/nextflow_telemetry/migrations/versions/20260504_e5f2a9b1c8d3_task_logs.py
+++ b/src/nextflow_telemetry/migrations/versions/20260504_e5f2a9b1c8d3_task_logs.py
@@ -1,0 +1,41 @@
+"""task_logs
+
+Revision ID: e5f2a9b1c8d3
+Revises: d4e1f8c2b7a5
+Create Date: 2026-05-04
+
+Adds the task_logs table for storing .command.sh and .command.err content
+uploaded by nf-client after each Nextflow task completes.
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e5f2a9b1c8d3"
+down_revision: Union[str, None] = "d4e1f8c2b7a5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "task_logs",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("run_name", sa.String(), nullable=False),
+        sa.Column("task_hash", sa.String(), nullable=False),
+        sa.Column("log_type", sa.String(), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("uploaded_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("run_name", "task_hash", "log_type", name="uq_task_log"),
+    )
+    op.create_index("ix_task_logs_run_hash", "task_logs", ["run_name", "task_hash"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_task_logs_run_hash", table_name="task_logs")
+    op.drop_table("task_logs")

--- a/src/nextflow_telemetry/models.py
+++ b/src/nextflow_telemetry/models.py
@@ -267,6 +267,7 @@ class TaskRow(BaseModel):
     name: Optional[str] = Field(default=None, description="Human-readable task name including tag.")
     status: str = Field(description="Task exit status: COMPLETED, FAILED, ABORTED, etc.")
     attempt: int = Field(description="Nextflow attempt number (1 = first attempt).")
+    task_hash: Optional[str] = Field(default=None, description="Nextflow work directory hash, e.g. 'ab/1234ef'. Used to retrieve task logs.")
     exit_code: Optional[str] = Field(default=None, description="Process exit code.")
     error_action: Optional[str] = Field(default=None, description="Nextflow error action: RETRY, FINISH, or IGNORE.")
     realtime_ms: Optional[float] = Field(default=None, description="Wall-clock time in milliseconds.")
@@ -306,6 +307,35 @@ class RunningProcessesResponse(BaseModel):
     total_running: int = Field(description="Total tasks actively executing across all runs.")
     total_queued: int = Field(description="Total tasks submitted to SLURM but not yet started.")
     by_process: list[RunningProcessRow]
+
+
+# ---------------------------------------------------------------------------
+# Task log upload / retrieval models
+# ---------------------------------------------------------------------------
+
+class TaskLogUploadRequest(BaseModel):
+    """Body for POST /task-logs — upload a single task log file."""
+    run_name: str = Field(description="Nextflow run name (must match an existing workflow_run).")
+    task_hash: str = Field(description="Nextflow work directory hash, e.g. 'ab/1234ef'.")
+    log_type: str = Field(description="Log file type: 'command_sh' or 'command_err'.")
+    content: str = Field(description="Raw text content of the log file (max 1 MB).")
+
+
+class TaskLogEntry(BaseModel):
+    """A single uploaded task log."""
+    id: int
+    run_name: str
+    task_hash: str
+    log_type: str
+    content: str
+    uploaded_at: datetime.datetime
+
+
+class TaskLogsResponse(BaseModel):
+    """Response from GET /task-logs/{run_name}/{task_hash}."""
+    run_name: str
+    task_hash: str
+    logs: list[TaskLogEntry]
 
 
 class WorkflowJobSummary(BaseModel):

--- a/src/nextflow_telemetry/routers/task_logs.py
+++ b/src/nextflow_telemetry/routers/task_logs.py
@@ -1,0 +1,97 @@
+"""Task log upload and retrieval — .command.sh and .command.err from Nextflow work dirs."""
+from __future__ import annotations
+
+import datetime
+from typing import Annotated
+
+from fastapi import APIRouter, HTTPException, Path
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from .. import models
+from ..db import task_logs_tbl
+
+_MAX_CONTENT_BYTES = 1 * 1024 * 1024  # 1 MB per log file
+_VALID_LOG_TYPES = {"command_sh", "command_err"}
+
+
+def create_task_logs_router(engine: AsyncEngine) -> APIRouter:
+    router = APIRouter(prefix="/task-logs", tags=["task-logs"])
+
+    @router.post(
+        "",
+        response_model=models.TaskLogEntry,
+        status_code=201,
+        summary="Upload a task log file",
+        description=(
+            "Upload the content of a .command.sh or .command.err file for a specific "
+            "Nextflow task. Identified by (run_name, task_hash, log_type). "
+            "Idempotent: re-uploading the same (run_name, task_hash, log_type) "
+            "replaces the previous content."
+        ),
+    )
+    async def upload_task_log(body: models.TaskLogUploadRequest) -> models.TaskLogEntry:
+        if body.log_type not in _VALID_LOG_TYPES:
+            raise HTTPException(
+                status_code=422,
+                detail=f"log_type must be one of: {sorted(_VALID_LOG_TYPES)}",
+            )
+        if len(body.content.encode()) > _MAX_CONTENT_BYTES:
+            raise HTTPException(status_code=413, detail="Content exceeds 1 MB limit.")
+
+        now = datetime.datetime.now(datetime.timezone.utc)
+
+        upsert_sql = text(
+            """
+            insert into task_logs (run_name, task_hash, log_type, content, uploaded_at)
+            values (:run_name, :task_hash, :log_type, :content, :uploaded_at)
+            on conflict on constraint uq_task_log
+            do update set content = excluded.content, uploaded_at = excluded.uploaded_at
+            returning id, run_name, task_hash, log_type, content, uploaded_at
+            """
+        )
+        async with engine.begin() as conn:
+            row = (await conn.execute(upsert_sql, {
+                "run_name": body.run_name,
+                "task_hash": body.task_hash,
+                "log_type": body.log_type,
+                "content": body.content,
+                "uploaded_at": now,
+            })).mappings().one()
+
+        return models.TaskLogEntry(**dict(row))
+
+    @router.get(
+        "/{run_name}/{task_hash:path}",
+        response_model=models.TaskLogsResponse,
+        summary="Retrieve task logs",
+        description=(
+            "Returns all uploaded log files (command_sh and command_err) for a specific "
+            "task, identified by run_name and the Nextflow work dir hash (e.g. 'ab/1234ef')."
+        ),
+    )
+    async def get_task_logs(
+        run_name: Annotated[str, Path(description="Nextflow run name.")],
+        task_hash: Annotated[str, Path(description="Nextflow work dir hash, e.g. 'ab/1234ef'.")],
+    ) -> models.TaskLogsResponse:
+        select_sql = text(
+            """
+            select id, run_name, task_hash, log_type, content, uploaded_at
+            from task_logs
+            where run_name = :run_name and task_hash = :task_hash
+            order by log_type
+            """
+        )
+        async with engine.connect() as conn:
+            rows = (await conn.execute(select_sql, {
+                "run_name": run_name,
+                "task_hash": task_hash,
+            })).mappings().all()
+
+        return models.TaskLogsResponse(
+            run_name=run_name,
+            task_hash=task_hash,
+            logs=[models.TaskLogEntry(**dict(r)) for r in rows],
+        )
+
+    return router

--- a/src/nextflow_telemetry/services/process_metrics.py
+++ b/src/nextflow_telemetry/services/process_metrics.py
@@ -736,6 +736,7 @@ class ProcessMetricsService:
               t.trace->>'name'                                                 as name,
               coalesce(t.trace->>'status','')                                  as status,
               coalesce(nullif(t.trace->>'attempt',''),'1')::int                as attempt,
+              nullif(t.trace->>'hash','')                                      as task_hash,
               nullif(t.trace->>'exit','')                                      as exit_code,
               nullif(t.trace->>'error_action','')                              as error_action,
               nullif(t.trace->>'realtime','')::double precision                as realtime_ms,

--- a/tests/test_task_logs_router.py
+++ b/tests/test_task_logs_router.py
@@ -1,0 +1,110 @@
+"""Unit tests for the task_logs router using TestClient with a mock engine."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from nextflow_telemetry.routers.task_logs import create_task_logs_router
+
+
+def _make_mock_engine() -> MagicMock:
+    """Return an engine mock that supports async context managers."""
+    conn = AsyncMock()
+    conn.__aenter__ = AsyncMock(return_value=conn)
+    conn.__aexit__ = AsyncMock(return_value=False)
+
+    engine = MagicMock()
+    engine.begin = MagicMock(return_value=conn)
+    engine.connect = MagicMock(return_value=conn)
+    return engine, conn
+
+
+def _client_with_mock_row(row_dict: dict) -> TestClient:
+    engine, conn = _make_mock_engine()
+
+    mapping = MagicMock()
+    mapping.one = MagicMock(return_value=row_dict)
+    mapping.all = MagicMock(return_value=[row_dict])
+
+    result = MagicMock()
+    result.mappings = MagicMock(return_value=mapping)
+    conn.execute = AsyncMock(return_value=result)
+
+    app = FastAPI()
+    app.include_router(create_task_logs_router(engine))
+    return TestClient(app)
+
+
+_FAKE_ROW = {
+    "id": 1,
+    "run_name": "happy-goldfish",
+    "task_hash": "ab/1234ef",
+    "log_type": "command_sh",
+    "content": "#!/bin/bash\necho hello",
+    "uploaded_at": "2026-01-01T00:00:00+00:00",
+}
+
+
+def test_upload_task_log_returns_201():
+    client = _client_with_mock_row(_FAKE_ROW)
+    r = client.post("/task-logs", json={
+        "run_name": "happy-goldfish",
+        "task_hash": "ab/1234ef",
+        "log_type": "command_sh",
+        "content": "#!/bin/bash\necho hello",
+    })
+    assert r.status_code == 201
+    body = r.json()
+    assert body["log_type"] == "command_sh"
+    assert body["task_hash"] == "ab/1234ef"
+
+
+def test_invalid_log_type_is_rejected():
+    engine, _ = _make_mock_engine()
+    app = FastAPI()
+    app.include_router(create_task_logs_router(engine))
+    client = TestClient(app)
+    r = client.post("/task-logs", json={
+        "run_name": "x",
+        "task_hash": "ab/cd",
+        "log_type": "bad_type",
+        "content": "data",
+    })
+    assert r.status_code == 422
+
+
+def test_content_too_large_is_rejected():
+    engine, _ = _make_mock_engine()
+    app = FastAPI()
+    app.include_router(create_task_logs_router(engine))
+    client = TestClient(app)
+    r = client.post("/task-logs", json={
+        "run_name": "x",
+        "task_hash": "ab/cd",
+        "log_type": "command_sh",
+        "content": "x" * (1024 * 1024 + 1),
+    })
+    assert r.status_code == 413
+
+
+def test_retrieve_task_logs_returns_response():
+    engine, conn = _make_mock_engine()
+
+    mapping = MagicMock()
+    mapping.all = MagicMock(return_value=[_FAKE_ROW])
+    result = MagicMock()
+    result.mappings = MagicMock(return_value=mapping)
+    conn.execute = AsyncMock(return_value=result)
+
+    app = FastAPI()
+    app.include_router(create_task_logs_router(engine))
+    client = TestClient(app)
+    r = client.get("/task-logs/happy-goldfish/ab/1234ef")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["run_name"] == "happy-goldfish"
+    assert data["task_hash"] == "ab/1234ef"
+    assert len(data["logs"]) == 1
+    assert data["logs"][0]["log_type"] == "command_sh"


### PR DESCRIPTION
## Summary

End-to-end task log capture: nf-client uploads `.command.sh`/`.command.err` after each Nextflow run; server stores them; Tasks tab shows them inline when a row is expanded.

### Backend
- **`task_logs` table** (`db.py` + migration): stores `(run_name, task_hash, log_type, content)` with a unique constraint; upsert semantics so re-uploads are idempotent.
- **`POST /task-logs`**: validates `log_type` (command_sh/command_err), enforces 1 MB content limit, returns the stored entry.
- **`GET /task-logs/{run_name}/{task_hash}`**: returns all logs for a task. The `task_hash` path segment supports slashes (e.g. `ab/1234ef`) via FastAPI's `{path}` converter.

### nf-client
- **`upload_task_log()` method** in `JobClient` — posts a single log entry.
- **`nf-client upload-logs`** CLI command: walks a Nextflow work directory (`<2-char-prefix>/<rest>/`), uploads `.command.sh` and `.command.err` for every task. Respects `--max-size-kb` (default 512), supports `--dry-run`.

**Usage after a run:**
```bash
nf-client upload-logs \
  --config client.yaml \
  --run-name r0123456-... \
  --work-dir /scratch/nextflow-runs/work
```

Can be added to the SLURM job script as a post-pipeline step.

### Frontend
- **Tasks tab**: replaced `DataTable` with a custom expandable table. Clicking any row reveals: task hash, human-readable name, read/write GB, requested CPUs/memory, and a **log viewer** panel.
- **`TaskLogViewer`**: fetches `GET /task-logs/…` on expand; shows `.command.err` by default (most useful for debugging), with a toggle to `.command.sh`. If no logs are captured, shows a hint to run `nf-client upload-logs`.

## Test plan

- [ ] `uv run pytest tests/test_task_logs_router.py` — 4 unit tests pass
- [ ] `uv run pytest tests/test_process_metrics_router.py` — 6 tests pass
- [ ] TypeScript compiles clean
- [ ] Tasks tab: click a row → expanded detail shows task hash and resource fields
- [ ] Log viewer shows "No logs captured" message for tasks without uploaded logs
- [ ] `nf-client upload-logs --dry-run` prints files that would be uploaded
- [ ] After `just migrate`, new `task_logs` table exists in Postgres

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)