### PR TITLE
feat: /admin/stats endpoint + nf-client stats subcommand

### DIFF
--- a/packages/nf_client/src/nf_client/cli.py
+++ b/packages/nf_client/src/nf_client/cli.py
@@ -318,6 +318,38 @@ def daemon(
     typer.echo(f"\nDaemon finished after {run_number} run(s).")
 
 
+@app.command()
+def stats(
+    config: Path = config_option,
+) -> None:
+    """Print a summary of system state: samples, workflows, jobs/runs by status, DLQ."""
+
+    async def _run() -> dict:
+        cfg = ClientConfig.from_yaml(config)
+        async with JobClient(cfg) as client:
+            return await client.get_stats()
+
+    payload = asyncio.run(_run())
+
+    typer.echo(f"samples:   {payload['samples']}")
+    typer.echo(f"workflows: {payload['workflows']}")
+    typer.echo(f"dead-letter (unresolved): {payload['dead_letter_unresolved']}")
+
+    typer.echo("\njobs by status:")
+    if payload["jobs_by_status"]:
+        for status, count in sorted(payload["jobs_by_status"].items()):
+            typer.echo(f"  {status:<10} {count}")
+    else:
+        typer.echo("  (none)")
+
+    typer.echo("\nruns by status:")
+    if payload["runs_by_status"]:
+        for status, count in sorted(payload["runs_by_status"].items()):
+            typer.echo(f"  {status:<10} {count}")
+    else:
+        typer.echo("  (none)")
+
+
 @app.command(name="upload-logs")
 def upload_logs(
     config: Path = config_option,

--- a/packages/nf_client/src/nf_client/client.py
+++ b/packages/nf_client/src/nf_client/client.py
@@ -33,7 +33,11 @@ class JobClient:
     # ------------------------------------------------------------------
 
     async def __aenter__(self) -> "JobClient":
-        self._http = httpx.AsyncClient(base_url=self._config.server_url, timeout=30)
+        # httpx resolves relative paths against base_url per RFC 3986: without a
+        # trailing slash, the last segment of base_url is replaced. Force a trailing
+        # slash so callers can pass `.../api` or `.../api/` interchangeably.
+        base_url = self._config.server_url.rstrip("/") + "/"
+        self._http = httpx.AsyncClient(base_url=base_url, timeout=30)
         return self
 
     async def __aexit__(self, *_) -> None:

--- a/packages/nf_client/src/nf_client/client.py
+++ b/packages/nf_client/src/nf_client/client.py
@@ -97,6 +97,12 @@ class JobClient:
         except Exception:
             pass
 
+    async def get_stats(self) -> dict:
+        """Return the server's summary stats payload (samples, workflows, jobs/runs by status, DLQ)."""
+        response = await self._client.get("admin/stats")
+        response.raise_for_status()
+        return response.json()
+
     async def report_submitted(
         self,
         run_name: str,

--- a/src/nextflow_telemetry/routers/admin.py
+++ b/src/nextflow_telemetry/routers/admin.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 import datetime
 
 from fastapi import APIRouter, HTTPException
-from sqlalchemy import select, update
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncEngine
 
-from ..db import dead_letter_tbl, jobs_tbl, workflow_runs_tbl
+from ..db import dead_letter_tbl, jobs_tbl, samples_tbl, workflow_runs_tbl, workflows_tbl
 from ..services.reconcile import ReconcileService, sweep_run_incomplete
 
 
@@ -179,5 +179,44 @@ def create_admin_router(engine: AsyncEngine) -> APIRouter:
             )
 
         return {"requeued": len(job_ids)}
+
+    @router.get(
+        "/stats",
+        summary="Summary counts across the catalog and dispatch tables",
+        description=(
+            "Returns total sample/workflow counts, jobs grouped by status, "
+            "workflow runs grouped by status, and the count of unresolved "
+            "dead-letter entries. Lightweight — used by `nf-client stats` "
+            "to give operators a one-shot system overview."
+        ),
+    )
+    async def stats():
+        async with engine.begin() as conn:
+            samples_total = (await conn.execute(
+                select(func.count()).select_from(samples_tbl)
+            )).scalar_one()
+            workflows_total = (await conn.execute(
+                select(func.count()).select_from(workflows_tbl)
+            )).scalar_one()
+            jobs_rows = (await conn.execute(
+                select(jobs_tbl.c.status, func.count())
+                .group_by(jobs_tbl.c.status)
+            )).all()
+            runs_rows = (await conn.execute(
+                select(workflow_runs_tbl.c.status, func.count())
+                .group_by(workflow_runs_tbl.c.status)
+            )).all()
+            dlq_unresolved = (await conn.execute(
+                select(func.count()).select_from(dead_letter_tbl)
+                .where(dead_letter_tbl.c.resolved_at.is_(None))
+            )).scalar_one()
+
+        return {
+            "samples": samples_total,
+            "workflows": workflows_total,
+            "jobs_by_status": {status: count for status, count in jobs_rows},
+            "runs_by_status": {status: count for status, count in runs_rows},
+            "dead_letter_unresolved": dlq_unresolved,
+        }
 
     return router

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -674,9 +674,9 @@ def test_admin_stats_shape_and_increments(integration_client):
 
     sample_id = f"SRR-stats-{uuid.uuid4().hex[:6]}"
     wf_id = f"stats-{uuid.uuid4().hex[:6]}"
-    client.post("/api/samples", json={"sample_id": sample_id})
-    client.post("/api/workflows", json=_wf_payload(workflow_id=wf_id))
-    client.post("/api/admin/reconcile-jobs")
+    assert client.post("/api/samples", json={"sample_id": sample_id}).status_code == 201
+    assert client.post("/api/workflows", json=_wf_payload(workflow_id=wf_id)).status_code in (200, 201)
+    assert client.post("/api/admin/reconcile-jobs").status_code == 200
 
     after = client.get("/api/admin/stats").json()
     assert after["samples"] >= pre["samples"] + 1

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -655,3 +655,32 @@ def test_retry_then_success(integration_client, db_url):
         dead_letter_tbl.c.sample_id == sample_id,
     )))
     assert len(dlq) == 0, "no DLQ entry — job eventually succeeded"
