### PR TITLE
feat: load_bioproject.py utility for seeding samples from omicidx parquet

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ dev = [
     "httpx>=0.27.0,<0.28.0",
     "testcontainers[postgres]>=4.8.0,<5.0.0",
     "greenlet>=3.0.0",
+    "click>=8.1.0,<9.0.0",
+    "duckdb>=1.0.0,<2.0.0",
 ]
 
 [build-system]

--- a/scripts/load_bioproject.py
+++ b/scripts/load_bioproject.py
@@ -50,11 +50,11 @@ COLUMNS = ["ncbi_accession", "sra_sample", "biosample", "bioproject", "sra_study
 
 
 def fetch_rows(bioproject: str) -> list[dict[str, str]]:
-    con = duckdb.connect(":memory:")
-    con.execute("SET enable_progress_bar = false")
-    cur = con.execute(QUERY, [PARQUET_URL, bioproject])
-    rows = cur.fetchall()
-    fields = [d[0] for d in cur.description]
+    with duckdb.connect(":memory:") as con:
+        con.execute("SET enable_progress_bar = false")
+        cur = con.execute(QUERY, [PARQUET_URL, bioproject])
+        rows = cur.fetchall()
+        fields = [d[0] for d in cur.description]
     return [dict(zip(fields, r)) for r in rows]
 
 
@@ -75,44 +75,44 @@ def upload_rows(rows: list[dict[str, str]], server: str, cohort: str | None) -> 
     from nextflow_telemetry.utils import parse_srrs, srrs_to_sample_id
 
     server = server.rstrip("/")
-    client = httpx.Client(base_url=f"{server}/api/", timeout=30)
 
-    try:
-        httpx.get(f"{server}/health", timeout=10).raise_for_status()
-    except Exception as e:
-        raise click.ClickException(f"cannot reach {server}: {e}")
+    with httpx.Client(base_url=server, timeout=30) as client:
+        try:
+            client.get("/health", timeout=10).raise_for_status()
+        except Exception as e:
+            raise click.ClickException(f"cannot reach {server}: {e}")
 
-    registered = failed = 0
-    for row in rows:
-        srrs = parse_srrs(row["ncbi_accession"])
-        if not srrs:
-            continue
-        sample_id = srrs_to_sample_id(srrs)
-        metadata = {
-            "bioproject": row["bioproject"],
-            "sra_study": row["sra_study"],
-            "sra_sample": row["sra_sample"],
-        }
-        if cohort:
-            metadata["cohort"] = cohort
+        registered = failed = 0
+        for row in rows:
+            srrs = parse_srrs(row["ncbi_accession"])
+            if not srrs:
+                continue
+            sample_id = srrs_to_sample_id(srrs)
+            metadata = {
+                "bioproject": row["bioproject"],
+                "sra_study": row["sra_study"],
+                "sra_sample": row["sra_sample"],
+            }
+            if cohort:
+                metadata["cohort"] = cohort
 
-        resp = client.post(
-            "samples",
-            json={
-                "sample_id": sample_id,
-                "ncbi_accession": row["ncbi_accession"],
-                "biosample_id": row["biosample"],
-                "metadata": metadata,
-            },
-        )
-        if resp.status_code in (200, 201):
-            registered += 1
-        else:
-            failed += 1
-            click.echo(
-                f"  WARN: {sample_id} ({row['sra_sample']}): {resp.status_code} {resp.text}",
-                err=True,
+            resp = client.post(
+                "/api/samples",
+                json={
+                    "sample_id": sample_id,
+                    "ncbi_accession": row["ncbi_accession"],
+                    "biosample_id": row["biosample"],
+                    "metadata": metadata,
+                },
             )
+            if resp.status_code in (200, 201):
+                registered += 1
+            else:
+                failed += 1
+                click.echo(
+                    f"  WARN: {sample_id} ({row['sra_sample']}): {resp.status_code} {resp.text}",
+                    err=True,
+                )
 
     click.echo(f"Uploaded: {registered} registered, {failed} failed")
 

--- a/scripts/load_bioproject.py
+++ b/scripts/load_bioproject.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Load samples for a BioProject from the omicidx SRA parquet.
+
+Pulls (sra_sample, biosample, bioproject, sra_study, srr) rows from
+https://data-omicidx.cancerdatasci.org/sra/parquet/sra_accessions.parquet,
+groups SRRs into a sorted semicolon-joined list per sample, and either
+writes a TSV (same shape as ArtachoA_2021_sample.tsv) or POSTs directly
+to /api/samples on a running telemetry server.
+
+Usage:
+    uv run python scripts/load_bioproject.py PRJNA000000 -o samples.tsv
+    uv run python scripts/load_bioproject.py PRJNA000000 --server http://localhost:8000
+"""
+from __future__ import annotations
+
+import csv
+import sys
+from pathlib import Path
+
+import click
+import duckdb
+import httpx
+
+REPO_ROOT = Path(__file__).parent.parent
+PARQUET_URL = "https://data-omicidx.cancerdatasci.org/sra/parquet/sra_accessions.parquet"
+
+QUERY = """
+WITH filtered AS (
+    SELECT DISTINCT
+        sample AS sra_sample,
+        biosample,
+        bioproject,
+        study AS sra_study,
+        accession AS srr
+    FROM read_parquet(?)
+    WHERE bioproject = ? AND type = 'RUN'
+)
+SELECT
+    sra_sample,
+    biosample,
+    bioproject,
+    sra_study,
+    string_agg(srr, ';' ORDER BY srr) AS ncbi_accession
+FROM filtered
+GROUP BY sra_sample, biosample, bioproject, sra_study
+ORDER BY sra_sample
+"""
+
+COLUMNS = ["ncbi_accession", "sra_sample", "biosample", "bioproject", "sra_study"]
+
+
+def fetch_rows(bioproject: str) -> list[dict[str, str]]:
+    con = duckdb.connect(":memory:")
+    con.execute("SET enable_progress_bar = false")
+    cur = con.execute(QUERY, [PARQUET_URL, bioproject])
+    rows = cur.fetchall()
+    fields = [d[0] for d in cur.description]
+    return [dict(zip(fields, r)) for r in rows]
+
+
+def write_tsv(rows: list[dict[str, str]], out: Path | None) -> None:
+    f = out.open("w", newline="") if out else sys.stdout
+    try:
+        writer = csv.DictWriter(f, fieldnames=COLUMNS, delimiter="\t", extrasaction="ignore")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+    finally:
+        if out:
+            f.close()
+
+
+def upload_rows(rows: list[dict[str, str]], server: str, cohort: str | None) -> None:
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+    from nextflow_telemetry.utils import parse_srrs, srrs_to_sample_id
+
+    server = server.rstrip("/")
+    client = httpx.Client(base_url=f"{server}/api/", timeout=30)
+
+    try:
+        httpx.get(f"{server}/health", timeout=10).raise_for_status()
+    except Exception as e:
+        raise click.ClickException(f"cannot reach {server}: {e}")
+
+    registered = failed = 0
+    for row in rows:
+        srrs = parse_srrs(row["ncbi_accession"])
+        if not srrs:
+            continue
+        sample_id = srrs_to_sample_id(srrs)
+        metadata = {
+            "bioproject": row["bioproject"],
+            "sra_study": row["sra_study"],
+            "sra_sample": row["sra_sample"],
+        }
+        if cohort:
+            metadata["cohort"] = cohort
+
+        resp = client.post(
+            "samples",
+            json={
+                "sample_id": sample_id,
+                "ncbi_accession": row["ncbi_accession"],
+                "biosample_id": row["biosample"],
+                "metadata": metadata,
+            },
+        )
+        if resp.status_code in (200, 201):
+            registered += 1
+        else:
+            failed += 1
+            click.echo(
+                f"  WARN: {sample_id} ({row['sra_sample']}): {resp.status_code} {resp.text}",
+                err=True,
+            )
+
+    click.echo(f"Uploaded: {registered} registered, {failed} failed")
+
+
+@click.command()
+@click.argument("bioproject")
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(dir_okay=False, path_type=Path),
+    help="Write TSV here (default: stdout if --server not given).",
+)
+@click.option(
+    "--server",
+    help="Telemetry server URL. If set, uploads via POST /api/samples instead of writing TSV.",
+)
+@click.option("--cohort", help="Cohort label added to each sample's metadata.")
+def main(bioproject: str, output: Path | None, server: str | None, cohort: str | None) -> None:
+    """Load samples for BIOPROJECT (e.g. PRJNA694605) from the omicidx parquet."""
+    if output and server:
+        raise click.UsageError("--output and --server are mutually exclusive")
+
+    rows = fetch_rows(bioproject)
+    click.echo(f"Found {len(rows)} samples for {bioproject}", err=True)
+    if not rows:
+        return
+
+    if server:
+        upload_rows(rows, server, cohort)
+    else:
+        write_tsv(rows, output)
+        if output:
+            click.echo(f"Wrote {output}", err=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -208,6 +208,42 @@ wheels = [
 ]
 
 [[package]]
+name = "duckdb"
+version = "1.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/66/744b4931b799a42f8cb9bc7a6f169e7b8e51195b62b246db407fd90bf15f/duckdb-1.5.2.tar.gz", hash = "sha256:638da0d5102b6cb6f7d47f83d0600708ac1d3cb46c5e9aaabc845f9ba4d69246", size = 18017166, upload-time = "2026-04-13T11:30:09.065Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/b0/d13e7e396d86c245290b3e93f692a2d27c2fe99f857aaf9205003c00c978/duckdb-1.5.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7f69164b048e498b9e9140a24343108a5ae5f17bfb3485185f55fdf9b1aa924d", size = 30020978, upload-time = "2026-04-13T11:28:52.486Z" },
+    { url = "https://files.pythonhosted.org/packages/70/7b/ae1ec7f516394aa55501d1949af1f731be8d9d7433f0acc3f4632a0ba484/duckdb-1.5.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:81fc4fbf0b5e25840b39ba2a10b78c6953c0314d5d0434191e7898f34ab1bba3", size = 15947821, upload-time = "2026-04-13T11:28:55.981Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/a5/cae0105e01a85f85ead61723bb42dab14c2f8ec49f91e67a2372c02574a4/duckdb-1.5.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:56d38b3c4e0ef2abb58898d0fd423933999ed535c45e75e9d9f72e1d5fed69b8", size = 14201656, upload-time = "2026-04-13T11:28:58.316Z" },
+    { url = "https://files.pythonhosted.org/packages/50/db/46c57e8813ac33762bddc9545610ed648751c5b6a379abf2dc6035505ce4/duckdb-1.5.2-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:376856066c65ccd55fcb3a380bbe33a71ce089fc4623d229ffc6e82251afdb6d", size = 19285181, upload-time = "2026-04-13T11:29:01.041Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/a2/67694010693ec8c8c975e6991f48ef886d35ecbdaa2f287234882a403c21/duckdb-1.5.2-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c69907354ffee94ba8cf782daf0480dab7557f21ce27fffa6c0ea8f74ed4b8e2", size = 21394852, upload-time = "2026-04-13T11:29:03.814Z" },
+    { url = "https://files.pythonhosted.org/packages/52/9f/2b1618c5a93949a70dcf105293db7e27bb2b2cc4aeb1ff46b806f430ec81/duckdb-1.5.2-cp311-cp311-win_amd64.whl", hash = "sha256:d9b4f5430bf4f05d4c0dc4c55c75def3a5af4be0343be20fa2bfc577343fbfc9", size = 13095526, upload-time = "2026-04-13T11:29:06.265Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/e9/cb39e0d94a32f5333e819112fd01439a31f541f9c56a31b66f9bd209704b/duckdb-1.5.2-cp311-cp311-win_arm64.whl", hash = "sha256:2323c1195c10fb2bb982fc0218c730b43d1b92a355d61e68e3c5f3ac9d44c34f", size = 13946215, upload-time = "2026-04-13T11:29:08.672Z" },
+    { url = "https://files.pythonhosted.org/packages/41/de/ebe66bbe78125fc610f4fd415447a65349d94245950f3b3dfb31d028af02/duckdb-1.5.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e6495b00cad16888384119842797c49316a96ae1cb132bb03856d980d95afee1", size = 30064950, upload-time = "2026-04-13T11:29:11.468Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/8a/3e25b5d03bcf1fb99d189912f8ce92b1db4f9c8778e1b1f55745973a855a/duckdb-1.5.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d72b8856b1839d35648f38301b058f6232f4d36b463fe4dc8f4d3fdff2df1a2e", size = 15969113, upload-time = "2026-04-13T11:29:14.139Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bb/58001f0815002b1a93431bf907f77854085c7d049b83d521814a07b9db0b/duckdb-1.5.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2a1de4f4d454b8c97aec546c82003fc834d3422ce4bc6a19902f3462ef293bed", size = 14224774, upload-time = "2026-04-13T11:29:16.758Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/2f/a7f0de9509d1cef35608aeb382919041cdd70f58c173865c3da6a0d87979/duckdb-1.5.2-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce0b8141a10d37ecef729c45bc41d334854013f4389f1488bd6035c5579aaac1", size = 19313510, upload-time = "2026-04-13T11:29:19.574Z" },
+    { url = "https://files.pythonhosted.org/packages/26/78/eb1e064ea8b9df3b87b167bfd7a407b2f615a4291e06cba756727adfa06c/duckdb-1.5.2-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c99ef73a277c8921bc0a1f16dee38d924484251d9cfd20951748c20fcd5ed855", size = 21429692, upload-time = "2026-04-13T11:29:22.575Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/12/05b0c47d14839925c5e35b79081d918ca82e3f236bb724a6f58409dd5291/duckdb-1.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:8d599758b4e48bf12e18c9b960cf491d219f0c4972d19a45489c05cc5ab36f83", size = 13107594, upload-time = "2026-04-13T11:29:25.43Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2c/80558a82b236e044330e84a154b96aacddb343316b479f3d49be03ea11cb/duckdb-1.5.2-cp312-cp312-win_arm64.whl", hash = "sha256:fc85a5dbcbe6eccac1113c72370d1d3aacfdd49198d63950bdf7d8638a307f00", size = 13927537, upload-time = "2026-04-13T11:29:27.842Z" },
+    { url = "https://files.pythonhosted.org/packages/98/f2/e3d742808f138d374be4bb516fade3d1f33749b813650810ab7885cdc363/duckdb-1.5.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:4420b3f47027a7849d0e1815532007f377fa95ee5810b47ea717d35525c12f79", size = 30064879, upload-time = "2026-04-13T11:29:30.763Z" },
+    { url = "https://files.pythonhosted.org/packages/72/0d/f3dc1cf97e1267ca15e4307d456f96ce583961f0703fd75e62b2ad8d64fa/duckdb-1.5.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:bb42e6ed543902e14eae647850da24103a89f0bc2587dec5601b1c1f213bd2ed", size = 15969327, upload-time = "2026-04-13T11:29:33.481Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e0/d5418def53ae4e05a63075705ff44ed5af5a1a5932627eb2b600c5df1c93/duckdb-1.5.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:98c0535cd6d901f61a5ea3c2e26a1fd28482953d794deb183daf568e3aa5dda6", size = 14225107, upload-time = "2026-04-13T11:29:35.882Z" },
+    { url = "https://files.pythonhosted.org/packages/16/a7/15aaa59dbecc35e9711980fcdbf525b32a52470b32d18ef678193a146213/duckdb-1.5.2-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:486c862bf7f163c0110b6d85b3e5c031d224a671cca468f12ebb1d3a348f6b39", size = 19313433, upload-time = "2026-04-13T11:29:38.367Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/21/d903cc63a5140c822b7b62b373a87dc557e60c29b321dfb435061c5e67cf/duckdb-1.5.2-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70631c847ca918ee710ec874241b00cf9d2e5be90762cbb2a0389f17823c08f7", size = 21429837, upload-time = "2026-04-13T11:29:41.135Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/0a/b770d1f60c70597302130d6247f418549b7094251a02348fbaf1c7e147ae/duckdb-1.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:52a21823f3fbb52f0f0e5425e20b07391ad882464b955879499b5ff0b45a376b", size = 13107699, upload-time = "2026-04-13T11:29:43.905Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/cf/e200fe431d700962d1a908d2ce89f53ccee1cc8db260174ae663ba09686b/duckdb-1.5.2-cp313-cp313-win_arm64.whl", hash = "sha256:411ad438bd4140f189a10e7f515781335962c5d18bd07837dc6d202e3985253d", size = 13927646, upload-time = "2026-04-13T11:29:46.598Z" },
+    { url = "https://files.pythonhosted.org/packages/83/a1/f6286c67726cc1ea60a6e3c0d9fbc66527dde24ae089a51bbe298b13ca78/duckdb-1.5.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6b0fe75c148000f060aa1a27b293cacc0ea08cc1cad724fbf2143d56070a3785", size = 30078598, upload-time = "2026-04-13T11:29:49.828Z" },
+    { url = "https://files.pythonhosted.org/packages/de/6a/59febb02f21a4a5c6b0b0099ef7c965fdd5e61e4904cf813809bb792e35f/duckdb-1.5.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:35579b8e3a064b5eaf15b0eafc558056a13f79a0a62e34cc4baf57119daecfec", size = 15975120, upload-time = "2026-04-13T11:29:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/09/70/ce750854d37bb5a45cccbb2c3cb04df4af56aea8fc30a2499bb643b4a9c0/duckdb-1.5.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ea58ff5b0880593a280cf5511734b17711b32ee1f58b47d726e8600848358160", size = 14227762, upload-time = "2026-04-13T11:29:55.564Z" },
+    { url = "https://files.pythonhosted.org/packages/28/dc/ad45ac3c0b6c4687dc649e8f6cf01af1c8b0443932a39b2abb4ebcb3babd/duckdb-1.5.2-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef461bca07313412dc09961c4a4757a851f56b95ac01c58fac6007632b7b94f2", size = 19315668, upload-time = "2026-04-13T11:29:58.427Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/b1/1464f468d2e5813f5808de95df9d3113a645a5bfa2ffcaecbc542ddae272/duckdb-1.5.2-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be37680ddb380015cb37318e378c53511c45c4f0d8fac5599d22b7d092b9217a", size = 21434056, upload-time = "2026-04-13T11:30:01.238Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/32/6673607e024722473fa7aafdd29c0e3dd231dd528f6cd8b5797fbeeb229d/duckdb-1.5.2-cp314-cp314-win_amd64.whl", hash = "sha256:0b291786014df1133f8f18b9df4d004484613146e858d71a21791e0fcca16cf4", size = 13633667, upload-time = "2026-04-13T11:30:04.05Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/e3/9d34173ec068631faea3ea6e73050700729363e7e33306a9a3218e5cdc61/duckdb-1.5.2-cp314-cp314-win_arm64.whl", hash = "sha256:c9f3e0b71b8a50fccfb42794899285d9d318ce2503782b9dd54868e5ecd0ad31", size = 14402513, upload-time = "2026-04-13T11:30:06.609Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.115.14"
 source = { registry = "https://pypi.org/simple" }
@@ -565,6 +601,8 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "click" },
+    { name = "duckdb" },
     { name = "greenlet" },
     { name = "httpx" },
     { name = "mypy" },
@@ -588,6 +626,8 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "click", specifier = ">=8.1.0,<9.0.0" },
+    { name = "duckdb", specifier = ">=1.0.0,<2.0.0" },
     { name = "greenlet", specifier = ">=3.0.0" },
     { name = "httpx", specifier = ">=0.27.0,<0.28.0" },
     { name = "mypy", specifier = ">=1.8.0,<2.0.0" },


### PR DESCRIPTION
## Summary

- Adds `scripts/load_bioproject.py` — a click CLI that pulls samples for a BioProject from the omicidx public SRA parquet (via DuckDB) and either writes a TSV (matching the `seed_from_tsv.py` shape) or POSTs directly to `/api/samples` for fast experimentation.
- Adds `click` and `duckdb` to the dev dependency group.

Closes #49.

## Behaviour

- Filter parquet on `bioproject = ?` and `type = 'RUN'`.
- Distinct `(sample, biosample, bioproject, study, accession)` tuples.
- Aggregate run accessions into a sorted, semicolon-joined `ncbi_accession` per `(sra_sample, biosample, bioproject, sra_study)`.
- Output columns: `ncbi_accession`, `sra_sample`, `biosample`, `bioproject`, `sra_study`.

## Test plan

- [x] Verified end-to-end against `PRJNA682730` (the ArtachoA cohort) — 139 samples returned with the expected column shape.
- [ ] Manual upload-mode test against a running server (`--server http://localhost:8000`) once a deployment is handy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)