### PR TITLE
feat: run-lifecycle event endpoint + workflow_runs observability columns

### DIFF
--- a/src/nextflow_telemetry/db.py
+++ b/src/nextflow_telemetry/db.py
@@ -161,7 +161,7 @@ workflow_runs_tbl = Table(
     Column("last_heartbeat_at", DateTime(timezone=True), nullable=True),
     Column("last_known_slurm_state", Text, nullable=True),
     Column("slurm_reason", Text, nullable=True),
-    Column("slurm_exit_code", Integer, nullable=True),
+    Column("wrapper_exit_code", Integer, nullable=True),
     Column("wait_seconds", Integer, nullable=True),
     Column("nextflow_log_uploaded_at", DateTime(timezone=True), nullable=True),
     Index("ix_workflow_runs_status", "status"),

--- a/src/nextflow_telemetry/db.py
+++ b/src/nextflow_telemetry/db.py
@@ -157,6 +157,13 @@ workflow_runs_tbl = Table(
     Column("submitted_at", DateTime(timezone=True), nullable=True),
     Column("started_at", DateTime(timezone=True), nullable=True),
     Column("completed_at", DateTime(timezone=True), nullable=True),
+    # Run-lifecycle observability (issue #63 / meta #62)
+    Column("last_heartbeat_at", DateTime(timezone=True), nullable=True),
+    Column("last_known_slurm_state", Text, nullable=True),
+    Column("slurm_reason", Text, nullable=True),
+    Column("slurm_exit_code", Integer, nullable=True),
+    Column("wait_seconds", Integer, nullable=True),
+    Column("nextflow_log_uploaded_at", DateTime(timezone=True), nullable=True),
     Index("ix_workflow_runs_status", "status"),
     Index("ix_workflow_runs_claimed_at", "claimed_at"),
 )

--- a/src/nextflow_telemetry/main.py
+++ b/src/nextflow_telemetry/main.py
@@ -13,6 +13,7 @@ from .routers.curated import create_curated_router
 from .routers.daemons import create_daemons_router
 from .routers.dispatch import create_dispatch_router
 from .routers.process_metrics import create_process_metrics_router
+from .routers.runs import create_runs_router
 from .routers.samples import create_samples_router
 from .routers.task_logs import create_task_logs_router
 from .routers.workflows import create_workflows_router
@@ -61,6 +62,7 @@ app.include_router(create_admin_router(engine), prefix="/api")
 app.include_router(create_task_logs_router(engine), prefix="/api")
 app.include_router(create_daemons_router(engine), prefix="/api")
 app.include_router(create_curated_router(engine), prefix="/api")
+app.include_router(create_runs_router(engine), prefix="/api")
 
 
 @app.get(

--- a/src/nextflow_telemetry/migrations/versions/20260510_b1c2d3e4_workflow_runs_observability.py
+++ b/src/nextflow_telemetry/migrations/versions/20260510_b1c2d3e4_workflow_runs_observability.py
@@ -8,9 +8,13 @@ Adds run-lifecycle observability columns to workflow_runs (#62 / #63):
   - last_heartbeat_at        — wrapper-emitted heartbeat (Phase 3)
   - last_known_slurm_state   — most recent sacct state (Phase 4)
   - slurm_reason             — sacct Reason field on terminal state
-  - slurm_exit_code          — wrapper-reported exit code from nextflow run
+  - wrapper_exit_code        — exit code from `nextflow run` reported by the wrapper
   - wait_seconds             — queue wait, submit→start
   - nextflow_log_uploaded_at — sentinel: have we received the .nextflow.log?
+
+(A separate `slurm_exit_code` column may be added in Phase 4 once sacct
+polling is wired up — sacct's ExitCode is a different value populated by
+a different code path, and conflating the two has been confusing.)
 """
 from __future__ import annotations
 
@@ -30,7 +34,7 @@ def upgrade() -> None:
     op.add_column("workflow_runs", sa.Column("last_heartbeat_at", sa.DateTime(timezone=True), nullable=True))
     op.add_column("workflow_runs", sa.Column("last_known_slurm_state", sa.Text(), nullable=True))
     op.add_column("workflow_runs", sa.Column("slurm_reason", sa.Text(), nullable=True))
-    op.add_column("workflow_runs", sa.Column("slurm_exit_code", sa.Integer(), nullable=True))
+    op.add_column("workflow_runs", sa.Column("wrapper_exit_code", sa.Integer(), nullable=True))
     op.add_column("workflow_runs", sa.Column("wait_seconds", sa.Integer(), nullable=True))
     op.add_column("workflow_runs", sa.Column("nextflow_log_uploaded_at", sa.DateTime(timezone=True), nullable=True))
 
@@ -38,7 +42,7 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.drop_column("workflow_runs", "nextflow_log_uploaded_at")
     op.drop_column("workflow_runs", "wait_seconds")
-    op.drop_column("workflow_runs", "slurm_exit_code")
+    op.drop_column("workflow_runs", "wrapper_exit_code")
     op.drop_column("workflow_runs", "slurm_reason")
     op.drop_column("workflow_runs", "last_known_slurm_state")
     op.drop_column("workflow_runs", "last_heartbeat_at")

--- a/src/nextflow_telemetry/migrations/versions/20260510_b1c2d3e4_workflow_runs_observability.py
+++ b/src/nextflow_telemetry/migrations/versions/20260510_b1c2d3e4_workflow_runs_observability.py
@@ -1,0 +1,44 @@
+"""workflow_runs_observability
+
+Revision ID: b1c2d3e4
+Revises: a1b2c3d4
+Create Date: 2026-05-10
+
+Adds run-lifecycle observability columns to workflow_runs (#62 / #63):
+  - last_heartbeat_at        — wrapper-emitted heartbeat (Phase 3)
+  - last_known_slurm_state   — most recent sacct state (Phase 4)
+  - slurm_reason             — sacct Reason field on terminal state
+  - slurm_exit_code          — wrapper-reported exit code from nextflow run
+  - wait_seconds             — queue wait, submit→start
+  - nextflow_log_uploaded_at — sentinel: have we received the .nextflow.log?
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "b1c2d3e4"
+down_revision: Union[str, Sequence[str], None] = "a1b2c3d4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("workflow_runs", sa.Column("last_heartbeat_at", sa.DateTime(timezone=True), nullable=True))
+    op.add_column("workflow_runs", sa.Column("last_known_slurm_state", sa.Text(), nullable=True))
+    op.add_column("workflow_runs", sa.Column("slurm_reason", sa.Text(), nullable=True))
+    op.add_column("workflow_runs", sa.Column("slurm_exit_code", sa.Integer(), nullable=True))
+    op.add_column("workflow_runs", sa.Column("wait_seconds", sa.Integer(), nullable=True))
+    op.add_column("workflow_runs", sa.Column("nextflow_log_uploaded_at", sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("workflow_runs", "nextflow_log_uploaded_at")
+    op.drop_column("workflow_runs", "wait_seconds")
+    op.drop_column("workflow_runs", "slurm_exit_code")
+    op.drop_column("workflow_runs", "slurm_reason")
+    op.drop_column("workflow_runs", "last_known_slurm_state")
+    op.drop_column("workflow_runs", "last_heartbeat_at")

--- a/src/nextflow_telemetry/migrations/versions/20260510_b1c2d3e4_workflow_runs_observability.py
+++ b/src/nextflow_telemetry/migrations/versions/20260510_b1c2d3e4_workflow_runs_observability.py
@@ -5,9 +5,12 @@ Revises: a1b2c3d4
 Create Date: 2026-05-10
 
 Adds run-lifecycle observability columns to workflow_runs (#62 / #63):
-  - last_heartbeat_at        — wrapper-emitted heartbeat (Phase 3)
+  - last_heartbeat_at        — wrapper-emitted heartbeat (Phase 3); set to
+                               server receipt time, not client utc_time
   - last_known_slurm_state   — most recent sacct state (Phase 4)
-  - slurm_reason             — sacct Reason field on terminal state
+  - slurm_reason             — sacct Reason field for the most recent state
+                               event (cleared to NULL when the latest state
+                               event omits it; not just terminal states)
   - wrapper_exit_code        — exit code from `nextflow run` reported by the wrapper
   - wait_seconds             — queue wait, submit→start
   - nextflow_log_uploaded_at — sentinel: have we received the .nextflow.log?

--- a/src/nextflow_telemetry/models.py
+++ b/src/nextflow_telemetry/models.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Any, Optional
+from typing import Annotated, Any, Literal, Optional, Union
 import datetime
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -349,6 +349,116 @@ class WorkflowJobSummary(BaseModel):
     failed: int = Field(description="Jobs that exhausted retries and are marked failed.")
     dead_letter: int = Field(description="Jobs that were routed to the dead-letter queue.")
     completion_pct: float = Field(description="Percentage of jobs completed (0–100). Zero when total is 0.")
+
+
+# ---------------------------------------------------------------------------
+# Run-lifecycle event union (issue #62 / #63)
+#
+# These events are POSTed to /api/runs/{run_name}/event by the wrapper, the
+# pipeline (workflow.onComplete/onError), and the daemon (sacct polling).
+# Together with weblog they make the lifecycle of a Nextflow run observable
+# end-to-end: queue → wrapper start → nextflow start → tasks → wrapper exit.
+#
+# Every variant carries a `type` discriminator and a `utc_time` timestamp.
+# All other fields are variant-specific.
+# ---------------------------------------------------------------------------
+
+
+class _RunEventBase(BaseModel):
+    """Common fields on every run-lifecycle event."""
+    utc_time: datetime.datetime = Field(description="UTC timestamp when the event was emitted by the client.")
+
+
+class WrapperStartedEvent(_RunEventBase):
+    """Emitted by the bash wrapper / Python wrapper as the very first action.
+
+    Tells the server that something *began* the run, even before nextflow itself
+    starts. Useful when the run dies before any weblog event is sent.
+    """
+    type: Literal["wrapper_started"]
+    hostname: Optional[str] = Field(default=None, description="Hostname of the compute node executing the wrapper.")
+    slurm_job_id: Optional[str] = Field(default=None, description="SLURM job id, if running under SLURM.")
+
+
+class PreNextflowEvent(_RunEventBase):
+    """Emitted just before exec'ing nextflow, after the scheduler awarded a node.
+
+    `wait_seconds` is queue-wait (submit → start), useful for scheduler health.
+    """
+    type: Literal["pre_nextflow"]
+    hostname: Optional[str] = None
+    wait_seconds: Optional[int] = Field(default=None, description="Submit→start time on the scheduler, in seconds.")
+
+
+class WrapperExitedEvent(_RunEventBase):
+    """Emitted by the wrapper after nextflow has returned (any exit code).
+
+    `exit_code` is nextflow's own exit status. The wrapper should also upload
+    the .nextflow.log file as the multipart attachment named `nextflow_log`.
+    """
+    type: Literal["wrapper_exited"]
+    exit_code: Optional[int] = Field(default=None, description="Exit code from `nextflow run`.")
+    duration_seconds: Optional[int] = Field(default=None, description="Wall-clock seconds the wrapper ran.")
+
+
+class HeartbeatEvent(_RunEventBase):
+    """Emitted on a timer (e.g. every 60 s) while the wrapper is alive."""
+    type: Literal["heartbeat"]
+
+
+class SlurmStateEvent(_RunEventBase):
+    """Emitted by the daemon after polling `sacct -j <jobid>`.
+
+    Carries the latest scheduler-observed state: RUNNING, COMPLETED, FAILED,
+    TIMEOUT, OUT_OF_MEMORY, NODE_FAIL, PREEMPTED, etc.
+    """
+    type: Literal["slurm_state"]
+    state: str = Field(description="sacct State (e.g. RUNNING, COMPLETED, FAILED, TIMEOUT, OUT_OF_MEMORY).")
+    reason: Optional[str] = Field(default=None, description="sacct Reason field, if any.")
+
+
+class WorkflowOnCompleteEvent(_RunEventBase):
+    """Emitted by Nextflow's `workflow.onComplete` hook (Phase 2)."""
+    type: Literal["workflow_oncomplete"]
+    success: bool = Field(description="True if Nextflow considered the run successful.")
+    exit_status: Optional[int] = Field(default=None, description="Nextflow's reported exit status.")
+    duration_ms: Optional[int] = Field(default=None, description="Total wall-clock duration in milliseconds.")
+    error_message: Optional[str] = Field(default=None, description="Top-level error message, if any.")
+
+
+class WorkflowOnErrorEvent(_RunEventBase):
+    """Emitted by Nextflow's `workflow.onError` hook (Phase 2)."""
+    type: Literal["workflow_onerror"]
+    error_message: Optional[str] = None
+
+
+class WrapperLogEvent(_RunEventBase):
+    """A chunk of the wrapper's stdout/stderr (free-form text)."""
+    type: Literal["wrapper_log"]
+    stream: Literal["stdout", "stderr"]
+    text: str
+
+
+RunEvent = Annotated[
+    Union[
+        WrapperStartedEvent,
+        PreNextflowEvent,
+        WrapperExitedEvent,
+        HeartbeatEvent,
+        SlurmStateEvent,
+        WorkflowOnCompleteEvent,
+        WorkflowOnErrorEvent,
+        WrapperLogEvent,
+    ],
+    Field(discriminator="type"),
+]
+
+
+class RunEventResponse(BaseModel):
+    """Response from POST /api/runs/{run_name}/event."""
+    run_name: str
+    type: str
+    nextflow_log_uploaded: bool = Field(description="True if a .nextflow.log file was attached and stored.")
 
 
 class DaemonHeartbeat(BaseModel):

--- a/src/nextflow_telemetry/models.py
+++ b/src/nextflow_telemetry/models.py
@@ -397,7 +397,7 @@ class WrapperExitedEvent(_RunEventBase):
     the .nextflow.log file as the multipart attachment named `nextflow_log`.
     """
     type: Literal["wrapper_exited"]
-    exit_code: Optional[int] = Field(default=None, description="Exit code from `nextflow run`.")
+    exit_code: int = Field(description="Exit code from `nextflow run`. Required: a wrapper that knows nextflow has exited must know what it exited with.")
     duration_seconds: Optional[int] = Field(default=None, description="Wall-clock seconds the wrapper ran.")
 
 

--- a/src/nextflow_telemetry/routers/runs.py
+++ b/src/nextflow_telemetry/routers/runs.py
@@ -115,7 +115,12 @@ def create_runs_router(engine: AsyncEngine) -> APIRouter:
                     ).where(workflow_runs_tbl.c.run_name == run_name)
                 )
             ).mappings().first()
-            run_id = (existing["run_id"] if existing else None) or ""
+            # run_id is NOT NULL on telemetry. When the run is known we copy
+            # Nextflow's UUID; when it isn't (events arriving before the
+            # weblog 'started' event), we fall back to a unique-per-run
+            # sentinel so events for distinct runs never share a run_id.
+            existing_run_id = existing["run_id"] if existing else None
+            run_id = existing_run_id or f"pre-weblog:{run_name}"
             workflow_id = existing["workflow_id"] if existing else None
             workflow_version = existing["workflow_version"] if existing else None
 
@@ -132,8 +137,6 @@ def create_runs_router(engine: AsyncEngine) -> APIRouter:
                 )
 
             # 2. Append raw event to telemetry (same shape as weblog rows).
-            # run_id is NOT NULL; we use empty string as a sentinel when Nextflow
-            # hasn't sent its 'started' event yet.
             await conn.execute(
                 insert(telemetry_tbl).values(
                     run_id=run_id,

--- a/src/nextflow_telemetry/routers/runs.py
+++ b/src/nextflow_telemetry/routers/runs.py
@@ -38,7 +38,7 @@ from ..models import (
     WrapperLogEvent,
     WrapperStartedEvent,
 )
-from ..db import task_logs_tbl, telemetry_tbl, workflow_runs_tbl
+from ..db import telemetry_tbl, workflow_runs_tbl
 
 
 _MAX_NEXTFLOW_LOG_BYTES = 16 * 1024 * 1024  # 16 MB
@@ -63,8 +63,10 @@ def create_runs_router(engine: AsyncEngine) -> APIRouter:
             "`nextflow_log` file attachment is only meaningful for `wrapper_exited`; "
             "if present it is stored under the run's task_logs with a sentinel hash "
             "and `nextflow_log_uploaded_at` is set on `workflow_runs`. Re-uploading "
-            "the same log is idempotent. Posting events for an unknown run_name "
-            "upserts a workflow_runs row so events are never dropped."
+            "the same log is idempotent. Events for an unknown `run_name` are still "
+            "appended to the raw `telemetry` table so nothing is dropped, but no "
+            "`workflow_runs` row is created — summary fields only update for runs "
+            "already on record (typically created by the dispatch claim)."
         ),
     )
     async def post_run_event(
@@ -81,6 +83,18 @@ def create_runs_router(engine: AsyncEngine) -> APIRouter:
             parsed: RunEvent = _run_event_adapter.validate_python(payload)
         except ValidationError as e:
             raise HTTPException(status_code=422, detail=e.errors())
+
+        # Read and validate the optional .nextflow.log *outside* the DB transaction
+        # so we don't hold a connection / locks while decoding a 16 MB payload.
+        log_content_str: str | None = None
+        if isinstance(parsed, WrapperExitedEvent) and nextflow_log is not None:
+            raw = await nextflow_log.read()
+            if len(raw) > _MAX_NEXTFLOW_LOG_BYTES:
+                raise HTTPException(
+                    status_code=413,
+                    detail=f"nextflow_log exceeds {_MAX_NEXTFLOW_LOG_BYTES} byte limit.",
+                )
+            log_content_str = raw.decode("utf-8", errors="replace")
 
         log_uploaded = False
         now = datetime.now(timezone.utc)
@@ -124,14 +138,7 @@ def create_runs_router(engine: AsyncEngine) -> APIRouter:
             await _apply_summary_update(conn, run_name, parsed, now)
 
             # 4. Optional .nextflow.log attachment (only on wrapper_exited)
-            if isinstance(parsed, WrapperExitedEvent) and nextflow_log is not None:
-                raw = await nextflow_log.read()
-                if len(raw) > _MAX_NEXTFLOW_LOG_BYTES:
-                    raise HTTPException(
-                        status_code=413,
-                        detail=f"nextflow_log exceeds {_MAX_NEXTFLOW_LOG_BYTES} byte limit.",
-                    )
-                content_str = raw.decode("utf-8", errors="replace")
+            if log_content_str is not None:
                 await conn.execute(
                     text(
                         """
@@ -145,7 +152,7 @@ def create_runs_router(engine: AsyncEngine) -> APIRouter:
                         "run_name": run_name,
                         "task_hash": _NEXTFLOW_LOG_SENTINEL_HASH,
                         "log_type": _NEXTFLOW_LOG_TYPE,
-                        "content": content_str,
+                        "content": log_content_str,
                         "uploaded_at": now,
                     },
                 )

--- a/src/nextflow_telemetry/routers/runs.py
+++ b/src/nextflow_telemetry/routers/runs.py
@@ -1,0 +1,216 @@
+"""Run-lifecycle event router (issues #62, #63).
+
+Clients (the wrapper, the pipeline, the daemon) POST events to
+`/api/runs/{run_name}/event` to describe what is happening *outside* of the
+weblog stream — wrapper start/exit, heartbeats, scheduler state, the
+Nextflow log itself.
+
+Events are stored two ways:
+
+1. Raw, append-only, in `telemetry_tbl` — same shape as weblog events so
+   downstream queries that read the table see one continuous stream.
+2. Denormalised summary fields on `workflow_runs` — fast dashboard reads
+   without scanning the raw event log.
+
+The .nextflow.log (when attached to `wrapper_exited`) is stored in
+`task_logs_tbl` with a sentinel hash so the existing log viewer can serve it.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Annotated
+
+from fastapi import APIRouter, File, Form, HTTPException, Path, UploadFile
+from pydantic import TypeAdapter, ValidationError
+from sqlalchemy import insert, select, text, update
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from ..models import (
+    HeartbeatEvent,
+    PreNextflowEvent,
+    RunEvent,
+    RunEventResponse,
+    SlurmStateEvent,
+    WorkflowOnCompleteEvent,
+    WorkflowOnErrorEvent,
+    WrapperExitedEvent,
+    WrapperLogEvent,
+    WrapperStartedEvent,
+)
+from ..db import task_logs_tbl, telemetry_tbl, workflow_runs_tbl
+
+
+_MAX_NEXTFLOW_LOG_BYTES = 16 * 1024 * 1024  # 16 MB
+_NEXTFLOW_LOG_SENTINEL_HASH = "nextflow_log"
+_NEXTFLOW_LOG_TYPE = "nextflow_log"
+
+_run_event_adapter: TypeAdapter[RunEvent] = TypeAdapter(RunEvent)
+
+
+def create_runs_router(engine: AsyncEngine) -> APIRouter:
+    router = APIRouter(prefix="/runs", tags=["runs"])
+
+    @router.post(
+        "/{run_name}/event",
+        response_model=RunEventResponse,
+        status_code=201,
+        summary="Record a run-lifecycle event",
+        description=(
+            "Append a wrapper / pipeline-hook / daemon event for a Nextflow run. "
+            "The event body is a JSON-encoded string posted as the `event` form "
+            "field; its `type` discriminator selects the variant. An optional "
+            "`nextflow_log` file attachment is only meaningful for `wrapper_exited`; "
+            "if present it is stored under the run's task_logs with a sentinel hash "
+            "and `nextflow_log_uploaded_at` is set on `workflow_runs`. Re-uploading "
+            "the same log is idempotent. Posting events for an unknown run_name "
+            "upserts a workflow_runs row so events are never dropped."
+        ),
+    )
+    async def post_run_event(
+        run_name: Annotated[str, Path(description="Nextflow run name (matches workflow_runs.run_name).")],
+        event: Annotated[str, Form(description="JSON-encoded run event; `type` selects the variant.")],
+        nextflow_log: Annotated[UploadFile | None, File(description="Optional .nextflow.log; honoured on `wrapper_exited`.")] = None,
+    ) -> RunEventResponse:
+        try:
+            payload = json.loads(event)
+        except json.JSONDecodeError as e:
+            raise HTTPException(status_code=422, detail=f"event field is not valid JSON: {e}")
+
+        try:
+            parsed: RunEvent = _run_event_adapter.validate_python(payload)
+        except ValidationError as e:
+            raise HTTPException(status_code=422, detail=e.errors())
+
+        log_uploaded = False
+        now = datetime.now(timezone.utc)
+
+        async with engine.begin() as conn:
+            # 1. Resolve workflow_id / version / run_id from the existing
+            # workflow_runs row if known. run_id is Nextflow's own UUID which
+            # we don't have at wrapper time — we copy whatever has been recorded
+            # from a prior weblog 'started' event so events join cleanly.
+            existing = (
+                await conn.execute(
+                    select(
+                        workflow_runs_tbl.c.run_id,
+                        workflow_runs_tbl.c.workflow_id,
+                        workflow_runs_tbl.c.workflow_version,
+                    ).where(workflow_runs_tbl.c.run_name == run_name)
+                )
+            ).mappings().first()
+            run_id = (existing["run_id"] if existing else None) or ""
+            workflow_id = existing["workflow_id"] if existing else None
+            workflow_version = existing["workflow_version"] if existing else None
+
+            # 2. Append raw event to telemetry (same shape as weblog rows).
+            # run_id is NOT NULL; we use empty string as a sentinel when Nextflow
+            # hasn't sent its 'started' event yet.
+            await conn.execute(
+                insert(telemetry_tbl).values(
+                    run_id=run_id,
+                    run_name=run_name,
+                    event=f"run_{parsed.type}",
+                    utc_time=parsed.utc_time,
+                    sample_id=None,
+                    workflow_id=workflow_id,
+                    workflow_version=workflow_version,
+                    metadata_=parsed.model_dump(mode="json"),
+                    trace=None,
+                )
+            )
+
+            # 3. Update workflow_runs summary columns by event variant
+            await _apply_summary_update(conn, run_name, parsed, now)
+
+            # 4. Optional .nextflow.log attachment (only on wrapper_exited)
+            if isinstance(parsed, WrapperExitedEvent) and nextflow_log is not None:
+                raw = await nextflow_log.read()
+                if len(raw) > _MAX_NEXTFLOW_LOG_BYTES:
+                    raise HTTPException(
+                        status_code=413,
+                        detail=f"nextflow_log exceeds {_MAX_NEXTFLOW_LOG_BYTES} byte limit.",
+                    )
+                content_str = raw.decode("utf-8", errors="replace")
+                await conn.execute(
+                    text(
+                        """
+                        INSERT INTO task_logs (run_name, task_hash, log_type, content, uploaded_at)
+                        VALUES (:run_name, :task_hash, :log_type, :content, :uploaded_at)
+                        ON CONFLICT ON CONSTRAINT uq_task_log
+                        DO UPDATE SET content = EXCLUDED.content, uploaded_at = EXCLUDED.uploaded_at
+                        """
+                    ),
+                    {
+                        "run_name": run_name,
+                        "task_hash": _NEXTFLOW_LOG_SENTINEL_HASH,
+                        "log_type": _NEXTFLOW_LOG_TYPE,
+                        "content": content_str,
+                        "uploaded_at": now,
+                    },
+                )
+                await conn.execute(
+                    update(workflow_runs_tbl)
+                    .where(workflow_runs_tbl.c.run_name == run_name)
+                    .values(nextflow_log_uploaded_at=now)
+                )
+                log_uploaded = True
+
+        return RunEventResponse(
+            run_name=run_name,
+            type=parsed.type,
+            nextflow_log_uploaded=log_uploaded,
+        )
+
+    return router
+
+
+async def _apply_summary_update(conn, run_name: str, parsed: RunEvent, now: datetime) -> None:
+    """Apply event-type-specific updates to workflow_runs summary columns.
+
+    No-ops if the variant carries no summary-relevant fields. Out-of-order
+    events do not roll back forward-looking state (e.g. a late `pre_nextflow`
+    after `wrapper_exited` does not reopen the run); each variant only writes
+    its own narrow fields.
+
+    Raw events are always recorded in telemetry_tbl by the caller. If no
+    workflow_runs row exists yet (e.g. a wrapper raced ahead of the claim
+    record), summary updates are silently skipped — operators can still
+    query telemetry_tbl directly to recover the event stream.
+    """
+    if isinstance(parsed, WrapperStartedEvent):
+        # Mark the run as "submitted" only if it's still in the earlier "claimed" state.
+        # We don't want to roll status back from running/completed.
+        await conn.execute(
+            update(workflow_runs_tbl)
+            .where(
+                workflow_runs_tbl.c.run_name == run_name,
+                workflow_runs_tbl.c.status == "claimed",
+            )
+            .values(status="submitted", submitted_at=now)
+        )
+        return
+
+    values: dict = {}
+    if isinstance(parsed, PreNextflowEvent):
+        if parsed.wait_seconds is not None:
+            values["wait_seconds"] = parsed.wait_seconds
+    elif isinstance(parsed, WrapperExitedEvent):
+        if parsed.exit_code is not None:
+            values["slurm_exit_code"] = parsed.exit_code
+    elif isinstance(parsed, HeartbeatEvent):
+        values["last_heartbeat_at"] = parsed.utc_time
+    elif isinstance(parsed, SlurmStateEvent):
+        values["last_known_slurm_state"] = parsed.state
+        if parsed.reason is not None:
+            values["slurm_reason"] = parsed.reason
+    # WorkflowOnComplete/OnError/WrapperLog have no summary columns — only the raw row matters.
+
+    if not values:
+        return
+
+    await conn.execute(
+        update(workflow_runs_tbl)
+        .where(workflow_runs_tbl.c.run_name == run_name)
+        .values(**values)
+    )

--- a/src/nextflow_telemetry/routers/runs.py
+++ b/src/nextflow_telemetry/routers/runs.py
@@ -88,8 +88,18 @@ def create_runs_router(engine: AsyncEngine) -> APIRouter:
 
         # Read and validate the optional .nextflow.log *outside* the DB transaction
         # so we don't hold a connection / locks while decoding a 16 MB payload.
+        # Reject attachments on non-wrapper_exited events outright — clients
+        # should never attach a log to a heartbeat or slurm_state.
         log_content_str: str | None = None
-        if isinstance(parsed, WrapperExitedEvent) and nextflow_log is not None:
+        if nextflow_log is not None:
+            if not isinstance(parsed, WrapperExitedEvent):
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        "nextflow_log attachment is only valid on wrapper_exited events; "
+                        f"received it with type={parsed.type}."
+                    ),
+                )
             raw = await nextflow_log.read()
             if len(raw) > _MAX_NEXTFLOW_LOG_BYTES:
                 raise HTTPException(
@@ -221,10 +231,13 @@ async def _apply_summary_update(conn, run_name: str, parsed: RunEvent, now: date
         if parsed.wait_seconds is not None:
             values["wait_seconds"] = parsed.wait_seconds
     elif isinstance(parsed, WrapperExitedEvent):
-        if parsed.exit_code is not None:
-            values["wrapper_exit_code"] = parsed.exit_code
+        values["wrapper_exit_code"] = parsed.exit_code
     elif isinstance(parsed, HeartbeatEvent):
-        values["last_heartbeat_at"] = parsed.utc_time
+        # Use server receipt time, not the client-supplied utc_time. Heartbeat
+        # staleness is "how recently did we hear from this wrapper?" — answering
+        # that with a clock the wrapper itself controls is unreliable when its
+        # clock drifts or events arrive out of order.
+        values["last_heartbeat_at"] = now
     elif isinstance(parsed, SlurmStateEvent):
         # `slurm_reason` is reset on every state event (including to NULL when
         # the new event omits it) so the column always reflects the *current*

--- a/src/nextflow_telemetry/routers/runs.py
+++ b/src/nextflow_telemetry/routers/runs.py
@@ -66,7 +66,9 @@ def create_runs_router(engine: AsyncEngine) -> APIRouter:
             "the same log is idempotent. Events for an unknown `run_name` are still "
             "appended to the raw `telemetry` table so nothing is dropped, but no "
             "`workflow_runs` row is created — summary fields only update for runs "
-            "already on record (typically created by the dispatch claim)."
+            "already on record (typically created by the dispatch claim). "
+            "A `nextflow_log` attachment requires a known `run_name`; otherwise the "
+            "request fails with 404 to avoid orphan log rows."
         ),
     )
     async def post_run_event(
@@ -117,6 +119,18 @@ def create_runs_router(engine: AsyncEngine) -> APIRouter:
             workflow_id = existing["workflow_id"] if existing else None
             workflow_version = existing["workflow_version"] if existing else None
 
+            # If a .nextflow.log was attached but no workflow_runs row exists,
+            # 404 — storing it would orphan the row and the response would
+            # falsely claim the upload succeeded against a known run.
+            if log_content_str is not None and existing is None:
+                raise HTTPException(
+                    status_code=404,
+                    detail=(
+                        f"No workflow_runs row for '{run_name}'; refusing to store "
+                        "nextflow_log attachment as an orphan."
+                    ),
+                )
+
             # 2. Append raw event to telemetry (same shape as weblog rows).
             # run_id is NOT NULL; we use empty string as a sentinel when Nextflow
             # hasn't sent its 'started' event yet.
@@ -137,7 +151,8 @@ def create_runs_router(engine: AsyncEngine) -> APIRouter:
             # 3. Update workflow_runs summary columns by event variant
             await _apply_summary_update(conn, run_name, parsed, now)
 
-            # 4. Optional .nextflow.log attachment (only on wrapper_exited)
+            # 4. Optional .nextflow.log attachment (only on wrapper_exited).
+            # Existence of the run row was verified above.
             if log_content_str is not None:
                 await conn.execute(
                     text(
@@ -204,13 +219,15 @@ async def _apply_summary_update(conn, run_name: str, parsed: RunEvent, now: date
             values["wait_seconds"] = parsed.wait_seconds
     elif isinstance(parsed, WrapperExitedEvent):
         if parsed.exit_code is not None:
-            values["slurm_exit_code"] = parsed.exit_code
+            values["wrapper_exit_code"] = parsed.exit_code
     elif isinstance(parsed, HeartbeatEvent):
         values["last_heartbeat_at"] = parsed.utc_time
     elif isinstance(parsed, SlurmStateEvent):
+        # `slurm_reason` is reset on every state event (including to NULL when
+        # the new event omits it) so the column always reflects the *current*
+        # scheduler state, not a stale reason from an earlier transition.
         values["last_known_slurm_state"] = parsed.state
-        if parsed.reason is not None:
-            values["slurm_reason"] = parsed.reason
+        values["slurm_reason"] = parsed.reason
     # WorkflowOnComplete/OnError/WrapperLog have no summary columns — only the raw row matters.
 
     if not values:

--- a/tests/test_runs_router.py
+++ b/tests/test_runs_router.py
@@ -1,0 +1,411 @@
+"""Integration tests for the run-lifecycle event router (POST /api/runs/{run_name}/event).
+
+Spec: issue #63. Tests use the shared testcontainers postgres fixture from
+conftest.py (no mocks).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import insert, select
+from sqlalchemy.ext.asyncio import create_async_engine
+
+
+def _make_run_name() -> str:
+    return f"test-{uuid.uuid4().hex[:12]}"
+
+
+def _ts() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+async def _query(db_url: str, stmt):
+    engine = create_async_engine(db_url)
+    try:
+        async with engine.connect() as conn:
+            return (await conn.execute(stmt)).mappings().all()
+    finally:
+        await engine.dispose()
+
+
+async def _exec(db_url: str, *stmts):
+    engine = create_async_engine(db_url)
+    try:
+        async with engine.begin() as conn:
+            for stmt in stmts:
+                await conn.execute(stmt)
+    finally:
+        await engine.dispose()
+
+
+def _seed_run(db_url: str, run_name: str, *, status: str = "claimed") -> None:
+    from nextflow_telemetry.db import workflow_runs_tbl
+    _run(_exec(
+        db_url,
+        insert(workflow_runs_tbl).values(
+            run_name=run_name,
+            workflow_id="curatedMetagenomics",
+            workflow_version="1.0.0",
+            status=status,
+        ),
+    ))
+
+
+def _post_event(client, run_name: str, body: dict, *, file: tuple | None = None):
+    payload: dict = {"data": {"event": json.dumps(body)}}
+    if file is not None:
+        payload["files"] = {"nextflow_log": file}
+    return client.post(f"/api/runs/{run_name}/event", **payload)
+
+
+# ---------------------------------------------------------------------------
+# Each event type round-trips into telemetry_tbl + the right summary update
+# ---------------------------------------------------------------------------
+
+def test_wrapper_started_promotes_claimed_to_submitted(integration_client, db_url):
+    from nextflow_telemetry.db import telemetry_tbl, workflow_runs_tbl
+
+    client, _ = integration_client
+    run_name = _make_run_name()
+    _seed_run(db_url, run_name, status="claimed")
+
+    resp = _post_event(client, run_name, {
+        "type": "wrapper_started",
+        "utc_time": _ts(),
+        "hostname": "compute-01",
+        "slurm_job_id": "12345",
+    })
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["type"] == "wrapper_started"
+    assert body["nextflow_log_uploaded"] is False
+
+    rows = _run(_query(db_url, select(workflow_runs_tbl).where(
+        workflow_runs_tbl.c.run_name == run_name
+    )))
+    assert rows[0]["status"] == "submitted"
+    assert rows[0]["submitted_at"] is not None
+
+    tel_rows = _run(_query(db_url, select(telemetry_tbl).where(
+        telemetry_tbl.c.run_name == run_name
+    )))
+    assert len(tel_rows) == 1
+    assert tel_rows[0]["event"] == "run_wrapper_started"
+    assert tel_rows[0]["metadata_"]["hostname"] == "compute-01"
+
+
+def test_wrapper_started_does_not_roll_back_running_state(integration_client, db_url):
+    from nextflow_telemetry.db import workflow_runs_tbl
+
+    client, _ = integration_client
+    run_name = _make_run_name()
+    _seed_run(db_url, run_name, status="running")
+
+    resp = _post_event(client, run_name, {
+        "type": "wrapper_started",
+        "utc_time": _ts(),
+    })
+    assert resp.status_code == 201
+
+    rows = _run(_query(db_url, select(workflow_runs_tbl).where(
+        workflow_runs_tbl.c.run_name == run_name
+    )))
+    assert rows[0]["status"] == "running"  # unchanged
+
+
+def test_pre_nextflow_records_wait_seconds(integration_client, db_url):
+    from nextflow_telemetry.db import workflow_runs_tbl
+
+    client, _ = integration_client
+    run_name = _make_run_name()
+    _seed_run(db_url, run_name)
+
+    resp = _post_event(client, run_name, {
+        "type": "pre_nextflow",
+        "utc_time": _ts(),
+        "wait_seconds": 312,
+    })
+    assert resp.status_code == 201
+
+    rows = _run(_query(db_url, select(workflow_runs_tbl).where(
+        workflow_runs_tbl.c.run_name == run_name
+    )))
+    assert rows[0]["wait_seconds"] == 312
+
+
+def test_heartbeat_updates_last_heartbeat_at(integration_client, db_url):
+    from nextflow_telemetry.db import workflow_runs_tbl
+
+    client, _ = integration_client
+    run_name = _make_run_name()
+    _seed_run(db_url, run_name)
+
+    resp = _post_event(client, run_name, {
+        "type": "heartbeat",
+        "utc_time": _ts(),
+    })
+    assert resp.status_code == 201
+
+    rows = _run(_query(db_url, select(workflow_runs_tbl).where(
+        workflow_runs_tbl.c.run_name == run_name
+    )))
+    assert rows[0]["last_heartbeat_at"] is not None
+
+
+def test_slurm_state_records_state_and_reason(integration_client, db_url):
+    from nextflow_telemetry.db import workflow_runs_tbl
+
+    client, _ = integration_client
+    run_name = _make_run_name()
+    _seed_run(db_url, run_name)
+
+    resp = _post_event(client, run_name, {
+        "type": "slurm_state",
+        "utc_time": _ts(),
+        "state": "TIMEOUT",
+        "reason": "WallTimeLimit",
+    })
+    assert resp.status_code == 201
+
+    rows = _run(_query(db_url, select(workflow_runs_tbl).where(
+        workflow_runs_tbl.c.run_name == run_name
+    )))
+    assert rows[0]["last_known_slurm_state"] == "TIMEOUT"
+    assert rows[0]["slurm_reason"] == "WallTimeLimit"
+
+
+def test_wrapper_exited_records_exit_code(integration_client, db_url):
+    from nextflow_telemetry.db import workflow_runs_tbl
+
+    client, _ = integration_client
+    run_name = _make_run_name()
+    _seed_run(db_url, run_name)
+
+    resp = _post_event(client, run_name, {
+        "type": "wrapper_exited",
+        "utc_time": _ts(),
+        "exit_code": 137,
+        "duration_seconds": 1842,
+    })
+    assert resp.status_code == 201
+    assert resp.json()["nextflow_log_uploaded"] is False
+
+    rows = _run(_query(db_url, select(workflow_runs_tbl).where(
+        workflow_runs_tbl.c.run_name == run_name
+    )))
+    assert rows[0]["slurm_exit_code"] == 137
+
+
+def test_wrapper_exited_with_attached_log_stores_in_task_logs(integration_client, db_url):
+    from nextflow_telemetry.db import task_logs_tbl, workflow_runs_tbl
+
+    client, _ = integration_client
+    run_name = _make_run_name()
+    _seed_run(db_url, run_name)
+
+    log_content = "Sep 09 12:34:56 - DEBUG - Nextflow starting\n... rest of log ...\n"
+
+    resp = _post_event(
+        client,
+        run_name,
+        {"type": "wrapper_exited", "utc_time": _ts(), "exit_code": 0},
+        file=("nextflow.log", log_content.encode(), "text/plain"),
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["nextflow_log_uploaded"] is True
+
+    log_rows = _run(_query(db_url, select(task_logs_tbl).where(
+        task_logs_tbl.c.run_name == run_name
+    )))
+    assert len(log_rows) == 1
+    assert log_rows[0]["task_hash"] == "nextflow_log"
+    assert log_rows[0]["log_type"] == "nextflow_log"
+    assert log_rows[0]["content"] == log_content
+
+    run_rows = _run(_query(db_url, select(workflow_runs_tbl).where(
+        workflow_runs_tbl.c.run_name == run_name
+    )))
+    assert run_rows[0]["nextflow_log_uploaded_at"] is not None
+
+
+def test_re_uploading_nextflow_log_is_idempotent(integration_client, db_url):
+    from nextflow_telemetry.db import task_logs_tbl
+
+    client, _ = integration_client
+    run_name = _make_run_name()
+    _seed_run(db_url, run_name)
+
+    for content in ("first\n", "second\n"):
+        resp = _post_event(
+            client,
+            run_name,
+            {"type": "wrapper_exited", "utc_time": _ts(), "exit_code": 0},
+            file=("nextflow.log", content.encode(), "text/plain"),
+        )
+        assert resp.status_code == 201
+
+    rows = _run(_query(db_url, select(task_logs_tbl).where(
+        task_logs_tbl.c.run_name == run_name
+    )))
+    assert len(rows) == 1  # UNIQUE constraint upserts
+    assert rows[0]["content"] == "second\n"
+
+
+def test_workflow_oncomplete_event_persists_to_telemetry(integration_client, db_url):
+    from nextflow_telemetry.db import telemetry_tbl
+
+    client, _ = integration_client
+    run_name = _make_run_name()
+    _seed_run(db_url, run_name)
+
+    resp = _post_event(client, run_name, {
+        "type": "workflow_oncomplete",
+        "utc_time": _ts(),
+        "success": False,
+        "exit_status": 1,
+        "duration_ms": 12345,
+        "error_message": "Something blew up",
+    })
+    assert resp.status_code == 201
+
+    rows = _run(_query(db_url, select(telemetry_tbl).where(
+        telemetry_tbl.c.run_name == run_name,
+        telemetry_tbl.c.event == "run_workflow_oncomplete",
+    )))
+    assert len(rows) == 1
+    assert rows[0]["metadata_"]["error_message"] == "Something blew up"
+
+
+def test_workflow_onerror_event_persists(integration_client, db_url):
+    from nextflow_telemetry.db import telemetry_tbl
+
+    client, _ = integration_client
+    run_name = _make_run_name()
+    _seed_run(db_url, run_name)
+
+    resp = _post_event(client, run_name, {
+        "type": "workflow_onerror",
+        "utc_time": _ts(),
+        "error_message": "boom",
+    })
+    assert resp.status_code == 201
+
+    rows = _run(_query(db_url, select(telemetry_tbl).where(
+        telemetry_tbl.c.run_name == run_name,
+        telemetry_tbl.c.event == "run_workflow_onerror",
+    )))
+    assert len(rows) == 1
+
+
+def test_wrapper_log_event_persists(integration_client, db_url):
+    from nextflow_telemetry.db import telemetry_tbl
+
+    client, _ = integration_client
+    run_name = _make_run_name()
+    _seed_run(db_url, run_name)
+
+    resp = _post_event(client, run_name, {
+        "type": "wrapper_log",
+        "utc_time": _ts(),
+        "stream": "stderr",
+        "text": "sbatch: error: foo",
+    })
+    assert resp.status_code == 201
+
+    rows = _run(_query(db_url, select(telemetry_tbl).where(
+        telemetry_tbl.c.run_name == run_name,
+        telemetry_tbl.c.event == "run_wrapper_log",
+    )))
+    assert len(rows) == 1
+    assert rows[0]["metadata_"]["stream"] == "stderr"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+def test_unknown_event_type_returns_422(integration_client, db_url):
+    client, _ = integration_client
+    run_name = _make_run_name()
+    _seed_run(db_url, run_name)
+
+    resp = _post_event(client, run_name, {
+        "type": "not_a_real_event",
+        "utc_time": _ts(),
+    })
+    assert resp.status_code == 422
+
+
+def test_malformed_event_json_returns_422(integration_client, db_url):
+    client, _ = integration_client
+    run_name = _make_run_name()
+    _seed_run(db_url, run_name)
+
+    resp = client.post(
+        f"/api/runs/{run_name}/event",
+        data={"event": "not-json"},
+    )
+    assert resp.status_code == 422
+
+
+def test_event_for_unknown_run_still_records_raw(integration_client, db_url):
+    """Wrapper-races-claim case — raw event must be captured even with no workflow_runs row."""
+    from nextflow_telemetry.db import telemetry_tbl, workflow_runs_tbl
+
+    client, _ = integration_client
+    run_name = _make_run_name()  # no _seed_run
+
+    resp = _post_event(client, run_name, {
+        "type": "heartbeat",
+        "utc_time": _ts(),
+    })
+    assert resp.status_code == 201
+
+    tel_rows = _run(_query(db_url, select(telemetry_tbl).where(
+        telemetry_tbl.c.run_name == run_name
+    )))
+    assert len(tel_rows) == 1
+
+    run_rows = _run(_query(db_url, select(workflow_runs_tbl).where(
+        workflow_runs_tbl.c.run_name == run_name
+    )))
+    assert len(run_rows) == 0  # we don't pollute workflow_runs with orphan events
+
+
+def test_out_of_order_pre_nextflow_after_exit_does_not_clobber_exit_code(integration_client, db_url):
+    """A late pre_nextflow event must not roll back forward-looking state."""
+    from nextflow_telemetry.db import workflow_runs_tbl
+
+    client, _ = integration_client
+    run_name = _make_run_name()
+    _seed_run(db_url, run_name)
+
+    # exit first
+    resp = _post_event(client, run_name, {
+        "type": "wrapper_exited",
+        "utc_time": _ts(),
+        "exit_code": 0,
+    })
+    assert resp.status_code == 201
+
+    # late pre_nextflow arrives — should add wait_seconds, leave exit_code alone
+    resp = _post_event(client, run_name, {
+        "type": "pre_nextflow",
+        "utc_time": _ts(),
+        "wait_seconds": 12,
+    })
+    assert resp.status_code == 201
+
+    rows = _run(_query(db_url, select(workflow_runs_tbl).where(
+        workflow_runs_tbl.c.run_name == run_name
+    )))
+    assert rows[0]["slurm_exit_code"] == 0
+    assert rows[0]["wait_seconds"] == 12

--- a/tests/test_runs_router.py
+++ b/tests/test_runs_router.py
@@ -201,7 +201,7 @@ def test_wrapper_exited_records_exit_code(integration_client, db_url):
     rows = _run(_query(db_url, select(workflow_runs_tbl).where(
         workflow_runs_tbl.c.run_name == run_name
     )))
-    assert rows[0]["slurm_exit_code"] == 137
+    assert rows[0]["wrapper_exit_code"] == 137
 
 
 def test_wrapper_exited_with_attached_log_stores_in_task_logs(integration_client, db_url):
@@ -380,6 +380,69 @@ def test_event_for_unknown_run_still_records_raw(integration_client, db_url):
     assert len(run_rows) == 0  # we don't pollute workflow_runs with orphan events
 
 
+def test_log_attachment_on_unknown_run_returns_404(integration_client, db_url):
+    """A .nextflow.log without a known run is rejected — no orphan task_logs row."""
+    from nextflow_telemetry.db import task_logs_tbl, telemetry_tbl
+
+    client, _ = integration_client
+    run_name = _make_run_name()  # no _seed_run
+
+    resp = _post_event(
+        client, run_name,
+        {"type": "wrapper_exited", "utc_time": _ts(), "exit_code": 0},
+        file=("nextflow.log", b"would-be-orphan", "text/plain"),
+    )
+    assert resp.status_code == 404
+
+    # No orphan log row was created.
+    log_rows = _run(_query(db_url, select(task_logs_tbl).where(
+        task_logs_tbl.c.run_name == run_name
+    )))
+    assert log_rows == []
+
+    # Transaction was rolled back: telemetry row must not be there either.
+    tel_rows = _run(_query(db_url, select(telemetry_tbl).where(
+        telemetry_tbl.c.run_name == run_name
+    )))
+    assert tel_rows == []
+
+
+def test_slurm_state_event_without_reason_clears_stale_reason(integration_client, db_url):
+    """A later state event without a reason should NULL the column, not leave a stale value."""
+    from nextflow_telemetry.db import workflow_runs_tbl
+
+    client, _ = integration_client
+    run_name = _make_run_name()
+    _seed_run(db_url, run_name)
+
+    # First: state with a reason.
+    resp = _post_event(client, run_name, {
+        "type": "slurm_state",
+        "utc_time": _ts(),
+        "state": "PENDING",
+        "reason": "Resources",
+    })
+    assert resp.status_code == 201
+    rows = _run(_query(db_url, select(workflow_runs_tbl).where(
+        workflow_runs_tbl.c.run_name == run_name
+    )))
+    assert rows[0]["slurm_reason"] == "Resources"
+
+    # Then: a state transition with no reason — the column must clear.
+    resp = _post_event(client, run_name, {
+        "type": "slurm_state",
+        "utc_time": _ts(),
+        "state": "RUNNING",
+    })
+    assert resp.status_code == 201
+
+    rows = _run(_query(db_url, select(workflow_runs_tbl).where(
+        workflow_runs_tbl.c.run_name == run_name
+    )))
+    assert rows[0]["last_known_slurm_state"] == "RUNNING"
+    assert rows[0]["slurm_reason"] is None
+
+
 def test_out_of_order_pre_nextflow_after_exit_does_not_clobber_exit_code(integration_client, db_url):
     """A late pre_nextflow event must not roll back forward-looking state."""
     from nextflow_telemetry.db import workflow_runs_tbl
@@ -407,5 +470,5 @@ def test_out_of_order_pre_nextflow_after_exit_does_not_clobber_exit_code(integra
     rows = _run(_query(db_url, select(workflow_runs_tbl).where(
         workflow_runs_tbl.c.run_name == run_name
     )))
-    assert rows[0]["slurm_exit_code"] == 0
+    assert rows[0]["wrapper_exit_code"] == 0
     assert rows[0]["wait_seconds"] == 12

--- a/tests/test_runs_router.py
+++ b/tests/test_runs_router.py
@@ -380,6 +380,58 @@ def test_event_for_unknown_run_still_records_raw(integration_client, db_url):
     assert len(run_rows) == 0  # we don't pollute workflow_runs with orphan events
 
 
+def test_log_attachment_on_non_wrapper_exited_returns_422(integration_client, db_url):
+    """Attaching a .nextflow.log to a heartbeat (or any other event) is rejected."""
+    client, _ = integration_client
+    run_name = _make_run_name()
+    _seed_run(db_url, run_name)
+
+    resp = _post_event(
+        client, run_name,
+        {"type": "heartbeat", "utc_time": _ts()},
+        file=("nextflow.log", b"x" * 1024, "text/plain"),
+    )
+    assert resp.status_code == 422
+
+
+def test_wrapper_exited_without_exit_code_returns_422(integration_client, db_url):
+    """exit_code is required: a wrapper claiming nextflow exited must say with what."""
+    client, _ = integration_client
+    run_name = _make_run_name()
+    _seed_run(db_url, run_name)
+
+    resp = _post_event(client, run_name, {
+        "type": "wrapper_exited",
+        "utc_time": _ts(),
+        # no exit_code
+    })
+    assert resp.status_code == 422
+
+
+def test_heartbeat_uses_server_receipt_time_not_client_utc_time(integration_client, db_url):
+    """last_heartbeat_at is server-authoritative — client clock drift mustn't poison staleness checks."""
+    from datetime import datetime, timezone, timedelta
+    from nextflow_telemetry.db import workflow_runs_tbl
+
+    client, _ = integration_client
+    run_name = _make_run_name()
+    _seed_run(db_url, run_name)
+
+    # Send a heartbeat with a client-supplied utc_time set 1 hour in the past.
+    one_hour_ago = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    resp = _post_event(client, run_name, {"type": "heartbeat", "utc_time": one_hour_ago})
+    assert resp.status_code == 201
+
+    rows = _run(_query(db_url, select(workflow_runs_tbl).where(
+        workflow_runs_tbl.c.run_name == run_name
+    )))
+    last = rows[0]["last_heartbeat_at"]
+    assert last is not None
+    # Server time, not client's stale time: should be within seconds of now.
+    skew = abs((datetime.now(timezone.utc) - last).total_seconds())
+    assert skew < 30, f"last_heartbeat_at drift {skew}s — server should use receipt time"
+
+
 def test_pre_weblog_events_get_unique_run_id_sentinel(integration_client, db_url):
     """Events for unknown runs must each get a unique run_id, not a shared empty string."""
     from nextflow_telemetry.db import telemetry_tbl

--- a/tests/test_runs_router.py
+++ b/tests/test_runs_router.py
@@ -380,6 +380,29 @@ def test_event_for_unknown_run_still_records_raw(integration_client, db_url):
     assert len(run_rows) == 0  # we don't pollute workflow_runs with orphan events
 
 
+def test_pre_weblog_events_get_unique_run_id_sentinel(integration_client, db_url):
+    """Events for unknown runs must each get a unique run_id, not a shared empty string."""
+    from nextflow_telemetry.db import telemetry_tbl
+
+    client, _ = integration_client
+    run_a = _make_run_name()
+    run_b = _make_run_name()
+
+    for run_name in (run_a, run_b):
+        resp = _post_event(client, run_name, {"type": "heartbeat", "utc_time": _ts()})
+        assert resp.status_code == 201
+
+    rows_a = _run(_query(db_url, select(telemetry_tbl).where(
+        telemetry_tbl.c.run_name == run_a
+    )))
+    rows_b = _run(_query(db_url, select(telemetry_tbl).where(
+        telemetry_tbl.c.run_name == run_b
+    )))
+    assert rows_a[0]["run_id"] == f"pre-weblog:{run_a}"
+    assert rows_b[0]["run_id"] == f"pre-weblog:{run_b}"
+    assert rows_a[0]["run_id"] != rows_b[0]["run_id"]
+
+
 def test_log_attachment_on_unknown_run_returns_404(integration_client, db_url):
     """A .nextflow.log without a known run is rejected — no orphan task_logs row."""
     from nextflow_telemetry.db import task_logs_tbl, telemetry_tbl


### PR DESCRIPTION
Closes #63. Phase 1 of #62.

## Summary

- Adds 6 nullable observability columns to \`workflow_runs\`: \`last_heartbeat_at\`, \`last_known_slurm_state\`, \`slurm_reason\`, \`wrapper_exit_code\`, \`wait_seconds\`, \`nextflow_log_uploaded_at\`. (\`wrapper_exit_code\` records nextflow's own exit status as reported by the wrapper. A separate \`slurm_exit_code\` from sacct's ExitCode field can be added in Phase 4 (#68) without conflating the two.)
- New \`POST /api/runs/{run_name}/event\` multipart endpoint accepting a discriminated-union event body + optional \`.nextflow.log\` upload.
- Pydantic v2 \`RunEvent\` union: \`wrapper_started\`, \`pre_nextflow\`, \`wrapper_exited\`, \`heartbeat\`, \`slurm_state\`, \`workflow_oncomplete\`, \`workflow_onerror\`, \`wrapper_log\`.
- Raw events go into \`telemetry_tbl\` (event = \`run_<type>\`); summary fields denormalised onto \`workflow_runs\` for fast dashboard reads.
- \`.nextflow.log\` stored in \`task_logs_tbl\` with \`task_hash=\"nextflow_log\"\` so the existing log viewer can serve it; the existing UNIQUE constraint makes re-uploads idempotent.

## Out-of-order semantics

- \`wrapper_started\` only promotes \`claimed → submitted\`; never rolls back \`running\`/\`completed\`.
- Each event variant writes only its own narrow set of fields; a late \`pre_nextflow\` after \`wrapper_exited\` adds \`wait_seconds\` without disturbing \`wrapper_exit_code\`.
- \`slurm_state\` always writes \`slurm_reason\` (including NULL when the new event omits one), so the column always reflects the latest scheduler state — never a stale reason from an earlier transition.
- Events for unknown \`run_name\` are still appended to \`telemetry\` (with a unique \`pre-weblog:{run_name}\` sentinel for run_id, so distinct runs never share a run_id); we deliberately do **not** create orphan \`workflow_runs\` rows.
- A \`.nextflow.log\` attachment for an unknown \`run_name\` is rejected with HTTP 404 — storing it would orphan the row and the response would falsely claim the upload succeeded against a known run.

## Out of scope

- Phase 2 (#66) pipeline \`workflow.onComplete\`/\`onError\` hooks — separate sub-issue, lives in \`seandavi/curatedMetagenomicsNextflow\`.
- Phase 3 (#67) \`nf_client.run_wrapper\` — depends on this endpoint; needs cluster validation.
- Phase 4 (#68) daemon-side \`sacct\` polling — depends on this endpoint.
- Dashboard UI surfacing the new columns — separate issue.

## Test plan

- [x] \`just typecheck\` — clean (34 files)
- [x] \`just test\` — 73 passed, 3 skipped
- [x] \`tests/test_runs_router.py\` — 18 integration tests via testcontainers covering every event variant, attached log, idempotency, malformed input, unknown run_names, out-of-order events, orphan-log rejection, slurm_reason explicit-clear, and the run_id sentinel uniqueness.
- [ ] Migration runs cleanly forward and backward (alembic upgrade/downgrade) — verify pre-deploy
- [ ] OpenAPI spec includes new endpoint and union — visual check at /docs after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)