+
+
+# ---------------------------------------------------------------------------
+# Admin stats
+# ---------------------------------------------------------------------------
+
+def test_admin_stats_shape_and_increments(integration_client):
+    client, _ = integration_client
+
+    before = client.get("/api/admin/stats")
+    assert before.status_code == 200
+    pre = before.json()
+    for key in ("samples", "workflows", "jobs_by_status", "runs_by_status", "dead_letter_unresolved"):
+        assert key in pre
+    assert isinstance(pre["jobs_by_status"], dict)
+    assert isinstance(pre["runs_by_status"], dict)
+
+    sample_id = f"SRR-stats-{uuid.uuid4().hex[:6]}"
+    wf_id = f"stats-{uuid.uuid4().hex[:6]}"
+    client.post("/api/samples", json={"sample_id": sample_id})
+    client.post("/api/workflows", json=_wf_payload(workflow_id=wf_id))
+    client.post("/api/admin/reconcile-jobs")
+
+    after = client.get("/api/admin/stats").json()
+    assert after["samples"] >= pre["samples"] + 1
+    assert after["workflows"] >= pre["workflows"] + 1
+    pending_before = pre["jobs_by_status"].get("pending", 0)
+    pending_after = after["jobs_by_status"].get("pending", 0)
+    assert pending_after >= pending_before + 1


### PR DESCRIPTION
## Summary

- Adds `GET /api/admin/stats` returning lightweight system-overview counts (samples, workflows, jobs by status, runs by status, unresolved DLQ).
- Adds `nf-client stats --config <path>` that prints a compact human-readable summary.
- Adds an integration test covering the endpoint shape and increments after creating a sample/workflow/reconcile.

Closes #51.

## Notes

- Out of scope: porting `scripts/seed_from_tsv.py` / `scripts/load_bioproject.py` into nf-client (would drag duckdb into HPC-node installs). See issue for rationale.
- Pre-existing main: most integration tests in `tests/test_integration.py` use unprefixed paths (`/admin/...`, `/samples`, ...) but routers are mounted under `/api`, so they currently 404. Not addressed here — the new test uses the correct `/api/...` prefix so it actually passes. Worth a separate cleanup PR to fix the rest.

## Test plan

- [x] `pytest tests/test_integration.py::test_admin_stats_shape_and_increments` passes against testcontainers postgres.
- [x] `nf-client --help` shows the `stats` subcommand.
- [ ] Run `nf-client stats --config <yaml>` against a live deployment to eyeball the output formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)