### PR TITLE
feat: content-addressed sample identity, biosample_id, collections schema (#42)

### DIFF
--- a/packages/nf_client/src/nf_client/models.py
+++ b/packages/nf_client/src/nf_client/models.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 
 class DispatchedJob(BaseModel):
     sample_id: str
+    ncbi_accession: str | None = None
     metadata: dict[str, Any] = {}
 
 

--- a/packages/nf_client/src/nf_client/submission.py
+++ b/packages/nf_client/src/nf_client/submission.py
@@ -32,12 +32,12 @@ def generate_run_name() -> str:
 def generate_metadata_tsv(jobs: list[DispatchedJob]) -> str:
     """Return TSV content with header sample_id\\tNCBI_accession.
 
-    Each row maps a biosample ID to its semicolon-separated SRR accessions
-    sourced from job.metadata['ncbi_accession'].
+    Uses the top-level ncbi_accession field; falls back to metadata dict
+    for compatibility with older server responses.
     """
     lines = ["sample_id\tNCBI_accession"]
     for job in jobs:
-        accession = job.metadata.get("ncbi_accession", "")
+        accession = job.ncbi_accession or job.metadata.get("ncbi_accession", "")
         lines.append(f"{job.sample_id}\t{accession}")
     return "\n".join(lines)
 

--- a/scripts/seed_from_tsv.py
+++ b/scripts/seed_from_tsv.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Seed the telemetry DB from a curation TSV file.
 
-Registers samples (sample_id + ncbi_accession + cohort metadata), registers the
-nf_testing stub workflow, then calls reconcile to create pending jobs.
+Registers samples using content-addressed sample_ids (md5 of SRR accessions),
+registers the nf_testing stub workflow, then calls reconcile to create pending jobs.
 
 Usage:
     uv run python scripts/seed_from_tsv.py [--tsv PATH] [--server URL]
@@ -37,6 +37,10 @@ def main() -> None:
     parser.add_argument("--server", default=DEFAULT_SERVER)
     args = parser.parse_args()
 
+    # Import here so the script works without installing the package
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+    from nextflow_telemetry.utils import srrs_to_sample_id, parse_srrs
+
     server = args.server.rstrip("/")
     client = httpx.Client(base_url=f"{server}/api/", timeout=30)
 
@@ -53,20 +57,23 @@ def main() -> None:
 
     registered = skipped = 0
     for row in rows:
-        sample_id = row["sample_id"].strip()
-        ncbi_accession = row["ncbi_accession"].strip()
-        cohort = row["study_name"].strip()
+        ncbi_accession = row.get("ncbi_accession", "").strip()
+        cohort = row.get("study_name", "").strip()
 
-        if not sample_id:
+        if not ncbi_accession:
             skipped += 1
             continue
 
+        srrs = parse_srrs(ncbi_accession)
+        sample_id = srrs_to_sample_id(srrs)
+
         resp = client.post("samples", json={
             "sample_id": sample_id,
-            "metadata": {"ncbi_accession": ncbi_accession, "cohort": cohort},
+            "ncbi_accession": ncbi_accession,
+            "metadata": {"cohort": cohort},
         })
         if resp.status_code not in (200, 201):
-            print(f"  WARN: {sample_id}: {resp.status_code} {resp.text}", file=sys.stderr)
+            print(f"  WARN: {sample_id} ({ncbi_accession}): {resp.status_code} {resp.text}", file=sys.stderr)
         else:
             registered += 1
 

--- a/src/nextflow_telemetry/db.py
+++ b/src/nextflow_telemetry/db.py
@@ -44,16 +44,47 @@ telemetry_tbl = Table(
 
 # ---------------------------------------------------------------------------
 # Sample catalog — one row per known sample
+# sample_id is the md5 hex of the sorted, deduplicated SRR accession list,
+# or a researcher-supplied opaque ID for non-SRA samples.
+# ncbi_accession stores the canonical sorted;deduped;semicolon-separated SRRs.
+# biosample_id is the NCBI BioSample accession (annotation only, not identity).
 # ---------------------------------------------------------------------------
 samples_tbl = Table(
     "samples",
     metadata,
     Column("id", Integer, primary_key=True),
     Column("sample_id", String, nullable=False, unique=True),
+    Column("ncbi_accession", Text, nullable=True),
+    Column("biosample_id", String, nullable=True),
     Column("metadata_", JSONB, nullable=True),
     Column("created_at", DateTime(timezone=True), nullable=False),
     Column("updated_at", DateTime(timezone=True), nullable=False),
     Index("ix_samples_sample_id", "sample_id"),
+    Index("ix_samples_biosample_id", "biosample_id"),
+)
+
+# ---------------------------------------------------------------------------
+# Collections — named groups of samples (e.g. a BioProject, a cohort)
+# ---------------------------------------------------------------------------
+collections_tbl = Table(
+    "collections",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("collection_id", String, nullable=False, unique=True),
+    Column("source", String, nullable=False),   # "bioproject" | "sra_study" | "manual"
+    Column("label", String, nullable=True),
+    Column("metadata_", JSONB, nullable=True),
+    Column("created_at", DateTime(timezone=True), nullable=False),
+    Column("updated_at", DateTime(timezone=True), nullable=False),
+    Index("ix_collections_collection_id", "collection_id"),
+)
+
+collection_samples_tbl = Table(
+    "collection_samples",
+    metadata,
+    Column("collection_id", String, ForeignKey("collections.collection_id"), nullable=False),
+    Column("sample_id", String, ForeignKey("samples.sample_id"), nullable=False),
+    UniqueConstraint("collection_id", "sample_id", name="uq_collection_sample"),
 )
 
 # ---------------------------------------------------------------------------

--- a/src/nextflow_telemetry/migrations/versions/20260506_f3a1b2c4d5e6_content_addressed_samples.py
+++ b/src/nextflow_telemetry/migrations/versions/20260506_f3a1b2c4d5e6_content_addressed_samples.py
@@ -1,0 +1,123 @@
+"""content_addressed_samples
+
+Revision ID: f3a1b2c4d5e6
+Revises: 4bc9877b
+Create Date: 2026-05-06
+
+Adds:
+  - samples.ncbi_accession  — sorted;deduped;semicolon-separated SRR list
+  - samples.biosample_id    — NCBI BioSample accession (nullable, indexed)
+  - Migrates existing ncbi_accession from metadata_ JSONB to the new column
+  - Recomputes sample_id as md5(canonical SRRs) for rows with an accession
+  - Updates denormalized sample_id in jobs, telemetry, dead_letter accordingly
+  - collections and collection_samples tables
+"""
+from __future__ import annotations
+
+import hashlib
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+revision: str = "f3a1b2c4d5e6"
+down_revision: Union[str, Sequence[str], None] = "4bc9877b"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _srrs_to_sample_id(ncbi_accession: str) -> str:
+    srrs = sorted(set(s.strip() for s in ncbi_accession.split(";") if s.strip()))
+    canonical = ";".join(srrs)
+    return hashlib.md5(canonical.encode()).hexdigest()
+
+
+def upgrade() -> None:
+    # -- new columns on samples -----------------------------------------------
+    op.add_column("samples", sa.Column("ncbi_accession", sa.Text, nullable=True))
+    op.add_column("samples", sa.Column("biosample_id", sa.String, nullable=True))
+    op.create_index("ix_samples_biosample_id", "samples", ["biosample_id"])
+
+    conn = op.get_bind()
+
+    # Populate ncbi_accession from the metadata_ JSONB blob
+    conn.execute(sa.text("""
+        UPDATE samples
+        SET ncbi_accession = metadata_->>'ncbi_accession'
+        WHERE metadata_->>'ncbi_accession' IS NOT NULL
+          AND metadata_->>'ncbi_accession' != ''
+    """))
+
+    # Recompute sample_id for rows that now have ncbi_accession.
+    # Must update all FK/denormalized references atomically before applying.
+    rows = conn.execute(sa.text(
+        "SELECT sample_id, ncbi_accession FROM samples WHERE ncbi_accession IS NOT NULL"
+    )).fetchall()
+
+    id_map: dict[str, str] = {}
+    for old_id, accession in rows:
+        new_id = _srrs_to_sample_id(accession)
+        if new_id != old_id:
+            id_map[old_id] = new_id
+
+    if id_map:
+        # Drop FK so we can update the referenced column freely
+        op.drop_constraint("jobs_sample_id_fkey", "jobs", type_="foreignkey")
+
+        for old_id, new_id in id_map.items():
+            # Update the canonical column first
+            conn.execute(sa.text(
+                "UPDATE samples SET sample_id = :new WHERE sample_id = :old"
+            ), {"new": new_id, "old": old_id})
+            # Propagate to FK reference
+            conn.execute(sa.text(
+                "UPDATE jobs SET sample_id = :new WHERE sample_id = :old"
+            ), {"new": new_id, "old": old_id})
+            # Propagate to denormalized columns (no FK constraint)
+            conn.execute(sa.text(
+                "UPDATE telemetry SET sample_id = :new WHERE sample_id = :old"
+            ), {"new": new_id, "old": old_id})
+            conn.execute(sa.text(
+                "UPDATE dead_letter SET sample_id = :new WHERE sample_id = :old"
+            ), {"new": new_id, "old": old_id})
+
+        # Restore FK
+        op.create_foreign_key(
+            "jobs_sample_id_fkey", "jobs", "samples",
+            ["sample_id"], ["sample_id"],
+        )
+
+    # -- collections ----------------------------------------------------------
+    op.create_table(
+        "collections",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("collection_id", sa.String, nullable=False, unique=True),
+        sa.Column("source", sa.String, nullable=False),
+        sa.Column("label", sa.String, nullable=True),
+        sa.Column("metadata_", JSONB, nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index("ix_collections_collection_id", "collections", ["collection_id"])
+
+    op.create_table(
+        "collection_samples",
+        sa.Column("collection_id", sa.String,
+                  sa.ForeignKey("collections.collection_id"), nullable=False),
+        sa.Column("sample_id", sa.String,
+                  sa.ForeignKey("samples.sample_id"), nullable=False),
+        sa.UniqueConstraint("collection_id", "sample_id", name="uq_collection_sample"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("collection_samples")
+    op.drop_table("collections")
+
+    op.drop_index("ix_samples_biosample_id", table_name="samples")
+    op.drop_column("samples", "biosample_id")
+    op.drop_column("samples", "ncbi_accession")
+    # Note: sample_id values rewritten by upgrade() are NOT reversed.
+    # Downgrade restores schema only, not data.

--- a/src/nextflow_telemetry/routers/dispatch.py
+++ b/src/nextflow_telemetry/routers/dispatch.py
@@ -32,7 +32,8 @@ class DispatchBatchRequest(BaseModel):
 class DispatchedJob(BaseModel):
     """A single job included in a dispatch batch."""
     sample_id: str = Field(description="The sample identifier to be processed in this run.")
-    metadata: dict[str, Any] = Field(default_factory=dict, description="Sample metadata (e.g. ncbi_accession). Sourced from the samples table.")
+    ncbi_accession: str | None = Field(default=None, description="Canonical semicolon-separated SRR accessions for this sample.")
+    metadata: dict[str, Any] = Field(default_factory=dict, description="Additional sample metadata.")
 
 
 class DispatchBatchResponse(BaseModel):
@@ -132,15 +133,19 @@ def create_dispatch_router(engine: AsyncEngine) -> APIRouter:
                 .values(run_name=run_name, status="claimed")
             )
 
-            # Fetch sample metadata in a separate query to avoid JOIN conflicts
+            # Fetch sample fields in a separate query to avoid JOIN conflicts
             # with the FOR UPDATE SKIP LOCKED above.
             sample_ids = [r["sample_id"] for r in rows]
             meta_result = await conn.execute(
-                select(samples_tbl.c.sample_id, samples_tbl.c.metadata_)
+                select(
+                    samples_tbl.c.sample_id,
+                    samples_tbl.c.ncbi_accession,
+                    samples_tbl.c.metadata_,
+                )
                 .where(samples_tbl.c.sample_id.in_(sample_ids))
             )
-            metadata_map: dict[str, Any] = {
-                r["sample_id"]: r["metadata_"] or {}
+            sample_map: dict[str, Any] = {
+                r["sample_id"]: r
                 for r in meta_result.mappings().all()
             }
 
@@ -154,7 +159,8 @@ def create_dispatch_router(engine: AsyncEngine) -> APIRouter:
             jobs=[
                 DispatchedJob(
                     sample_id=r["sample_id"],
-                    metadata=metadata_map.get(r["sample_id"], {}),
+                    ncbi_accession=sample_map.get(r["sample_id"], {}).get("ncbi_accession"),
+                    metadata=sample_map.get(r["sample_id"], {}).get("metadata_") or {},
                 )
                 for r in rows
             ],

--- a/src/nextflow_telemetry/routers/samples.py
+++ b/src/nextflow_telemetry/routers/samples.py
@@ -12,19 +12,35 @@ from ..services.sample import SampleService
 
 class SampleRegisterRequest(BaseModel):
     """Request body for registering or updating a sample."""
-    sample_id: str = Field(description="Unique identifier for the sample, e.g. an SRA accession like 'SRR1234567'.")
-    metadata: dict[str, Any] | None = Field(default=None, description="Optional arbitrary JSON metadata (source, phenotype, cohort, etc.). Merged on upsert.")
+    sample_id: str = Field(description="Unique identifier. For SRA samples derive via srrs_to_sample_id().")
+    ncbi_accession: str | None = Field(default=None, description="Semicolon-separated SRR accessions (e.g. 'SRR001;SRR002'). Normalised to sorted, deduplicated form on write.")
+    biosample_id: str | None = Field(default=None, description="NCBI BioSample accession (e.g. 'SAMN12345678'). Annotation only — not used as identity.")
+    metadata: dict[str, Any] | None = Field(default=None, description="Optional arbitrary JSON metadata. Replaced on upsert.")
 
 
 class SampleResponse(BaseModel):
     """A sample record from the catalog."""
     id: int = Field(description="Auto-incrementing database primary key.")
-    sample_id: str = Field(description="Unique sample identifier as supplied by the caller.")
-    metadata: dict[str, Any] | None = Field(default=None, description="Arbitrary JSON metadata attached to this sample.")
+    sample_id: str = Field(description="Unique sample identifier (md5 of SRRs for SRA samples).")
+    ncbi_accession: str | None = Field(default=None, description="Canonical semicolon-separated SRR list.")
+    biosample_id: str | None = Field(default=None, description="NCBI BioSample accession, if known.")
+    metadata: dict[str, Any] | None = Field(default=None, description="Arbitrary JSON metadata.")
     created_at: Any = Field(description="UTC timestamp when this sample was first registered.")
-    updated_at: Any = Field(description="UTC timestamp of the most recent metadata update.")
+    updated_at: Any = Field(description="UTC timestamp of the most recent update.")
 
     model_config = {"from_attributes": True}
+
+
+def _row_to_response(row: dict) -> SampleResponse:
+    return SampleResponse(
+        id=row["id"],
+        sample_id=row["sample_id"],
+        ncbi_accession=row.get("ncbi_accession"),
+        biosample_id=row.get("biosample_id"),
+        metadata=row["metadata_"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
 
 
 def create_samples_router(engine: AsyncEngine) -> APIRouter:
@@ -37,65 +53,72 @@ def create_samples_router(engine: AsyncEngine) -> APIRouter:
         status_code=201,
         summary="Register or update a sample",
         description=(
-            "Adds a sample to the catalog, or updates its metadata if it already exists (upsert on `sample_id`). "
-            "The sample becomes eligible for processing once at least one active workflow exists. "
-            "Call `POST /admin/reconcile-jobs` after registering new samples to materialise pending jobs."
+            "Adds a sample to the catalog, or updates its fields if it already exists "
+            "(upsert on `sample_id`). For SRA samples, derive `sample_id` from the SRR "
+            "list using `srrs_to_sample_id(srrs)` so that identity is content-addressed. "
+            "Call `POST /admin/reconcile-jobs` after registering new samples to create pending jobs."
         ),
     )
     async def register_sample(req: SampleRegisterRequest):
-        row = await svc.register(req.sample_id, req.metadata)
-        return SampleResponse(
-            id=row["id"],
-            sample_id=row["sample_id"],
-            metadata=row["metadata_"],
-            created_at=row["created_at"],
-            updated_at=row["updated_at"],
+        row = await svc.register(
+            req.sample_id,
+            ncbi_accession=req.ncbi_accession,
+            biosample_id=req.biosample_id,
+            metadata=req.metadata,
         )
+        return _row_to_response(row)
 
     @router.get(
         "",
         response_model=list[SampleResponse],
         summary="List samples",
-        description=(
-            "Returns a paginated list of all samples in the catalog, ordered by insertion time. "
-            "Use `limit` and `offset` for pagination."
-        ),
+        description="Returns a paginated list of all samples, ordered by insertion time.",
     )
     async def list_samples(
         limit: int = Query(default=100, ge=1, le=1000, description="Maximum number of samples to return."),
-        offset: int = Query(default=0, ge=0, description="Number of samples to skip (for pagination)."),
+        offset: int = Query(default=0, ge=0, description="Number of samples to skip."),
     ):
         rows = await svc.list_samples(limit=limit, offset=offset)
-        return [
-            SampleResponse(
-                id=r["id"],
-                sample_id=r["sample_id"],
-                metadata=r["metadata_"],
-                created_at=r["created_at"],
-                updated_at=r["updated_at"],
-            )
-            for r in rows
-        ]
+        return [_row_to_response(r) for r in rows]
+
+    @router.get(
+        "/by-srr/{srr_accession}",
+        response_model=SampleResponse,
+        summary="Look up a sample by SRR accession",
+        description=(
+            "Returns the sample whose `ncbi_accession` contains the given SRR. "
+            "Returns 404 if no sample is registered with that accession."
+        ),
+    )
+    async def get_by_srr(srr_accession: str):
+        row = await svc.get_by_srr(srr_accession)
+        if not row:
+            raise HTTPException(status_code=404, detail=f"No sample found with SRR '{srr_accession}'")
+        return _row_to_response(row)
+
+    @router.get(
+        "/by-biosample/{biosample_id}",
+        response_model=list[SampleResponse],
+        summary="Look up samples by BioSample accession",
+        description=(
+            "Returns all samples with the given `biosample_id`, newest first. "
+            "Multiple results occur when the BioSample gained new SRRs over time."
+        ),
+    )
+    async def get_by_biosample(biosample_id: str):
+        rows = await svc.get_by_biosample(biosample_id)
+        return [_row_to_response(r) for r in rows]
 
     @router.get(
         "/{sample_id}",
         response_model=SampleResponse,
         summary="Get a sample by ID",
-        description=(
-            "Retrieves a single sample record by its `sample_id` string. "
-            "Returns 404 if the sample has not been registered."
-        ),
+        description="Retrieves a single sample by its `sample_id`. Returns 404 if not found.",
     )
     async def get_sample(sample_id: str):
         row = await svc.get(sample_id)
         if not row:
             raise HTTPException(status_code=404, detail=f"Sample '{sample_id}' not found")
-        return SampleResponse(
-            id=row["id"],
-            sample_id=row["sample_id"],
-            metadata=row["metadata_"],
-            created_at=row["created_at"],
-            updated_at=row["updated_at"],
-        )
+        return _row_to_response(row)
 
     return router

--- a/src/nextflow_telemetry/services/sample.py
+++ b/src/nextflow_telemetry/services/sample.py
@@ -10,28 +10,53 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from ..db import samples_tbl
+from ..utils import normalize_srrs, parse_srrs
 
 
 @dataclass
 class SampleService:
     engine: AsyncEngine
 
-    async def register(self, sample_id: str, metadata: dict[str, Any] | None = None) -> dict:
-        """Insert or update a sample; returns the row."""
+    async def register(
+        self,
+        sample_id: str,
+        ncbi_accession: str | None = None,
+        biosample_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict:
+        """Insert or update a sample; returns the row.
+
+        ncbi_accession is normalised (sorted, deduplicated) before storage.
+        metadata_ is replaced on conflict; ncbi_accession and biosample_id are
+        updated only when explicitly supplied.
+        """
         now = datetime.now(timezone.utc)
+        normalised: str | None = None
+        if ncbi_accession:
+            normalised = normalize_srrs(parse_srrs(ncbi_accession))
+
+        values: dict[str, Any] = {
+            "sample_id": sample_id,
+            "metadata_": metadata,
+            "created_at": now,
+            "updated_at": now,
+        }
+        if normalised is not None:
+            values["ncbi_accession"] = normalised
+        if biosample_id is not None:
+            values["biosample_id"] = biosample_id
+
+        set_: dict[str, Any] = {"metadata_": metadata, "updated_at": now}
+        if normalised is not None:
+            set_["ncbi_accession"] = normalised
+        if biosample_id is not None:
+            set_["biosample_id"] = biosample_id
+
         async with self.engine.begin() as conn:
             stmt = (
                 pg_insert(samples_tbl)
-                .values(
-                    sample_id=sample_id,
-                    metadata_=metadata,
-                    created_at=now,
-                    updated_at=now,
-                )
-                .on_conflict_do_update(
-                    index_elements=["sample_id"],
-                    set_={"metadata_": metadata, "updated_at": now},
-                )
+                .values(**values)
+                .on_conflict_do_update(index_elements=["sample_id"], set_=set_)
                 .returning(*samples_tbl.c)
             )
             result = await conn.execute(stmt)
@@ -52,3 +77,28 @@ class SampleService:
             )
             row = result.mappings().one_or_none()
             return dict(row) if row else None
+
+    async def get_by_srr(self, srr: str) -> dict | None:
+        """Return the sample whose ncbi_accession contains the given SRR accession."""
+        async with self.engine.connect() as conn:
+            result = await conn.execute(
+                select(samples_tbl).where(
+                    samples_tbl.c.ncbi_accession.contains(srr)
+                )
+            )
+            row = result.mappings().one_or_none()
+            return dict(row) if row else None
+
+    async def get_by_biosample(self, biosample_id: str) -> list[dict]:
+        """Return all samples with the given biosample_id, newest first.
+
+        Multiple rows can exist for one BioSample if SRRs were added to it over
+        time (each distinct SRR set produces a distinct sample_id).
+        """
+        async with self.engine.connect() as conn:
+            result = await conn.execute(
+                select(samples_tbl)
+                .where(samples_tbl.c.biosample_id == biosample_id)
+                .order_by(samples_tbl.c.created_at.desc())
+            )
+            return [dict(r) for r in result.mappings()]

--- a/src/nextflow_telemetry/utils.py
+++ b/src/nextflow_telemetry/utils.py
@@ -1,0 +1,24 @@
+"""Shared utility functions."""
+from __future__ import annotations
+
+import hashlib
+
+
+def normalize_srrs(srrs: list[str]) -> str:
+    """Return canonical semicolon-separated SRR string: sorted and deduplicated."""
+    return ";".join(sorted(set(s.strip() for s in srrs if s.strip())))
+
+
+def srrs_to_sample_id(srrs: list[str]) -> str:
+    """Return the md5 hex sample_id for a set of SRR accessions.
+
+    The canonical form (sorted, deduplicated, semicolon-joined) is hashed so
+    that the same input set always produces the same ID regardless of order.
+    """
+    canonical = normalize_srrs(srrs)
+    return hashlib.md5(canonical.encode()).hexdigest()
+
+
+def parse_srrs(ncbi_accession: str) -> list[str]:
+    """Parse a semicolon-separated SRR string into a list of accessions."""
+    return [s.strip() for s in ncbi_accession.split(";") if s.strip()]


### PR DESCRIPTION
Closes #42

## Summary

- `sample_id` is now the md5 hex of the sorted, deduplicated SRR accession list — content-addressed, immutable, works for non-SRA samples
- New columns on `samples`: `ncbi_accession` (normalized `SRR001;SRR002` string) and `biosample_id` (NCBI BioSample accession, annotation only, indexed)
- New tables: `collections` and `collection_samples` (many-to-many) for named sample groups
- `srrs_to_sample_id()` / `normalize_srrs()` / `parse_srrs()` utility functions in `utils.py`
- `GET /samples/by-srr/{srr}` and `GET /samples/by-biosample/{biosample_id}` reverse-lookup endpoints
- `DispatchedJob` now carries `ncbi_accession` as a top-level field; nf_client falls back to `metadata['ncbi_accession']` for older servers
- Migration recomputes `sample_id` for all existing rows and cascades to `jobs`, `telemetry`, `dead_letter`
- `seed_from_tsv.py` now derives `sample_id` via `srrs_to_sample_id()` rather than using researcher codes

## Migration note

**Run migration before deploying the new image.** The new columns are nullable so the existing API revision continues to work during the window between migration and deploy.

The migration rewrites existing `sample_id` values (e.g. `s_126` → md5 hash) for any row that has `ncbi_accession` in its metadata blob, and propagates to all FK/denormalized references.

## Test plan

- [ ] `just typecheck` passes (one pre-existing untyped-import warning in dispatch.py, unrelated)
- [ ] `just test` passes with same failures as main (pre-existing integration test path issues and one process-metrics mock mismatch)
- [ ] Migration runs cleanly against prod: `export $(grep SQLALCHEMY_URI .env.prod | xargs) && uv run alembic upgrade head`
- [ ] `GET /api/samples` returns rows with `ncbi_accession` and `biosample_id` fields
- [ ] `GET /api/samples/by-srr/SRR13436222` returns the correct sample
