### PR TITLE
feat: curated sample annotations tables, service, router, and tests (#45)

### DIFF
--- a/src/nextflow_telemetry/db.py
+++ b/src/nextflow_telemetry/db.py
@@ -197,6 +197,36 @@ dead_letter_tbl = Table(
 )
 
 # ---------------------------------------------------------------------------
+# Curated studies — one row per imported curatedMetagenomicData study
+# ---------------------------------------------------------------------------
+curated_studies_tbl = Table(
+    "curated_studies",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("study_name", Text, nullable=False, unique=True),
+    Column("source_file", Text, nullable=True),
+    Column("metadata_", JSONB, nullable=True),   # pubmed_id, doi, etc.
+    Column("loaded_at", DateTime(timezone=True), nullable=False),
+)
+
+# ---------------------------------------------------------------------------
+# Curated sample annotations — one row per (sample_id, study_name) pair
+# ---------------------------------------------------------------------------
+curated_sample_annotations_tbl = Table(
+    "curated_sample_annotations",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("sample_id", Text, nullable=False),       # md5 join key
+    Column("study_name", Text, ForeignKey("curated_studies.study_name"), nullable=False),
+    Column("ncbi_accession", Text, nullable=True),   # raw SRR string from TSV
+    Column("metadata_", JSONB, nullable=False),
+    Column("loaded_at", DateTime(timezone=True), nullable=False),
+    UniqueConstraint("sample_id", "study_name", name="uq_csa_sample_study"),
+    Index("ix_csa_sample_id", "sample_id"),
+    Index("ix_csa_study_name", "study_name"),
+)
+
+# ---------------------------------------------------------------------------
 # Daemon agent registry — upserted by nf-client on every heartbeat
 # ---------------------------------------------------------------------------
 daemon_agents_tbl = Table(

--- a/src/nextflow_telemetry/main.py
+++ b/src/nextflow_telemetry/main.py
@@ -9,6 +9,7 @@ from .config import settings
 from .log import logger
 from . import models
 from .routers.admin import create_admin_router
+from .routers.curated import create_curated_router
 from .routers.daemons import create_daemons_router
 from .routers.dispatch import create_dispatch_router
 from .routers.process_metrics import create_process_metrics_router
@@ -59,6 +60,7 @@ app.include_router(create_workflows_router(engine), prefix="/api")
 app.include_router(create_admin_router(engine), prefix="/api")
 app.include_router(create_task_logs_router(engine), prefix="/api")
 app.include_router(create_daemons_router(engine), prefix="/api")
+app.include_router(create_curated_router(engine), prefix="/api")
 
 
 @app.get(

--- a/src/nextflow_telemetry/migrations/versions/20260507_a1b2c3d4_curated_annotations.py
+++ b/src/nextflow_telemetry/migrations/versions/20260507_a1b2c3d4_curated_annotations.py
@@ -1,0 +1,59 @@
+"""curated_annotations
+
+Revision ID: a1b2c3d4
+Revises: f3a1b2c4d5e6
+Create Date: 2026-05-07
+
+Adds:
+  - curated_studies table — one row per imported study (e.g. a curatedMetagenomicData TSV)
+  - curated_sample_annotations table — one row per (sample_id, study_name) pair
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+revision: str = "a1b2c3d4"
+down_revision: Union[str, Sequence[str], None] = "f3a1b2c4d5e6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "curated_studies",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("study_name", sa.Text, nullable=False, unique=True),
+        sa.Column("source_file", sa.Text, nullable=True),
+        sa.Column("metadata_", JSONB, nullable=True),
+        sa.Column("loaded_at", sa.DateTime(timezone=True), nullable=False),
+    )
+
+    op.create_table(
+        "curated_sample_annotations",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("sample_id", sa.Text, nullable=False),
+        sa.Column(
+            "study_name",
+            sa.Text,
+            sa.ForeignKey("curated_studies.study_name"),
+            nullable=False,
+        ),
+        sa.Column("ncbi_accession", sa.Text, nullable=True),
+        sa.Column("metadata_", JSONB, nullable=False),
+        sa.Column("loaded_at", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint("sample_id", "study_name", name="uq_csa_sample_study"),
+    )
+    op.create_index("ix_csa_sample_id", "curated_sample_annotations", ["sample_id"])
+    op.create_index("ix_csa_study_name", "curated_sample_annotations", ["study_name"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_csa_study_name", table_name="curated_sample_annotations")
+    op.drop_index("ix_csa_sample_id", table_name="curated_sample_annotations")
+    op.drop_table("curated_sample_annotations")
+    op.drop_table("curated_studies")

--- a/src/nextflow_telemetry/routers/curated.py
+++ b/src/nextflow_telemetry/routers/curated.py
@@ -1,0 +1,198 @@
+"""Curated sample annotations router.
+
+Provides endpoints for importing curatedMetagenomicData-style TSV files
+and querying the resulting study/annotation records.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, File, Form, HTTPException, Query, UploadFile
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from ..services.curated import CuratedService
+
+
+# ---------------------------------------------------------------------------
+# Pydantic response models
+# ---------------------------------------------------------------------------
+
+class DroppedRowResponse(BaseModel):
+    """A row that was skipped during import (missing ncbi_accession)."""
+    row_index: int
+    subject_id: str | None = None
+
+
+class ImportSummaryResponse(BaseModel):
+    """Summary of a TSV import operation."""
+    rows_loaded: int
+    rows_updated: int
+    rows_dropped: int
+    dropped_rows: list[DroppedRowResponse]
+
+
+class StudyResponse(BaseModel):
+    """A curated study record."""
+    id: int
+    study_name: str
+    source_file: str | None = None
+    metadata: dict[str, Any] | None = None
+    loaded_at: Any
+
+    model_config = {"from_attributes": True}
+
+
+class AnnotationResponse(BaseModel):
+    """A curated sample annotation record."""
+    id: int
+    sample_id: str
+    study_name: str
+    ncbi_accession: str | None = None
+    metadata: dict[str, Any]
+    loaded_at: Any
+
+    model_config = {"from_attributes": True}
+
+
+# ---------------------------------------------------------------------------
+# Router factory
+# ---------------------------------------------------------------------------
+
+def create_curated_router(engine: AsyncEngine) -> APIRouter:
+    """Return a router for curated annotation endpoints, injected with *engine*."""
+    router = APIRouter(prefix="/curated", tags=["curated"])
+    svc = CuratedService(engine=engine)
+
+    # -----------------------------------------------------------------------
+    # Import
+    # -----------------------------------------------------------------------
+
+    @router.post(
+        "/import",
+        response_model=ImportSummaryResponse,
+        status_code=200,
+        summary="Import a curatedMetagenomicData TSV",
+        description=(
+            "Upload a tab-separated file where one column (case-insensitive) is "
+            "`ncbi_accession`. Each row becomes a `curated_sample_annotations` record "
+            "keyed by the content-addressed `sample_id` (md5 of sorted SRRs). "
+            "Rows with a missing or empty `ncbi_accession` are dropped and reported. "
+            "Re-importing the same study is idempotent — rows are upserted on "
+            "`(sample_id, study_name)`."
+        ),
+    )
+    async def import_tsv(
+        file: UploadFile = File(..., description="Tab-separated file to import."),
+        study_name: str = Form(..., description="Unique name for this study (e.g. 'ArtachoA_2021')."),
+        pubmed_id: str | None = Form(default=None, description="PubMed ID for the study."),
+        doi: str | None = Form(default=None, description="DOI for the study."),
+    ):
+        content = await file.read()
+        try:
+            summary = await svc.import_tsv(
+                tsv_content=content,
+                study_name=study_name,
+                source_file=file.filename,
+                pubmed_id=pubmed_id,
+                doi=doi,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc))
+        return ImportSummaryResponse(
+            rows_loaded=summary.rows_loaded,
+            rows_updated=summary.rows_updated,
+            rows_dropped=summary.rows_dropped,
+            dropped_rows=[
+                DroppedRowResponse(row_index=d.row_index, subject_id=d.subject_id)
+                for d in summary.dropped_rows
+            ],
+        )
+
+    # -----------------------------------------------------------------------
+    # Studies
+    # -----------------------------------------------------------------------
+
+    @router.get(
+        "/studies",
+        response_model=list[StudyResponse],
+        summary="List all curated studies",
+        description="Returns all imported studies ordered by name.",
+    )
+    async def list_studies():
+        rows = await svc.list_studies()
+        return [_study_to_response(r) for r in rows]
+
+    @router.get(
+        "/studies/{study_name}",
+        response_model=StudyResponse,
+        summary="Get a curated study by name",
+        description="Returns a single study record. Returns 404 if the study does not exist.",
+    )
+    async def get_study(study_name: str):
+        row = await svc.get_study(study_name)
+        if row is None:
+            raise HTTPException(status_code=404, detail=f"Study '{study_name}' not found")
+        return _study_to_response(row)
+
+    @router.get(
+        "/studies/{study_name}/samples",
+        response_model=list[AnnotationResponse],
+        summary="List samples for a curated study",
+        description="Returns a paginated list of annotation records for the given study.",
+    )
+    async def list_study_samples(
+        study_name: str,
+        limit: int = Query(default=100, ge=1, le=1000, description="Maximum rows to return."),
+        offset: int = Query(default=0, ge=0, description="Number of rows to skip."),
+    ):
+        rows = await svc.list_study_samples(study_name, limit=limit, offset=offset)
+        return [_annotation_to_response(r) for r in rows]
+
+    # -----------------------------------------------------------------------
+    # Samples (cross-study lookup)
+    # -----------------------------------------------------------------------
+
+    @router.get(
+        "/samples/{sample_id}",
+        response_model=list[AnnotationResponse],
+        summary="Get curated annotations for a sample",
+        description=(
+            "Returns all curated annotation records for the given `sample_id` "
+            "across all studies. Returns an empty list if no annotations exist."
+        ),
+    )
+    async def get_sample_annotations(sample_id: str):
+        rows = await svc.get_sample_annotations(sample_id)
+        return [_annotation_to_response(r) for r in rows]
+
+    return router
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _study_to_response(row: Any) -> StudyResponse:
+    from ..services.curated import StudyRow
+    r: StudyRow = row
+    return StudyResponse(
+        id=r.id,
+        study_name=r.study_name,
+        source_file=r.source_file,
+        metadata=r.metadata_,
+        loaded_at=r.loaded_at,
+    )
+
+
+def _annotation_to_response(row: Any) -> AnnotationResponse:
+    from ..services.curated import AnnotationRow
+    r: AnnotationRow = row
+    return AnnotationResponse(
+        id=r.id,
+        sample_id=r.sample_id,
+        study_name=r.study_name,
+        ncbi_accession=r.ncbi_accession,
+        metadata=r.metadata_,
+        loaded_at=r.loaded_at,
+    )

--- a/src/nextflow_telemetry/routers/curated.py
+++ b/src/nextflow_telemetry/routers/curated.py
@@ -26,6 +26,7 @@ class DroppedRowResponse(BaseModel):
 
 class ImportSummaryResponse(BaseModel):
     """Summary of a TSV import operation."""
+    study_name: str
     rows_loaded: int
     rows_updated: int
     rows_dropped: int
@@ -100,6 +101,7 @@ def create_curated_router(engine: AsyncEngine) -> APIRouter:
         except ValueError as exc:
             raise HTTPException(status_code=422, detail=str(exc))
         return ImportSummaryResponse(
+            study_name=summary.study_name,
             rows_loaded=summary.rows_loaded,
             rows_updated=summary.rows_updated,
             rows_dropped=summary.rows_dropped,

--- a/src/nextflow_telemetry/services/curated.py
+++ b/src/nextflow_telemetry/services/curated.py
@@ -34,6 +34,7 @@ class DroppedRow:
 @dataclass
 class ImportSummary:
     """Summary returned by CuratedService.import_tsv()."""
+    study_name: str
     rows_loaded: int
     rows_updated: int
     rows_dropped: int
@@ -86,16 +87,24 @@ class CuratedService:
         2. Locate the ncbi_accession column case-insensitively; raise ValueError if absent.
         3. For each row:
            - If ncbi_accession is null/empty → record as a dropped row.
+           - If parse_srrs() returns an empty list → record as a dropped row.
            - Otherwise compute sample_id = srrs_to_sample_id(parse_srrs(ncbi_accession))
-             and build a metadata_ JSONB from all columns except ncbi_accession.
-        4. Upsert curated_studies first, then upsert each annotation row.
+             and build a metadata_ JSONB from all columns except ncbi_accession
+             (None and empty-string keys are excluded to avoid JSONB errors).
+        4. Upsert curated_studies first (preserving existing metadata_ when new
+           import has no pubmed_id/doi), then bulk-upsert all annotation rows.
         5. Return an ImportSummary.
         """
         text = tsv_content.decode("utf-8")
         reader = csv.DictReader(io.StringIO(text), delimiter="\t")
 
         if reader.fieldnames is None:
-            return ImportSummary(rows_loaded=0, rows_updated=0, rows_dropped=0)
+            return ImportSummary(
+                study_name=study_name,
+                rows_loaded=0,
+                rows_updated=0,
+                rows_dropped=0,
+            )
 
         # Case-insensitive lookup for the ncbi_accession column
         fieldnames: list[str] = list(reader.fieldnames)
@@ -135,10 +144,27 @@ class CuratedService:
                 dropped.append(DroppedRow(row_index=row_index, subject_id=subject_id))
                 continue
 
-            sample_id = srrs_to_sample_id(parse_srrs(raw_accession))
+            # Fix #2: treat rows where parse_srrs yields no valid SRRs as dropped.
+            srrs = parse_srrs(raw_accession)
+            if not srrs:
+                dropped.append(
+                    DroppedRow(
+                        row_index=row_index,
+                        subject_id=subject_id,
+                    )
+                )
+                continue
 
-            # All columns except the accession column become metadata_
-            meta: dict[str, Any] = {k: v for k, v in row.items() if k != accession_col}
+            sample_id = srrs_to_sample_id(srrs)
+
+            # Fix #3: exclude None keys (csv.DictReader overflow columns) and the
+            # accession column itself from the metadata_ dict to avoid JSONB errors.
+            acol = accession_col
+            meta: dict[str, Any] = {
+                k: v
+                for k, v in row.items()
+                if k is not None and k != "" and k != acol
+            }
 
             annotation_rows.append({
                 "sample_id": sample_id,
@@ -148,51 +174,67 @@ class CuratedService:
                 "loaded_at": now,
             })
 
-        rows_updated = 0
-
         async with self.engine.begin() as conn:
-            # 1. Upsert the study record
+            # 1. Upsert the study record.
+            # Fix #1: only update metadata_ when the new import provides non-empty
+            # study_meta — this prevents overwriting previously stored pubmed_id/doi
+            # with NULL when re-importing without those fields.
+            study_values: dict[str, Any] = {
+                "study_name": study_name,
+                "source_file": source_file,
+                "metadata_": study_meta or None,
+                "loaded_at": now,
+            }
+            conflict_set: dict[str, Any] = {
+                "source_file": source_file,
+                "loaded_at": now,
+            }
+            if study_meta:
+                conflict_set["metadata_"] = study_meta
+
             study_stmt = (
                 pg_insert(curated_studies_tbl)
-                .values(
-                    study_name=study_name,
-                    source_file=source_file,
-                    metadata_=study_meta or None,
-                    loaded_at=now,
-                )
+                .values(**study_values)
                 .on_conflict_do_update(
                     index_elements=["study_name"],
-                    set_={
-                        "source_file": source_file,
-                        "metadata_": study_meta or None,
-                        "loaded_at": now,
-                    },
+                    set_=conflict_set,
                 )
             )
             await conn.execute(study_stmt)
 
-            # 2. Upsert annotation rows and count conflicts (updates)
-            for ann in annotation_rows:
-                ann_stmt = (
-                    pg_insert(curated_sample_annotations_tbl)
-                    .values(**ann)
-                    .on_conflict_do_update(
-                        constraint="uq_csa_sample_study",
-                        set_={
-                            "ncbi_accession": ann["ncbi_accession"],
-                            "metadata_": ann["metadata_"],
-                            "loaded_at": ann["loaded_at"],
-                        },
+            # Fix #4: count pre-existing annotation rows for this study to compute
+            # rows_updated accurately.
+            existing_sample_ids: set[str] = set()
+            if annotation_rows:
+                candidate_ids = [r["sample_id"] for r in annotation_rows]
+                existing_result = await conn.execute(
+                    select(curated_sample_annotations_tbl.c.sample_id).where(
+                        curated_sample_annotations_tbl.c.study_name == study_name,
+                        curated_sample_annotations_tbl.c.sample_id.in_(candidate_ids),
                     )
-                    .returning(curated_sample_annotations_tbl.c.id)
                 )
-                # PostgreSQL returns the row whether it was inserted or updated.
-                # Use xmax to detect updates: xmax != 0 means it was an UPDATE.
-                # Simpler approach: track by counting conflicts via advisory or just
-                # return 0 for updates (idempotent re-imports are expected).
+                existing_sample_ids = {row[0] for row in existing_result}
+
+            rows_updated = len(existing_sample_ids)
+
+            # Fix #5: bulk-upsert all annotation rows in a single round-trip instead
+            # of one execute() call per row.
+            if annotation_rows:
+                ann_insert = pg_insert(curated_sample_annotations_tbl).values(
+                    annotation_rows
+                )
+                ann_stmt = ann_insert.on_conflict_do_update(
+                    constraint="uq_csa_sample_study",
+                    set_={
+                        "ncbi_accession": ann_insert.excluded.ncbi_accession,
+                        "metadata_": ann_insert.excluded.metadata_,
+                        "loaded_at": ann_insert.excluded.loaded_at,
+                    },
+                )
                 await conn.execute(ann_stmt)
 
         return ImportSummary(
+            study_name=study_name,
             rows_loaded=len(annotation_rows),
             rows_updated=rows_updated,
             rows_dropped=len(dropped),

--- a/src/nextflow_telemetry/services/curated.py
+++ b/src/nextflow_telemetry/services/curated.py
@@ -1,0 +1,268 @@
+"""Curated sample annotations service.
+
+Handles import and querying of curatedMetagenomicData-style TSV files.
+Each TSV represents a study; rows become curated_sample_annotations entries
+keyed by the content-addressed sample_id (md5 of sorted SRR accessions).
+"""
+from __future__ import annotations
+
+import csv
+import io
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from ..db import curated_sample_annotations_tbl, curated_studies_tbl
+from ..utils import parse_srrs, srrs_to_sample_id
+
+
+# ---------------------------------------------------------------------------
+# Data-transfer objects
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DroppedRow:
+    """Describes a row that was skipped during import (missing ncbi_accession)."""
+    row_index: int
+    subject_id: str | None = None
+
+
+@dataclass
+class ImportSummary:
+    """Summary returned by CuratedService.import_tsv()."""
+    rows_loaded: int
+    rows_updated: int
+    rows_dropped: int
+    dropped_rows: list[DroppedRow] = field(default_factory=list)
+
+
+@dataclass
+class StudyRow:
+    """Represents a row from curated_studies."""
+    id: int
+    study_name: str
+    source_file: str | None
+    metadata_: dict[str, Any] | None
+    loaded_at: datetime
+
+
+@dataclass
+class AnnotationRow:
+    """Represents a row from curated_sample_annotations."""
+    id: int
+    sample_id: str
+    study_name: str
+    ncbi_accession: str | None
+    metadata_: dict[str, Any]
+    loaded_at: datetime
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+@dataclass
+class CuratedService:
+    """Business logic for curated study imports and queries."""
+
+    engine: AsyncEngine
+
+    async def import_tsv(
+        self,
+        tsv_content: bytes,
+        study_name: str,
+        source_file: str | None = None,
+        pubmed_id: str | None = None,
+        doi: str | None = None,
+    ) -> ImportSummary:
+        """Parse a TSV and upsert rows into curated_studies / curated_sample_annotations.
+
+        Steps:
+        1. Decode the bytes as UTF-8 and parse with csv.DictReader (tab-separated).
+        2. Locate the ncbi_accession column case-insensitively; raise ValueError if absent.
+        3. For each row:
+           - If ncbi_accession is null/empty → record as a dropped row.
+           - Otherwise compute sample_id = srrs_to_sample_id(parse_srrs(ncbi_accession))
+             and build a metadata_ JSONB from all columns except ncbi_accession.
+        4. Upsert curated_studies first, then upsert each annotation row.
+        5. Return an ImportSummary.
+        """
+        text = tsv_content.decode("utf-8")
+        reader = csv.DictReader(io.StringIO(text), delimiter="\t")
+
+        if reader.fieldnames is None:
+            return ImportSummary(rows_loaded=0, rows_updated=0, rows_dropped=0)
+
+        # Case-insensitive lookup for the ncbi_accession column
+        fieldnames: list[str] = list(reader.fieldnames)
+        accession_col: str | None = None
+        for col in fieldnames:
+            if col.lower() == "ncbi_accession":
+                accession_col = col
+                break
+        if accession_col is None:
+            raise ValueError(
+                "TSV is missing an 'ncbi_accession' column (case-insensitive). "
+                f"Found columns: {fieldnames}"
+            )
+
+        now = datetime.now(timezone.utc)
+        study_meta: dict[str, Any] = {}
+        if pubmed_id is not None:
+            study_meta["pubmed_id"] = pubmed_id
+        if doi is not None:
+            study_meta["doi"] = doi
+
+        annotation_rows: list[dict[str, Any]] = []
+        dropped: list[DroppedRow] = []
+
+        for row_index, row in enumerate(reader):
+            raw_accession: str = (row.get(accession_col) or "").strip()
+
+            # Derive a human-readable subject label for dropped-row reporting.
+            subject_id: str | None = (
+                row.get("subject_id")
+                or row.get("sample_id")
+                or row.get("Subject_id")
+                or row.get("Sample_id")
+            )
+
+            if not raw_accession:
+                dropped.append(DroppedRow(row_index=row_index, subject_id=subject_id))
+                continue
+
+            sample_id = srrs_to_sample_id(parse_srrs(raw_accession))
+
+            # All columns except the accession column become metadata_
+            meta: dict[str, Any] = {k: v for k, v in row.items() if k != accession_col}
+
+            annotation_rows.append({
+                "sample_id": sample_id,
+                "study_name": study_name,
+                "ncbi_accession": raw_accession,
+                "metadata_": meta,
+                "loaded_at": now,
+            })
+
+        rows_updated = 0
+
+        async with self.engine.begin() as conn:
+            # 1. Upsert the study record
+            study_stmt = (
+                pg_insert(curated_studies_tbl)
+                .values(
+                    study_name=study_name,
+                    source_file=source_file,
+                    metadata_=study_meta or None,
+                    loaded_at=now,
+                )
+                .on_conflict_do_update(
+                    index_elements=["study_name"],
+                    set_={
+                        "source_file": source_file,
+                        "metadata_": study_meta or None,
+                        "loaded_at": now,
+                    },
+                )
+            )
+            await conn.execute(study_stmt)
+
+            # 2. Upsert annotation rows and count conflicts (updates)
+            for ann in annotation_rows:
+                ann_stmt = (
+                    pg_insert(curated_sample_annotations_tbl)
+                    .values(**ann)
+                    .on_conflict_do_update(
+                        constraint="uq_csa_sample_study",
+                        set_={
+                            "ncbi_accession": ann["ncbi_accession"],
+                            "metadata_": ann["metadata_"],
+                            "loaded_at": ann["loaded_at"],
+                        },
+                    )
+                    .returning(curated_sample_annotations_tbl.c.id)
+                )
+                # PostgreSQL returns the row whether it was inserted or updated.
+                # Use xmax to detect updates: xmax != 0 means it was an UPDATE.
+                # Simpler approach: track by counting conflicts via advisory or just
+                # return 0 for updates (idempotent re-imports are expected).
+                await conn.execute(ann_stmt)
+
+        return ImportSummary(
+            rows_loaded=len(annotation_rows),
+            rows_updated=rows_updated,
+            rows_dropped=len(dropped),
+            dropped_rows=dropped,
+        )
+
+    async def list_studies(self) -> list[StudyRow]:
+        """Return all studies ordered by name."""
+        async with self.engine.connect() as conn:
+            result = await conn.execute(
+                select(curated_studies_tbl).order_by(curated_studies_tbl.c.study_name)
+            )
+            return [_map_study(row) for row in result.mappings()]
+
+    async def get_study(self, study_name: str) -> StudyRow | None:
+        """Return a single study by name, or None if not found."""
+        async with self.engine.connect() as conn:
+            result = await conn.execute(
+                select(curated_studies_tbl).where(
+                    curated_studies_tbl.c.study_name == study_name
+                )
+            )
+            row = result.mappings().one_or_none()
+            return _map_study(row) if row else None
+
+    async def list_study_samples(
+        self, study_name: str, limit: int = 100, offset: int = 0
+    ) -> list[AnnotationRow]:
+        """Return paginated annotations for a given study."""
+        async with self.engine.connect() as conn:
+            result = await conn.execute(
+                select(curated_sample_annotations_tbl)
+                .where(curated_sample_annotations_tbl.c.study_name == study_name)
+                .order_by(curated_sample_annotations_tbl.c.id)
+                .limit(limit)
+                .offset(offset)
+            )
+            return [_map_annotation(row) for row in result.mappings()]
+
+    async def get_sample_annotations(self, sample_id: str) -> list[AnnotationRow]:
+        """Return all curated annotations for a given sample_id across all studies."""
+        async with self.engine.connect() as conn:
+            result = await conn.execute(
+                select(curated_sample_annotations_tbl)
+                .where(curated_sample_annotations_tbl.c.sample_id == sample_id)
+                .order_by(curated_sample_annotations_tbl.c.study_name)
+            )
+            return [_map_annotation(row) for row in result.mappings()]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _map_study(row: Any) -> StudyRow:
+    return StudyRow(
+        id=row["id"],
+        study_name=row["study_name"],
+        source_file=row["source_file"],
+        metadata_=row["metadata_"],
+        loaded_at=row["loaded_at"],
+    )
+
+
+def _map_annotation(row: Any) -> AnnotationRow:
+    return AnnotationRow(
+        id=row["id"],
+        sample_id=row["sample_id"],
+        study_name=row["study_name"],
+        ncbi_accession=row["ncbi_accession"],
+        metadata_=row["metadata_"],
+        loaded_at=row["loaded_at"],
+    )

--- a/tests/test_curated.py
+++ b/tests/test_curated.py
@@ -1,0 +1,268 @@
+"""Integration tests for curated sample annotation endpoints.
+
+All tests use the shared ``integration_client`` fixture (real Postgres via
+testcontainers). The schema is created once per session via the ``create_schema``
+autouse fixture in conftest.py, which calls ``metadata.create_all`` — this
+picks up the two new tables added to db.py.
+"""
+from __future__ import annotations
+
+import io
+import uuid
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_study_name() -> str:
+    return f"TestStudy_{uuid.uuid4().hex[:8]}"
+
+
+def _make_tsv(rows: list[dict], extra_cols: list[str] | None = None) -> bytes:
+    """Build a minimal TSV with ncbi_accession + optional extra columns."""
+    cols = ["ncbi_accession"] + (extra_cols or ["subject_id", "disease"])
+    lines = ["\t".join(cols)]
+    for row in rows:
+        lines.append("\t".join(row.get(c, "") for c in cols))
+    return "\n".join(lines).encode("utf-8")
+
+
+def _import(client, study_name: str, tsv: bytes, **kwargs):
+    """POST /curated/import with multipart form data."""
+    return client.post(
+        "/api/curated/import",
+        data={"study_name": study_name, **kwargs},
+        files={"file": ("test.tsv", io.BytesIO(tsv), "text/tab-separated-values")},
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST /curated/import — happy path
+# ---------------------------------------------------------------------------
+
+def test_import_happy_path(integration_client):
+    client, _ = integration_client
+    study_name = _make_study_name()
+
+    tsv = _make_tsv([
+        {"ncbi_accession": "SRR000001;SRR000002", "subject_id": "S1", "disease": "healthy"},
+        {"ncbi_accession": "SRR000003",            "subject_id": "S2", "disease": "IBD"},
+    ])
+    resp = _import(client, study_name, tsv, pubmed_id="12345678")
+    assert resp.status_code == 200, resp.text
+
+    data = resp.json()
+    assert data["rows_loaded"] == 2
+    assert data["rows_dropped"] == 0
+    assert data["dropped_rows"] == []
+
+
+def test_import_creates_study(integration_client):
+    client, _ = integration_client
+    study_name = _make_study_name()
+
+    tsv = _make_tsv([{"ncbi_accession": "SRR111111", "subject_id": "A"}])
+    _import(client, study_name, tsv, doi="10.1234/test")
+
+    resp = client.get(f"/api/curated/studies/{study_name}")
+    assert resp.status_code == 200
+    study = resp.json()
+    assert study["study_name"] == study_name
+    assert study["metadata"]["doi"] == "10.1234/test"
+
+
+# ---------------------------------------------------------------------------
+# Idempotent re-import
+# ---------------------------------------------------------------------------
+
+def test_import_idempotent(integration_client):
+    client, _ = integration_client
+    study_name = _make_study_name()
+
+    tsv = _make_tsv([{"ncbi_accession": "SRR222222", "subject_id": "B", "disease": "healthy"}])
+    resp1 = _import(client, study_name, tsv)
+    resp2 = _import(client, study_name, tsv)
+
+    assert resp1.status_code == 200
+    assert resp2.status_code == 200
+    # Both calls report 1 row loaded (upsert)
+    assert resp1.json()["rows_loaded"] == 1
+    assert resp2.json()["rows_loaded"] == 1
+
+    # Only one annotation row should exist
+    resp = client.get(f"/api/curated/studies/{study_name}/samples")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+
+# ---------------------------------------------------------------------------
+# Null / empty ncbi_accession rows are dropped
+# ---------------------------------------------------------------------------
+
+def test_import_drops_null_accession_rows(integration_client):
+    client, _ = integration_client
+    study_name = _make_study_name()
+
+    tsv = _make_tsv([
+        {"ncbi_accession": "SRR333333", "subject_id": "C", "disease": "healthy"},
+        {"ncbi_accession": "",           "subject_id": "D", "disease": "IBD"},
+        {"ncbi_accession": "SRR333334", "subject_id": "E", "disease": "healthy"},
+    ])
+    resp = _import(client, study_name, tsv)
+    assert resp.status_code == 200
+
+    data = resp.json()
+    assert data["rows_loaded"] == 2
+    assert data["rows_dropped"] == 1
+    assert len(data["dropped_rows"]) == 1
+    dropped = data["dropped_rows"][0]
+    assert dropped["row_index"] == 1
+    assert dropped["subject_id"] == "D"
+
+
+# ---------------------------------------------------------------------------
+# Case-insensitive ncbi_accession column detection
+# ---------------------------------------------------------------------------
+
+def test_import_case_insensitive_column(integration_client):
+    """TSV with NCBI_ACCESSION (uppercase) should be accepted."""
+    client, _ = integration_client
+    study_name = _make_study_name()
+
+    # Build a TSV with the column named in uppercase
+    tsv = "NCBI_ACCESSION\tsubject_id\nSRR444444\tX\n".encode("utf-8")
+    resp = _import(client, study_name, tsv)
+    assert resp.status_code == 200
+    assert resp.json()["rows_loaded"] == 1
+
+
+def test_import_missing_accession_column_returns_422(integration_client):
+    """TSV without any ncbi_accession-like column should return 422."""
+    client, _ = integration_client
+    study_name = _make_study_name()
+
+    tsv = "subject_id\tdisease\nS1\thealthy\n".encode("utf-8")
+    resp = _import(client, study_name, tsv)
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /curated/studies
+# ---------------------------------------------------------------------------
+
+def test_list_studies(integration_client):
+    client, _ = integration_client
+    study_name = _make_study_name()
+
+    tsv = _make_tsv([{"ncbi_accession": "SRR555555", "subject_id": "F"}])
+    _import(client, study_name, tsv)
+
+    resp = client.get("/api/curated/studies")
+    assert resp.status_code == 200
+    names = [s["study_name"] for s in resp.json()]
+    assert study_name in names
+
+
+# ---------------------------------------------------------------------------
+# GET /curated/studies/{study_name}
+# ---------------------------------------------------------------------------
+
+def test_get_study_not_found(integration_client):
+    client, _ = integration_client
+    resp = client.get("/api/curated/studies/DOES_NOT_EXIST_STUDY_XYZ")
+    assert resp.status_code == 404
+
+
+def test_get_study_found(integration_client):
+    client, _ = integration_client
+    study_name = _make_study_name()
+
+    tsv = _make_tsv([{"ncbi_accession": "SRR666666", "subject_id": "G"}])
+    _import(client, study_name, tsv, pubmed_id="99999999")
+
+    resp = client.get(f"/api/curated/studies/{study_name}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["study_name"] == study_name
+    assert data["metadata"]["pubmed_id"] == "99999999"
+
+
+# ---------------------------------------------------------------------------
+# GET /curated/studies/{study_name}/samples
+# ---------------------------------------------------------------------------
+
+def test_list_study_samples(integration_client):
+    client, _ = integration_client
+    study_name = _make_study_name()
+
+    tsv = _make_tsv([
+        {"ncbi_accession": "SRR777771", "subject_id": "H1"},
+        {"ncbi_accession": "SRR777772", "subject_id": "H2"},
+        {"ncbi_accession": "SRR777773", "subject_id": "H3"},
+    ])
+    _import(client, study_name, tsv)
+
+    resp = client.get(f"/api/curated/studies/{study_name}/samples")
+    assert resp.status_code == 200
+    annotations = resp.json()
+    assert len(annotations) == 3
+    study_names = {a["study_name"] for a in annotations}
+    assert study_names == {study_name}
+
+
+def test_list_study_samples_pagination(integration_client):
+    client, _ = integration_client
+    study_name = _make_study_name()
+
+    tsv = _make_tsv([
+        {"ncbi_accession": f"SRR88888{i}", "subject_id": f"P{i}"}
+        for i in range(5)
+    ])
+    _import(client, study_name, tsv)
+
+    resp = client.get(f"/api/curated/studies/{study_name}/samples?limit=2&offset=0")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 2
+
+    resp2 = client.get(f"/api/curated/studies/{study_name}/samples?limit=2&offset=2")
+    assert resp2.status_code == 200
+    assert len(resp2.json()) == 2
+
+
+# ---------------------------------------------------------------------------
+# GET /curated/samples/{sample_id}
+# ---------------------------------------------------------------------------
+
+def test_get_sample_annotations(integration_client):
+    """sample_id lookup should return annotations from all studies."""
+    from nextflow_telemetry.utils import parse_srrs, srrs_to_sample_id
+
+    client, _ = integration_client
+    srr = f"SRR9{uuid.uuid4().hex[:7]}"
+    expected_sample_id = srrs_to_sample_id(parse_srrs(srr))
+
+    study_name_a = _make_study_name()
+    study_name_b = _make_study_name()
+
+    tsv_a = f"ncbi_accession\tsubject_id\n{srr}\tX\n".encode("utf-8")
+    tsv_b = f"ncbi_accession\tsubject_id\n{srr}\tY\n".encode("utf-8")
+
+    _import(client, study_name_a, tsv_a)
+    _import(client, study_name_b, tsv_b)
+
+    resp = client.get(f"/api/curated/samples/{expected_sample_id}")
+    assert resp.status_code == 200
+    annotations = resp.json()
+    # Should find the annotation in both studies
+    assert len(annotations) == 2
+    returned_studies = {a["study_name"] for a in annotations}
+    assert returned_studies == {study_name_a, study_name_b}
+
+
+def test_get_sample_annotations_empty(integration_client):
+    """Unknown sample_id should return empty list (not 404)."""
+    client, _ = integration_client
+    resp = client.get("/api/curated/samples/0000000000000000000000000000000000000000")
+    assert resp.status_code == 200
+    assert resp.json() == []

--- a/tests/test_curated.py
+++ b/tests/test_curated.py
@@ -77,23 +77,40 @@ def test_import_creates_study(integration_client):
 # ---------------------------------------------------------------------------
 
 def test_import_idempotent(integration_client):
+    """Re-importing the same study is idempotent and preserves existing metadata."""
     client, _ = integration_client
     study_name = _make_study_name()
 
     tsv = _make_tsv([{"ncbi_accession": "SRR222222", "subject_id": "B", "disease": "healthy"}])
-    resp1 = _import(client, study_name, tsv)
-    resp2 = _import(client, study_name, tsv)
 
+    # First import includes pubmed_id and doi so study metadata is persisted.
+    resp1 = _import(client, study_name, tsv, pubmed_id="11111111", doi="10.1234/idempotent")
     assert resp1.status_code == 200
-    assert resp2.status_code == 200
-    # Both calls report 1 row loaded (upsert)
-    assert resp1.json()["rows_loaded"] == 1
-    assert resp2.json()["rows_loaded"] == 1
+    data1 = resp1.json()
+    assert data1["rows_loaded"] == 1
+    assert data1["rows_updated"] == 0  # no pre-existing rows on first import
+    assert data1["study_name"] == study_name
 
-    # Only one annotation row should exist
+    # Re-import the same TSV WITHOUT pubmed_id/doi — metadata must NOT be cleared.
+    resp2 = _import(client, study_name, tsv)
+    assert resp2.status_code == 200
+    data2 = resp2.json()
+    # rows_loaded should stay the same (not doubled)
+    assert data2["rows_loaded"] == 1
+    # rows_updated should reflect that the row already existed
+    assert data2["rows_updated"] > 0
+
+    # Only one annotation row should exist (upsert, not insert)
     resp = client.get(f"/api/curated/studies/{study_name}/samples")
     assert resp.status_code == 200
     assert len(resp.json()) == 1
+
+    # Study metadata must still be present after re-import without pubmed_id/doi
+    study_resp = client.get(f"/api/curated/studies/{study_name}")
+    assert study_resp.status_code == 200
+    study_data = study_resp.json()
+    assert study_data["metadata"]["pubmed_id"] == "11111111"
+    assert study_data["metadata"]["doi"] == "10.1234/idempotent"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `curated_studies` and `curated_sample_annotations` tables with Alembic migration
- `POST /curated/import` multipart endpoint: upload TSV + optional `study_name`, `pubmed_id`, `doi` form fields; synchronous response with full import summary
- Study-level metadata (pubmed_id, doi, etc.) stored in `curated_studies.metadata_` JSONB for flexibility
- Case-insensitive `ncbi_accession` column detection; null rows dropped with row index + subject_id in response
- Idempotent upsert on `(sample_id, study_name)` — safe to re-import the same TSV
- No FK from `curated_sample_annotations.sample_id` → `samples.sample_id`; join is logical via md5 key so imports work before pipeline records exist
- 13 integration tests against real Postgres (testcontainers), all passing

## Endpoints

| Method | Path | Description |
|---|---|---|
| `POST` | `/curated/import` | Upload TSV; returns import summary |
| `GET` | `/curated/studies` | List all loaded studies |
| `GET` | `/curated/studies/{study_name}` | Study detail |
| `GET` | `/curated/studies/{study_name}/samples` | Paginated annotations for a study |
| `GET` | `/curated/samples/{sample_id}` | All curated annotations for a sample across studies |

## Test plan

- [x] Happy-path import creates study + annotations
- [x] Study metadata (pubmed_id, doi) stored in JSONB
- [x] Idempotent re-import updates rows, does not duplicate
- [x] Null/empty `ncbi_accession` rows dropped; report includes row_index and subject_id
- [x] Case-insensitive column detection (`NCBI_ACCESSION`, `ncbi_accession`, etc.)
- [x] Missing accession column returns 422
- [x] All GET endpoints: list studies, get study, study samples (with pagination), cross-study sample lookup
- [x] Unknown sample_id returns empty list (not 404)

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)