### PR TITLE
docs: sample metadata + publish/catalog design drafts

### DIFF
--- a/docs/publish-and-catalog-design.md
+++ b/docs/publish-and-catalog-design.md
@@ -1,0 +1,203 @@
+# Publish & catalog design
+
+> Status: **draft** — supersedes the experimental [`curatedMetagenomicDataETL`](https://github.com/seandavi/curatedMetagenomicDataETL) approach. Read alongside [`sample-metadata-design.md`](./sample-metadata-design.md): that doc is about sample *inputs* and harmonization; this one is about pipeline *outputs* and the analytical catalog.
+
+## Framing
+
+Three observations the design rests on:
+
+1. **The Nextflow pipeline's `publishDir` layout is fully deterministic from operational state telemetry already owns.**
+    ```
+    ${publish_base_dir}/${workflow.manifest.name}/${workflow.manifest.version}/${meta.sample}/[${branch}/]${step_name}/
+    ```
+    Every component is in `workflows` (`workflow_id`, `version`) or `samples` (`sample_id`) today. `jobs_tbl`'s `UniqueConstraint(sample_id, workflow_id, workflow_version)` is the publish-path identity. No new "analyses" entity is needed in the operational schema — it's already there, implicitly.
+
+2. **Telemetry is the operational source of truth.** It knows what samples exist, which jobs have completed, and (with one new column) where each job published its output. It can be the SoT for pipeline outputs in the catalog too — no separate ETL needs to discover them by globbing S3.
+
+3. **The group's analytical surface is moving toward DuckLake (DuckDB v1.0).** Postgres-backed catalog over parquet (and other) files in object storage. Multiple producers will share it: omicidx, bugsigdb, PMC fulltext (Dagster-managed); pipeline outputs (this design).
+
+What this rules out:
+- A separate ETL pipeline that globs S3 to discover what got produced (today's `curatedMetagenomicDataETL`).
+- A `sample_id_map.csv` artifact carried independently of telemetry.
+- Promoting taxonomic/marker counts into telemetry's Postgres schema. They live in object storage; the catalog points at them.
+- Routing pipeline-output cataloging through Dagster. The dependency graph is one edge (completion → register); telemetry already sits on the source side of that edge.
+
+What stays in scope:
+- A clear contract for the publish path.
+- A small change to telemetry's schema and HTTP surface so the catalog can be populated event-driven from completion.
+- A stable public parquet artifact at known URLs for external consumers.
+
+## Two layers
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  telemetry server (this repo) — operational SoT             │
+│  Postgres                                                    │
+│   - samples, workflows, jobs, workflow_runs, MARK_COMPLETE   │
+│   - + workflows.publish_base_uri                             │
+│  HTTP                                                        │
+│   - + GET /api/published                                     │
+│  On completion → write to catalog DB (idempotent, async)     │
+└──────────────────┬──────────────────────────────────────────┘
+                   │ catalog write
+                   ▼
+┌─────────────────────────────────────────────────────────────┐
+│  DuckLake catalog (DuckDB v1.0)                             │
+│  - same Postgres instance, separate database                 │
+│  - manifest + table metadata managed by DuckDB               │
+│  - reads pipeline outputs (TSV.gz) directly — no transform   │
+│  Other tenants (Dagster-published):                          │
+│  - omicidx (BioSample/BioProject/SRA)                        │
+│  - bugsigdb                                                  │
+│  - PMC fulltext                                              │
+└──────────────────┬──────────────────────────────────────────┘
+                   │ read access (group internal, ATTACH)
+                   ▼
+┌─────────────────────────────────────────────────────────────┐
+│  Public parquet artifact                                     │
+│  - periodic COPY from DuckLake views, full replace           │
+│  - stable URLs at s3://cmgd-export/<dataset>/study_name=…/  │
+│  - optional ATTACH-able cmgd.duckdb shim                     │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Telemetry-side changes
+
+Three concrete deltas, each independently shippable.
+
+### 1. `workflows.publish_base_uri`
+
+```python
+ALTER TABLE workflows
+    ADD COLUMN publish_base_uri text;     -- e.g. 's3://gs-cmgd-mirror'
+```
+
+Per `(workflow_id, version)`, nullable. NULL means "this workflow's outputs aren't cataloged" (test workflows, ad-hoc runs). Nullable rather than NOT NULL because the column has to backfill onto historical workflow rows that predate the catalog.
+
+Per-execution-site overrides (anvil → S3, google profile → GCS) are deferred. If they materialize as a real concern, the column moves to `workflow_runs`. For now we assume one publish location per (workflow, version).
+
+### 2. `GET /api/published`
+
+```
+GET /api/published?workflow_id=cmgd_nextflow&version=1.6.0&since=2026-05-01
+```
+
+Joins `jobs` (status=`completed`) × `samples` × `workflows`, returns:
+
+```json
+{
+  "items": [
+    {
+      "sample_id": "abc123…",
+      "run_ids": "SRR1;SRR2",
+      "sample_name": "…",
+      "study_name": "…",
+      "workflow_id": "cmgd_nextflow",
+      "workflow_version": "1.6.0",
+      "publish_prefix": "s3://gs-cmgd-mirror/cmgd_nextflow/1.6.0/abc123…",
+      "completed_at": "…"
+    }
+  ],
+  "next_since": "…"
+}
+```
+
+Useful even before DuckLake exists — it's a structured replacement for the current ETL's `glob() + split(file, '/')[7]` discovery path. Optional `?expand_steps=true` returns one row per `(sample × step)` with the full per-step prefix; the step list is a constant in code keyed by `workflow_id`.
+
+### 3. On-completion catalog write
+
+A new `CatalogPublisher` service called from the `MARK_COMPLETE → completed` transition. Connects to the catalog DB (separate connection string in `Settings`). Idempotent on `(workflow_id, version, sample_id)`. Failure to write does **not** roll back the completion — telemetry's operational state is authoritative; catalog drift is recoverable.
+
+Reconcile path: a periodic sweep finds completed jobs whose catalog rows are missing and registers them. Same pattern as `sweep_run_incomplete()`. Means a catalog DB outage causes no data loss, only delayed visibility.
+
+## DuckLake catalog
+
+### Location
+
+Same Postgres instance as telemetry, separate database. Avoids cross-cluster joins; keeps the operational and analytical schemas from contaminating each other (different consumers, different uptime profiles, different schema-evolution cadences).
+
+### Source format
+
+TSV.gz, read directly via DuckDB. **No conversion step.** The Nextflow pipeline's `publishDir` output is the on-disk SoT.
+
+### Logical tables
+
+DuckLake exposes one logical table per dataset (`marker_abundance`, `marker_presence`, `marker_rel_ab_w_read_stats`, `metaphlan_unknown_list`, `metaphlan_viruses_list`, future: `humann_genefamilies`, `humann_pathabundance`). Each is a DuckDB read over the union of TSV.gz files at the registered prefixes, joined to the catalog's identity columns (`sample_id`, `study_name`, `run_ids`).
+
+### Other tenants
+
+- **omicidx** — BioSample / BioProject / SRA metadata. Already used by `scripts/load_bioproject.py` (read from a parquet file). Dagster-published.
+- **bugsigdb** — curated microbial signatures.
+- **PMC fulltext** — pulled for harmonization downstream (see [`sample-metadata-design.md`](./sample-metadata-design.md)).
+
+All share the same DuckLake. Joins on accession (`run_id`, `study_id`, etc.) are first-class because every tenant publishes into the same catalog.
+
+## Public parquet artifact
+
+Group-internal users hit DuckLake. External consumers want stable parquet URLs without DuckLake / DuckDB-version dependencies. We keep that surface:
+
+- A periodic job (cron / Dagster sensor / cron-equivalent) runs:
+  ```sql
+  COPY (SELECT * FROM ducklake.marker_abundance)
+  TO 's3://cmgd-export/marker_abundance/'
+  (FORMAT PARQUET, PARTITION_BY 'study_name', COMPRESSION 'zstd');
+  ```
+  Full replace per dataset. No incremental machinery — at our scale a periodic full rewrite is simple and the right tradeoff vs. the operational complexity of incremental.
+- Stable URLs preserved: `s3://cmgd-export/<dataset>/study_name=…/` continues to be the public address (same shape `curatedMetagenomicDataETL` already publishes).
+- Optional `cmgd.duckdb` ATTACH-able shim at `https://minio.cancerdatasci.org/cmgd-export/cmgd.duckdb`, kept for backward compatibility with the existing public consumer entry point.
+
+This is the only surviving "ETL"-shaped step in the design, and it's a single `COPY` per dataset on a schedule.
+
+## What replaces `curatedMetagenomicDataETL`
+
+The repo's three jobs all become obsolete:
+
+| Today | Target |
+|---|---|
+| Glob `s3://gs-cmgd-mirror/**` + parse `split(file, '/')[7]` for `sample_id` | Telemetry catalog write at completion; `/api/published` for on-demand discovery |
+| Convert TSV.gz to partitioned parquet | DuckLake reads TSV.gz directly; public parquet is a periodic full-replace `COPY` |
+| Maintain `sample_id_map.csv` (4.6 MB checked in) | DuckLake view over `samples ⨝ curated_sample_annotations` |
+
+Migration:
+
+1. This repo gains `workflows.publish_base_uri` + `/api/published` + the catalog-write hook.
+2. DuckLake catalog stood up with one tenant (pipeline outputs).
+3. Public parquet generator runs alongside the existing ETL output for a transition window.
+4. Cross-check generated parquet against the existing public artifact; once verified equivalent, deprecate `curatedMetagenomicDataETL` and archive the repo. The public URL doesn't change.
+
+## Open questions
+
+1. **DuckLake's representation of TSV.gz as a logical table**: needs verification. DuckLake v1.0 is parquet-native; non-parquet inputs may need wrapping (a DuckDB view that reads via `read_csv`, registered as a logical table). Worst case we shim TSV.gz → parquet at registration time; that's a per-sample one-time cost, still no global ETL pass.
+2. **Catalog-write idempotency key**: probably `(workflow_id, workflow_version, sample_id)` — the same composite as `jobs_tbl`.
+3. **Schema evolution on MetaPhlAn version bumps**: if `marker_abundance` columns change, do we tag rows with the producing version, or partition logical tables per version so consumers opt in? Lean toward the latter — a `marker_abundance_v4` / `marker_abundance_v5` split with a union view. Avoids silent column drift across years of data.
+4. **Branch dimension**: the `full_data` / `rarefied_data` path component currently splits each step's output. Expose as a partition column on the logical table, or as separate logical tables (`marker_abundance` vs `marker_abundance_rarefied`)? Lean partition column — it's a small dimension and consumers will want both reachable.
+5. **Catalog-write failure mode**: synchronous (blocks completion-write but logged) vs. async (fire-and-forget with reconcile). Position above is async. Worth pushback if there's a reason completion shouldn't be observable until cataloged.
+6. **Public parquet generator location**: in this repo (sibling to `nf_client`), in a separate package, or as a Dagster asset on the existing instance? Lean in this repo for now (`packages/cmgd_publish/`?) — small enough that a separate repo is overhead. Migrating to Dagster later is mechanical if the catalog grows complex enough.
+7. **HUMAnN outputs**: not yet emitted by the pipeline (`skip_humann=true`). When that flips, the catalog gains gene-family / pathway tables. Reach-ready under this design — same publish-prefix → register pattern, just new step names.
+8. **Per-execution-site publish locations**: anvil → S3, google profile → GCS. Today's design assumes one location per (workflow, version). If multi-site execution is real, `publish_base_uri` moves to `workflow_runs`. Defer until it bites.
+
+## Suggested next steps
+
+Smallest first. Each independently shippable.
+
+1. **Migration: `workflows.publish_base_uri`** (trivial). One column. Backfill the existing workflow.
+2. **`GET /api/published`** (small). Read-only, joins existing tables. Useful pre-DuckLake.
+3. **DuckLake catalog DB scaffolding** (medium). New database, DuckDB-managed schema, connection settings.
+4. **Catalog-write hook on completion + reconcile sweep** (small). Mirrors existing service patterns.
+5. **Logical tables / views over pipeline outputs** (small per dataset).
+6. **Public parquet generator** (small). One `COPY` per dataset, scheduled.
+7. **Deprecate `curatedMetagenomicDataETL`** (after #6 is verified against the existing public artifact).
+
+That's the full telemetry-side roadmap for catalog publishing.
+
+## What this design explicitly does NOT do
+
+- No `analyses_tbl` in telemetry. The implicit `(jobs.completed × samples × workflows)` is sufficient.
+- No taxonomic / marker / functional tables in telemetry's Postgres.
+- No transform step in the ingestion path. TSV.gz stays as-is; the only conversion is the periodic public-parquet rewrite.
+- No Dagster integration in this repo. The existing group Dagster owns SRA/biosample metadata; pipeline outputs are catalog-side via telemetry directly.
+- No coupling between telemetry uptime and catalog availability. Catalog write failure is async and recoverable.
+- No incremental public-parquet machinery. Full replace is simple and cheap at our scale.
+- No Iceberg. DuckDB writes to Iceberg are not yet first-class; DuckLake is the chosen format.
+
+If a feature belongs in the analytical catalog, it doesn't belong in telemetry's Postgres schema. That's the line.

--- a/docs/sample-metadata-design.md
+++ b/docs/sample-metadata-design.md
@@ -1,0 +1,165 @@
+# Sample metadata — design positions
+
+> Status: **draft v2** — addresses #55 with a corrected framing: most samples have no curation, and metadata harmonization is a separate module from telemetry. Read the meta-issue first for context.
+
+## Framing
+
+Two facts that constrain the design:
+
+1. **Most samples have no curation.** Roughly 10× more samples will flow through this pipeline as bare SRA accessions (BioProject → samples loaded via `load_bioproject.py`) than as cMD-curated cohorts. The default sample carries SRA + BioSample-derived metadata only. cMD-style curated annotations are a minority overlay on top of a much larger raw substrate.
+
+2. **Telemetry is operational; harmonization is not.** The existing separation of `samples_tbl` (content-addressed, SRA-derivable) from `curated_sample_annotations_tbl` (cMD-format, manually curated) was deliberate. Harmonization — turning messy free-text metadata + abstracts into normalized, ontology-backed facets — should live in a **separate module with its own lifecycle**, not be baked into the telemetry server's schema.
+
+What this rules out:
+- Promoting harmonization tables (publications, vocabularies, provenance, conflict review) into the telemetry server's database.
+- Treating cMD's schema as the canonical sample-metadata shape. cMD is one of several inputs to harmonization.
+- Coupling dispatch / reconcile / orchestration to harmonization state (a "dispute" on a body_site field doesn't gate execution).
+
+What stays in scope:
+- A clear contract for what the telemetry server stores about samples.
+- A clear contract for what the harmonization module reads from telemetry and writes back (or doesn't).
+- An explicit boundary so we can build harmonization later without retrofitting telemetry.
+
+## Two layers
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  telemetry server (this repo)                               │
+│  - samples (content-addressed, SRA-derivable fields)        │
+│  - curated_sample_annotations (cMD TSV imports, JSONB)      │
+│  - jobs / runs / workflows / telemetry / process_metrics    │
+│  - dispatch / reconcile / completion                        │
+│  Operational. No LLM. No vocabularies. No publications.     │
+└──────────────────┬──────────────────────────────────────────┘
+                   │ read-only API: samples, accessions,
+                   │ curated_sample_annotations.metadata_
+                   ▼
+┌─────────────────────────────────────────────────────────────┐
+│  harmonization module (separate package/service)            │
+│  - publications (PMID/DOI, abstract, fulltext)              │
+│  - vocabularies (mirror of cMD data dictionary + OLS4)      │
+│  - sra_attributes (raw BioSample/SRA XML attributes)        │
+│  - harmonized_facets (LLM/rule-based normalized values      │
+│     with provenance, confidence, citations)                 │
+│  - review queue, accept/reject endpoints                    │
+│  Owns its own DB (or schema). Re-runnable. Versioned.       │
+└─────────────────────────────────────────────────────────────┘
+```
+
+The harmonization module **reads** from telemetry. It does not write back into telemetry tables. Consumers (frontends, downstream analysis) that want harmonized facets for a sample call the harmonization module directly, joining on `samples.sample_id`.
+
+## Telemetry-side data model (this repo)
+
+The minimum required to support the operational work, plus a small SRA-derived footprint so common queries don't require harmonization to be running.
+
+### `samples` (existing, mostly unchanged)
+
+Stays content-addressed (`sample_id` = md5 of sorted SRR list). Add a small set of columns that are **directly derivable from SRA/BioSample without any harmonization decisions**:
+
+```
+ALTER TABLE samples
+    ADD COLUMN organism text,             -- 'Homo sapiens' | 'Mus musculus' | NULL
+    ADD COLUMN library_strategy text,     -- WGS | AMPLICON | RNA-Seq | …  (SRA enum, verbatim)
+    ADD COLUMN library_source text,       -- METAGENOMIC | METATRANSCRIPTOMIC | …
+    ADD COLUMN platform text,             -- ILLUMINA | OXFORD_NANOPORE | …
+    ADD COLUMN instrument_model text,     -- 'Illumina NovaSeq 6000' (SRA verbatim)
+    ADD COLUMN total_spots bigint,
+    ADD COLUMN total_bases bigint;
+```
+
+These are SRA-canonical values, fetched once per accession at sample-registration time, populated verbatim from the SRA XML. **No vocabulary mapping, no LLM, no decisions** — if SRA says `ILLUMINA`, that's what we store. If a value is missing or ambiguous in SRA, the column is NULL. Used for:
+- Coarse dispatch filters (`organism = 'Homo sapiens'`)
+- Sanity checks ("are we accidentally claiming non-metagenomic samples?")
+- Sample browsing in the UI without round-tripping the harmonization module
+
+Not in scope for these columns: `body_site`, `disease`, `condition`, `host_phenotype`, anything controlled-vocabulary or interpretation-laden. Those live in harmonization.
+
+### `curated_sample_annotations` (existing, one column added)
+
+```
+ALTER TABLE curated_sample_annotations
+    ADD COLUMN cmd_sample_id text;        -- so cMD-format export can round-trip
+```
+
+The `metadata_` JSONB stays the verbatim TSV row. No schema change to the JSON shape. The harmonization module reads from here and uses it as one of its inputs; it does not write back.
+
+### `sra_attributes` (new — but lives where?)
+
+Raw BioSample/SRA XML attributes (the messy `key=value` pairs typed by submitters: `host_disease=ulcerative colitis`, `env_broad_scale=human-associated`, etc.) are needed by the harmonization module. **Open question**: do they live in the telemetry DB (because they're populated at sample-registration time, alongside the SRA-derivable columns above) or in the harmonization module's DB (because no operational code reads them)?
+
+Argued either way. **Position**: put them in the telemetry DB as a thin `sra_attributes(sample_id, attribute_name, attribute_value, source)` table — fetched at sample-registration time alongside the columns above, written-once. Pro: single fetch path, normalized location, frontends can show "raw SRA attributes" for any sample without touching harmonization. Con: telemetry DB grows by ~10–30 rows per sample. At our volumes this is fine.
+
+### Nothing else
+
+No publications. No vocabularies. No provenance. No `sample_field_*` tables. Those are harmonization's problem.
+
+## Harmonization module (separate, sketched)
+
+Not implementing now. Sketched to make the boundary explicit.
+
+### Lifecycle independence
+
+- **Separate package**: probably `packages/nf_harmonize/` or a sibling repo — TBD based on whether it ever needs different deploy targets.
+- **Separate database / schema**: probably its own Postgres database. Cross-DB joins are fine via FDW or a thin gateway service that joins server-side. Keeping schemas separate avoids accidentally treating harmonized facets as authoritative in operational queries.
+- **Separate release cadence**: prompts, models, and vocabularies change far more often than dispatch logic. Decoupling versioning means we can rev harmonization weekly without touching the telemetry server.
+- **Re-runnable**: a re-run on the same inputs with a new model produces a new result set. Old results stay accessible for evaluation and audit.
+
+### What it owns
+
+- `publications(pmid, doi, title, abstract, year, authors, fulltext_uri, fetched_at, raw_jsonb)`
+- `study_publications(study_name, pmid, role)` — only for studies that exist in `curated_sample_annotations`. Uncurated samples have no `study_name`.
+- `vocabulary_fields`, `vocabulary_terms` — mirror of cMD `cMD_data_dictionary.csv` + OLS4-resolved dynamic enums, pinned to a cMD repo SHA.
+- `harmonized_facets(sample_id, field, value, curie, source, source_evidence, confidence, model, status, set_at)` — append-only with status (`pending|accepted|rejected|superseded`).
+- Review-queue endpoints, accept/reject endpoints, harmonization-run records.
+
+### What it reads from telemetry
+
+- `samples` (the SRA-derivable columns + `sra_attributes`)
+- `curated_sample_annotations` (when present)
+- Sample identifiers (the cMD `study_name` for fetching the right paper(s))
+
+Read-only. Via stable HTTP API on the telemetry server. No direct DB joins across modules.
+
+### How consumers use it
+
+A frontend wanting to display "body_site" for a sample does **two** API calls (or one to a gateway): `GET /samples/{id}` → operational facts; `GET /harmonize/samples/{id}/facets` → harmonized values with provenance. The harmonization API can be missing entirely (module not deployed) and the operational layer still works.
+
+## cMD round-trip
+
+cMD's curated TSV format remains a first-class input and output, but it lives at the **boundary**, not the core:
+
+- **Input**: `seed_from_tsv.py` writes to `curated_sample_annotations.metadata_` verbatim. Already works.
+- **Output**: a `harmonize export-cmd --study=…` command (in the harmonization module, not telemetry) reads accepted facets + curated annotations + SRA-derivable fields, projects them onto the cMD4 schema, and emits a TSV. Validates against `OmicsMLRepoCuration::validate_data_against_schema()` as the last step.
+
+The export tool only runs against samples that have a `study_name` (i.e. exist in `curated_sample_annotations`). Uncurated samples never round-trip to cMD because they were never cMD samples to begin with.
+
+## Open questions
+
+- **`sra_attributes` location**: telemetry DB or harmonization DB? Position above is "telemetry," but worth pushback. The argument for "harmonization" is that nothing in the operational path reads attributes; the argument for "telemetry" is single-fetch-path and avoiding a network round-trip for any UI that wants to show raw SRA metadata.
+- **Harmonization deployment shape**: package-in-repo, sibling repo, or separately deployed service? Affects whether cross-DB queries are even an option. Smallest first: a Python package in `packages/nf_harmonize/` with its own SQLAlchemy metadata, deployed alongside the telemetry server, but using a separate DB connection string. Can be split out later if it grows.
+- **Module-to-module API shape**: REST gateway on the telemetry server (`/harmonize/*` mounted but proxy-only)? Or harmonization runs on its own port and clients are responsible for hitting both? The former is friendlier for frontends; the latter is purer.
+- **Subject identity across uncurated samples**: cMD's `subject_id` is curator-assigned. For the 10× uncurated case, we have no subjects — only BioSamples. Decide whether the harmonization module ever attempts subject inference (e.g. multiple BioSamples sharing a `host_subject_id` attribute) or stays sample-level only.
+- **Validator integration**: same question as before — Rscript sidecar invoking `OmicsMLRepoCuration` or Python port. Decide when the export path is built.
+
+## Suggested next steps (telemetry side only)
+
+Ordered, smallest first. Each is independently shippable.
+
+1. **SRA-derivable columns on `samples`** (small): migration adding `organism`, `library_strategy`, `library_source`, `platform`, `instrument_model`, `total_spots`, `total_bases`. Backfill via a `populate-from-sra` admin endpoint that fetches via E-utils for a list of `sample_id`s. `load_bioproject.py` populates them at registration time going forward. **High value, no harmonization dependency** — closes a gap that bites every uncurated-sample query.
+2. **`sra_attributes` table + populate-from-sra ingestion** (small): single new table. Same fetch path as #1, written in the same transaction. Sets up the substrate that harmonization will consume later. Operational value too: frontend can show raw SRA attributes for debugging.
+3. **`cmd_sample_id` column on `curated_sample_annotations`** (trivial): one column, populated by `seed_from_tsv.py`. Closes the cMD round-trip gap that exists today regardless of whether harmonization ever ships.
+
+That's it for the telemetry-side roadmap. The harmonization module is a separate planning exercise — once we have #1–#3 plus a handful of real samples loaded, we have everything the harmonization service needs to read, and we can scope its first ticket without changing this server.
+
+## What this design explicitly does NOT do
+
+- No publications table in the telemetry DB.
+- No vocabulary tables in the telemetry DB.
+- No `sample_field_provenance` table in the telemetry DB.
+- No conflict-review endpoints in the telemetry server.
+- No LLM dependencies in the telemetry server's deps tree.
+- No biome ontology (project is human + mouse).
+- No Temporal (shelved separately).
+- No cMD `sample_id` as a join key (curators use it, our content-addressed `sample_id` is the join key).
+
+If a feature appears in the harmonization-module section, it does not belong in the telemetry server. That's the line.


### PR DESCRIPTION
## Summary

Two complementary draft design docs covering the next two threads of work, sharing context with #55:

- **`docs/sample-metadata-design.md`** (input side). Telemetry stores SRA-derivable facts on samples and verbatim curated annotations. Harmonization (publications, vocabularies, normalized facets) lives in a separate module with its own lifecycle.
- **`docs/publish-and-catalog-design.md`** (output side). Telemetry becomes the operational SoT for pipeline outputs: one `publish_base_uri` per workflow, a `/api/published` read endpoint, and a catalog-write hook on completion that registers artifacts in a DuckLake catalog. Replaces the experimental `curatedMetagenomicDataETL` approach.

Both docs are drafts — they take positions and list open questions rather than locking in schema. A meta-issue will reference these once merged.

## Test plan

- [ ] Read both docs end-to-end
- [ ] Confirm framing of sample-metadata-design (curated annotations as a minority overlay; harmonization as separate module) still matches your view
- [ ] Confirm publish-and-catalog-design's positions (DuckLake over Iceberg; TSV.gz read directly; full-replace public parquet; no Dagster integration in this repo) match the constraints from our discussion

🤖 Generated with [Claude Code](https://claude.com/claude-code)