### PR TITLE
feat: cohort summary page with click-through to failed processes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,21 +1,23 @@
 import { useState } from 'react'
-import { LayoutDashboard, BarChart2, GitBranch, FlaskConical, SendHorizonal, Server, type LucideIcon } from 'lucide-react'
+import { LayoutDashboard, BarChart2, GitBranch, FlaskConical, SendHorizonal, Server, Users, type LucideIcon } from 'lucide-react'
 import { T } from './tokens'
 import { MOCK_HEALTH } from './lib/mock-data'
 import OverviewPage from './pages/OverviewPage'
 import MetricsPage from './pages/MetricsPage'
 import WorkflowsPage from './pages/WorkflowsPage'
 import SamplesPage from './pages/SamplesPage'
+import CohortsPage from './pages/CohortsPage'
 import DispatchPage from './pages/DispatchPage'
 import InfraPage from './pages/InfraPage'
 
-type NavId = 'overview' | 'metrics' | 'workflows' | 'samples' | 'dispatch' | 'infra'
+type NavId = 'overview' | 'metrics' | 'workflows' | 'samples' | 'cohorts' | 'dispatch' | 'infra'
 
 const NAV: Array<{ id: NavId; label: string; icon: LucideIcon; sub: string }> = [
   { id: 'overview',  label: 'Overview',        icon: LayoutDashboard, sub: 'Pipeline health'      },
   { id: 'metrics',   label: 'Process Metrics', icon: BarChart2,       sub: 'Failures & resources' },
   { id: 'workflows', label: 'Workflows',        icon: GitBranch,       sub: 'Registry'             },
   { id: 'samples',   label: 'Samples',          icon: FlaskConical,    sub: 'Catalog'              },
+  { id: 'cohorts',   label: 'Cohorts',          icon: Users,           sub: 'Collection summary'   },
   { id: 'dispatch',  label: 'Dispatch',         icon: SendHorizonal,   sub: '& Admin'              },
   { id: 'infra',     label: 'Infrastructure',   icon: Server,          sub: 'Daemon fleet'         },
 ]
@@ -136,6 +138,7 @@ export default function App() {
     metrics:   <MetricsPage   pollInterval={pollInterval} />,
     workflows: <WorkflowsPage pollInterval={pollInterval} />,
     samples:   <SamplesPage   pollInterval={pollInterval} />,
+    cohorts:   <CohortsPage   pollInterval={pollInterval} />,
     dispatch:  <DispatchPage />,
     infra:     <InfraPage     pollInterval={pollInterval} />,
   }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -19,6 +19,9 @@ import type {
   SampleRegisterRequest,
   SubmittedRequest,
   DaemonAgentResponse,
+  CohortListItem,
+  CohortSummaryResponse,
+  CohortFailuresResponse,
 } from '../types'
 
 export interface MetricsFilters {
@@ -119,5 +122,23 @@ export const api = {
   daemons: {
     list: (activeOnly = false) =>
       get<DaemonAgentResponse[]>(`/daemons/${activeOnly ? '?active_only=true' : ''}`),
+  },
+
+  cohorts: {
+    list: () => get<CohortListItem[]>('/cohorts'),
+    summary: (collectionId: string, opts: { workflowId?: string; workflowVersion?: string } = {}) => {
+      const p = new URLSearchParams()
+      if (opts.workflowId)      p.set('workflow_id',      opts.workflowId)
+      if (opts.workflowVersion) p.set('workflow_version', opts.workflowVersion)
+      const q = p.toString()
+      return get<CohortSummaryResponse>(`/cohorts/${encodeURIComponent(collectionId)}/summary${q ? `?${q}` : ''}`)
+    },
+    failures: (collectionId: string, process: string, opts: { workflowId?: string; workflowVersion?: string; limit?: number } = {}) => {
+      const p = new URLSearchParams({ process })
+      if (opts.workflowId)      p.set('workflow_id',      opts.workflowId)
+      if (opts.workflowVersion) p.set('workflow_version', opts.workflowVersion)
+      if (opts.limit != null)   p.set('limit',            String(opts.limit))
+      return get<CohortFailuresResponse>(`/cohorts/${encodeURIComponent(collectionId)}/failures?${p}`)
+    },
   },
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -50,7 +50,8 @@ function metricsParams(f: MetricsFilters, extra?: Record<string, string | number
   return s ? `?${s}` : ''
 }
 
-const BASE = (import.meta.env.VITE_API_URL ?? '') + '/api'
+export const API_BASE = (import.meta.env.VITE_API_URL ?? '') + '/api'
+const BASE = API_BASE
 
 async function req<T>(method: string, path: string, body?: unknown): Promise<T> {
   const res = await fetch(`${BASE}${path}`, {

--- a/frontend/src/pages/CohortsPage.tsx
+++ b/frontend/src/pages/CohortsPage.tsx
@@ -1,0 +1,306 @@
+import { useEffect, useMemo, useState } from 'react'
+import { T } from '../tokens'
+import { fmtNum, fmtDate } from '../lib/format'
+import { usePoll, fmtUpdated } from '../lib/usePoll'
+import { api } from '../lib/api'
+import PageWrap from '../components/PageWrap'
+import Panel from '../components/Panel'
+import SectionHeader from '../components/SectionHeader'
+import Btn from '../components/Btn'
+import type {
+  CohortListItem,
+  CohortSummaryResponse,
+  CohortFailureRow,
+  WorkflowResponse,
+} from '../types'
+
+function StatusChip({ label, count, color }: { label: string; count: number; color: string }) {
+  return (
+    <div style={{
+      display: 'flex', flexDirection: 'column', gap: 2,
+      padding: '12px 16px', minWidth: 92,
+      background: T.elevated, border: `1px solid ${T.border}`, borderRadius: 6,
+    }}>
+      <div style={{ fontSize: 10, color: T.muted, textTransform: 'uppercase', letterSpacing: '0.06em' }}>{label}</div>
+      <div style={{ fontSize: 20, fontWeight: 700, color, fontFamily: 'DM Mono, monospace' }}>{fmtNum(count)}</div>
+    </div>
+  )
+}
+
+function FailureBar({
+  process, failedCount, sampleCount, total, onClick, selected,
+}: {
+  process: string
+  failedCount: number
+  sampleCount: number
+  total: number
+  onClick: () => void
+  selected: boolean
+}) {
+  const pct = total > 0 ? (failedCount / total) * 100 : 0
+  return (
+    <div
+      onClick={onClick}
+      style={{
+        display: 'grid', gridTemplateColumns: '1fr 70px 80px 32px', gap: 12,
+        alignItems: 'center', padding: '10px 12px', borderRadius: 4,
+        background: selected ? T.accentDim : 'transparent',
+        border: `1px solid ${selected ? T.accent : 'transparent'}`,
+        cursor: 'pointer',
+      }}
+    >
+      <div style={{ fontFamily: 'DM Mono, monospace', fontSize: 12, color: T.text, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {process}
+      </div>
+      <div style={{ position: 'relative', height: 6, background: T.border, borderRadius: 3, overflow: 'hidden' }}>
+        <div style={{
+          position: 'absolute', top: 0, left: 0, height: '100%',
+          width: `${Math.min(100, pct)}%`, background: T.red,
+        }} />
+      </div>
+      <div style={{ fontSize: 12, color: T.text, textAlign: 'right', fontFamily: 'DM Mono, monospace' }}>
+        {failedCount} <span style={{ color: T.muted }}>/{sampleCount}</span>
+      </div>
+      <div style={{ fontSize: 11, color: T.muted, textAlign: 'right' }}>›</div>
+    </div>
+  )
+}
+
+function FailuresTable({ rows, loading }: { rows: CohortFailureRow[]; loading: boolean }) {
+  if (loading) {
+    return <div style={{ fontSize: 12, color: T.muted, padding: 14 }}>Loading…</div>
+  }
+  if (rows.length === 0) {
+    return <div style={{ fontSize: 12, color: T.muted, padding: 14 }}>No failed tasks for this process.</div>
+  }
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column' }}>
+      <div style={{
+        display: 'grid',
+        gridTemplateColumns: '180px 1fr 1fr 60px 60px 110px',
+        gap: 12, padding: '8px 12px',
+        fontSize: 10, color: T.muted, textTransform: 'uppercase', letterSpacing: '0.06em',
+        borderBottom: `1px solid ${T.border}`,
+      }}>
+        <div>Sample</div>
+        <div>Run name</div>
+        <div>Task hash</div>
+        <div style={{ textAlign: 'right' }}>Attempt</div>
+        <div style={{ textAlign: 'right' }}>Exit</div>
+        <div style={{ textAlign: 'right' }}>When</div>
+      </div>
+      {rows.map((r) => (
+        <div key={r.telemetry_id} style={{
+          display: 'grid',
+          gridTemplateColumns: '180px 1fr 1fr 60px 60px 110px',
+          gap: 12, padding: '8px 12px', alignItems: 'center',
+          borderBottom: `1px solid ${T.border}`,
+        }}>
+          <div style={{ fontFamily: 'DM Mono, monospace', fontSize: 11, color: T.text, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {r.sample_id ?? '—'}
+          </div>
+          <div style={{ fontFamily: 'DM Mono, monospace', fontSize: 11, color: T.muted, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {r.run_name}
+          </div>
+          <div style={{ fontFamily: 'DM Mono, monospace', fontSize: 11, color: T.muted, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {r.task_hash ? (
+              <a
+                href={`/api/task-logs/${encodeURIComponent(r.run_name)}/${r.task_hash}`}
+                target="_blank"
+                rel="noreferrer"
+                style={{ color: T.accent, textDecoration: 'none' }}
+              >
+                {r.task_hash}
+              </a>
+            ) : '—'}
+          </div>
+          <div style={{ fontSize: 11, color: T.text, textAlign: 'right', fontFamily: 'DM Mono, monospace' }}>{r.attempt}</div>
+          <div style={{ fontSize: 11, color: T.text, textAlign: 'right', fontFamily: 'DM Mono, monospace' }}>{r.exit_code ?? '—'}</div>
+          <div style={{ fontSize: 11, color: T.muted, textAlign: 'right' }}>{fmtDate(r.utc_time)}</div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default function CohortsPage({ pollInterval = 30_000 }: { pollInterval?: number }) {
+  const { tick, refresh, lastUpdated } = usePoll(pollInterval)
+
+  const [cohorts, setCohorts] = useState<CohortListItem[]>([])
+  const [selectedCohort, setSelectedCohort] = useState<string>('')
+  const [workflows, setWorkflows] = useState<WorkflowResponse[]>([])
+  const [workflowKey, setWorkflowKey] = useState<string>('')  // "wf_id|version" or ""
+  const [summary, setSummary] = useState<CohortSummaryResponse | null>(null)
+  const [selectedProcess, setSelectedProcess] = useState<string>('')
+  const [failures, setFailures] = useState<CohortFailureRow[]>([])
+  const [loadingFailures, setLoadingFailures] = useState(false)
+
+  useEffect(() => {
+    api.cohorts.list().then(setCohorts).catch(console.error)
+    api.workflows.list().then(setWorkflows).catch(console.error)
+  }, [tick])
+
+  useEffect(() => {
+    if (!selectedCohort && cohorts.length > 0) setSelectedCohort(cohorts[0].collection_id)
+  }, [cohorts, selectedCohort])
+
+  const wfFilter = useMemo(() => {
+    if (!workflowKey) return {}
+    const [workflowId, workflowVersion] = workflowKey.split('|')
+    return { workflowId, workflowVersion }
+  }, [workflowKey])
+
+  useEffect(() => {
+    if (!selectedCohort) return
+    setSummary(null)
+    setSelectedProcess('')
+    setFailures([])
+    api.cohorts.summary(selectedCohort, wfFilter).then(setSummary).catch(console.error)
+  }, [selectedCohort, workflowKey, tick])
+
+  useEffect(() => {
+    if (!selectedCohort || !selectedProcess) return
+    setLoadingFailures(true)
+    api.cohorts.failures(selectedCohort, selectedProcess, wfFilter)
+      .then(r => setFailures(r.rows))
+      .catch(console.error)
+      .finally(() => setLoadingFailures(false))
+  }, [selectedCohort, selectedProcess, workflowKey, tick])
+
+  const totalFailedAcrossProcesses = summary?.failure_by_process.reduce((s, r) => s + r.failed_count, 0) ?? 0
+  const counts = summary?.job_status_counts
+
+  return (
+    <PageWrap>
+      <SectionHeader
+        title="Cohorts"
+        sub="Workflow completion and failure breakdown for each collection"
+        actions={
+          <>
+            <span style={{ fontSize: 11, color: T.muted, alignSelf: 'center' }}>{fmtUpdated(lastUpdated)}</span>
+            <Btn variant="ghost" onClick={refresh}>Refresh</Btn>
+          </>
+        }
+      />
+
+      <Panel>
+        <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap', alignItems: 'flex-end' }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 4, minWidth: 280 }}>
+            <label style={{ fontSize: 10, color: T.muted, textTransform: 'uppercase', letterSpacing: '0.06em' }}>Cohort</label>
+            <select
+              value={selectedCohort}
+              onChange={e => setSelectedCohort(e.target.value)}
+              style={{
+                background: T.elevated, color: T.text,
+                border: `1px solid ${T.border}`, borderRadius: 4,
+                padding: '8px 10px', fontFamily: 'DM Mono, monospace', fontSize: 12,
+              }}
+            >
+              {cohorts.length === 0 && <option value="">No cohorts yet</option>}
+              {cohorts.map(c => (
+                <option key={c.collection_id} value={c.collection_id}>
+                  {c.collection_id} ({c.sample_count} samples) — {c.source}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 4, minWidth: 280 }}>
+            <label style={{ fontSize: 10, color: T.muted, textTransform: 'uppercase', letterSpacing: '0.06em' }}>Workflow filter</label>
+            <select
+              value={workflowKey}
+              onChange={e => setWorkflowKey(e.target.value)}
+              style={{
+                background: T.elevated, color: T.text,
+                border: `1px solid ${T.border}`, borderRadius: 4,
+                padding: '8px 10px', fontFamily: 'DM Mono, monospace', fontSize: 12,
+              }}
+            >
+              <option value="">All workflows</option>
+              {workflows.map(w => (
+                <option key={`${w.workflow_id}|${w.version}`} value={`${w.workflow_id}|${w.version}`}>
+                  {w.workflow_id} v{w.version} ({w.status})
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      </Panel>
+
+      {summary && (
+        <>
+          <Panel>
+            <div style={{ display: 'flex', alignItems: 'baseline', gap: 12, marginBottom: 16 }}>
+              <div style={{ fontSize: 14, fontWeight: 700, color: T.text }}>{summary.collection_id}</div>
+              <div style={{ fontSize: 11, color: T.muted }}>{summary.label ?? summary.source}</div>
+            </div>
+            <div style={{ display: 'flex', gap: 14, flexWrap: 'wrap', alignItems: 'stretch' }}>
+              <StatusChip label="Samples" count={summary.sample_count} color={T.text} />
+              <StatusChip label="Jobs total" count={summary.total_jobs} color={T.text} />
+              <StatusChip label="Pending" count={counts?.pending ?? 0} color={T.muted} />
+              <StatusChip label="Claimed" count={counts?.claimed ?? 0} color={T.blue} />
+              <StatusChip label="Running" count={counts?.running ?? 0} color={T.amber} />
+              <StatusChip label="Completed" count={counts?.completed ?? 0} color={T.green} />
+              <StatusChip label="Failed" count={counts?.failed ?? 0} color={T.red} />
+              <div style={{
+                display: 'flex', flexDirection: 'column', gap: 2,
+                padding: '12px 16px', minWidth: 140,
+                background: T.elevated, border: `1px solid ${T.border}`, borderRadius: 6,
+              }}>
+                <div style={{ fontSize: 10, color: T.muted, textTransform: 'uppercase', letterSpacing: '0.06em' }}>Completion</div>
+                <div style={{ fontSize: 20, fontWeight: 700, color: T.green, fontFamily: 'DM Mono, monospace' }}>
+                  {summary.completion_pct.toFixed(1)}%
+                </div>
+              </div>
+            </div>
+          </Panel>
+
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1.4fr', gap: 18, alignItems: 'flex-start' }}>
+            <Panel>
+              <div style={{ fontSize: 12, fontWeight: 700, color: T.text, marginBottom: 12 }}>
+                Failures by process
+              </div>
+              {summary.failure_by_process.length === 0 ? (
+                <div style={{ fontSize: 12, color: T.muted, padding: 14 }}>
+                  No process failures recorded for this cohort/workflow.
+                </div>
+              ) : (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                  {summary.failure_by_process.map(p => (
+                    <FailureBar
+                      key={p.process}
+                      process={p.process}
+                      failedCount={p.failed_count}
+                      sampleCount={p.sample_count}
+                      total={Math.max(totalFailedAcrossProcesses, 1)}
+                      onClick={() => setSelectedProcess(p.process)}
+                      selected={selectedProcess === p.process}
+                    />
+                  ))}
+                </div>
+              )}
+            </Panel>
+
+            <Panel>
+              <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 12 }}>
+                <div style={{ fontSize: 12, fontWeight: 700, color: T.text }}>
+                  {selectedProcess ? `Failed tasks · ${selectedProcess}` : 'Click a process to inspect failures'}
+                </div>
+                {selectedProcess && (
+                  <div style={{ fontSize: 11, color: T.muted }}>{failures.length} task{failures.length !== 1 ? 's' : ''}</div>
+                )}
+              </div>
+              {selectedProcess ? (
+                <FailuresTable rows={failures} loading={loadingFailures} />
+              ) : (
+                <div style={{ fontSize: 12, color: T.muted, padding: 14 }}>
+                  Select a process on the left to see the failed task occurrences for this cohort.
+                </div>
+              )}
+            </Panel>
+          </div>
+        </>
+      )}
+    </PageWrap>
+  )
+}

--- a/frontend/src/pages/CohortsPage.tsx
+++ b/frontend/src/pages/CohortsPage.tsx
@@ -39,17 +39,20 @@ function FailureBar({
 }) {
   const pct = total > 0 ? (failedCount / total) * 100 : 0
   return (
-    <div
+    <button
+      type="button"
       onClick={onClick}
+      aria-pressed={selected}
       style={{
         display: 'grid', gridTemplateColumns: '1fr 70px 80px 32px', gap: 12,
         alignItems: 'center', padding: '10px 12px', borderRadius: 4,
         background: selected ? T.accentDim : 'transparent',
         border: `1px solid ${selected ? T.accent : 'transparent'}`,
         cursor: 'pointer',
+        font: 'inherit', color: 'inherit', textAlign: 'inherit', width: '100%',
       }}
     >
-      <div style={{ fontFamily: 'DM Mono, monospace', fontSize: 12, color: T.text, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+      <div style={{ fontFamily: 'DM Mono, monospace', fontSize: 12, color: T.text, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', textAlign: 'left' }}>
         {process}
       </div>
       <div style={{ position: 'relative', height: 6, background: T.border, borderRadius: 3, overflow: 'hidden' }}>
@@ -62,7 +65,7 @@ function FailureBar({
         {failedCount} <span style={{ color: T.muted }}>/{sampleCount}</span>
       </div>
       <div style={{ fontSize: 11, color: T.muted, textAlign: 'right' }}>›</div>
-    </div>
+    </button>
   )
 }
 

--- a/frontend/src/pages/CohortsPage.tsx
+++ b/frontend/src/pages/CohortsPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { T } from '../tokens'
 import { fmtNum, fmtDate } from '../lib/format'
 import { usePoll, fmtUpdated } from '../lib/usePoll'
-import { api } from '../lib/api'
+import { api, API_BASE } from '../lib/api'
 import PageWrap from '../components/PageWrap'
 import Panel from '../components/Panel'
 import SectionHeader from '../components/SectionHeader'
@@ -105,7 +105,7 @@ function FailuresTable({ rows, loading }: { rows: CohortFailureRow[]; loading: b
           <div style={{ fontFamily: 'DM Mono, monospace', fontSize: 11, color: T.muted, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
             {r.task_hash ? (
               <a
-                href={`/api/task-logs/${encodeURIComponent(r.run_name)}/${r.task_hash}`}
+                href={`${API_BASE}/task-logs/${encodeURIComponent(r.run_name)}/${r.task_hash}`}
                 target="_blank"
                 rel="noreferrer"
                 style={{ color: T.accent, textDecoration: 'none' }}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -331,3 +331,62 @@ export interface DaemonAgentResponse {
   started_at: string
   is_active: boolean
 }
+
+// ---------------------------------------------------------------------------
+// Cohorts (issue #36)
+// ---------------------------------------------------------------------------
+
+export interface CohortListItem {
+  collection_id: string
+  source: string
+  label: string | null
+  sample_count: number
+  created_at: string
+  updated_at: string
+}
+
+export interface CohortJobStatusCounts {
+  pending: number
+  claimed: number
+  running: number
+  completed: number
+  failed: number
+}
+
+export interface CohortFailureByProcessRow {
+  process: string
+  failed_count: number
+  sample_count: number
+}
+
+export interface CohortSummaryResponse {
+  collection_id: string
+  source: string
+  label: string | null
+  workflow_id: string | null
+  workflow_version: string | null
+  sample_count: number
+  total_jobs: number
+  job_status_counts: CohortJobStatusCounts
+  completion_pct: number
+  failure_by_process: CohortFailureByProcessRow[]
+  generated_at_utc: string
+}
+
+export interface CohortFailureRow {
+  telemetry_id: number
+  sample_id: string | null
+  run_name: string
+  utc_time: string
+  task_name: string | null
+  task_hash: string | null
+  status: string
+  exit_code: string | null
+  attempt: number
+}
+
+export interface CohortFailuresResponse {
+  collection_id: string
+  process: string
+  rows: CohortFailureRow[]
+}

--- a/src/nextflow_telemetry/main.py
+++ b/src/nextflow_telemetry/main.py
@@ -9,6 +9,7 @@ from .config import settings
 from .log import logger
 from . import models
 from .routers.admin import create_admin_router
+from .routers.cohorts import create_cohorts_router
 from .routers.curated import create_curated_router
 from .routers.daemons import create_daemons_router
 from .routers.dispatch import create_dispatch_router
@@ -63,6 +64,7 @@ app.include_router(create_task_logs_router(engine), prefix="/api")
 app.include_router(create_daemons_router(engine), prefix="/api")
 app.include_router(create_curated_router(engine), prefix="/api")
 app.include_router(create_runs_router(engine), prefix="/api")
+app.include_router(create_cohorts_router(engine), prefix="/api")
 
 
 @app.get(

--- a/src/nextflow_telemetry/routers/cohorts.py
+++ b/src/nextflow_telemetry/routers/cohorts.py
@@ -127,6 +127,9 @@ def create_cohorts_router(engine: AsyncEngine) -> APIRouter:
         workflow_version: Annotated[Optional[str], Query()] = None,
         limit: Annotated[int, Query(ge=1, le=1000, description="Max rows.")] = 200,
     ) -> CohortFailuresResponse:
+        # Match /summary's behaviour: 404 on unknown cohort, not 200 + empty rows.
+        if not await svc.cohort_exists(collection_id):
+            raise HTTPException(status_code=404, detail=f"Cohort '{collection_id}' not found.")
         rows = await svc.failures_for_process(
             collection_id, process, workflow_id, workflow_version, limit=limit
         )

--- a/src/nextflow_telemetry/routers/cohorts.py
+++ b/src/nextflow_telemetry/routers/cohorts.py
@@ -1,0 +1,139 @@
+"""Cohort summary router (issue #36).
+
+Lightweight wrapper over CohortService that exposes:
+  - GET /api/cohorts                     — list cohorts/collections
+  - GET /api/cohorts/{id}/summary        — counts + completion % + per-process failures
+  - GET /api/cohorts/{id}/failures       — drill-down: failed tasks for a process
+
+A "cohort" is a collection (PRJNA bioproject, SRA Study, or manual group)
+already represented by the collections + collection_samples tables.
+"""
+from __future__ import annotations
+
+import datetime
+from typing import Annotated, Optional
+
+from fastapi import APIRouter, HTTPException, Path, Query
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from ..services.cohort import CohortService
+
+
+class CohortListItem(BaseModel):
+    collection_id: str
+    source: str = Field(description="bioproject | sra_study | manual")
+    label: Optional[str] = None
+    sample_count: int
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+
+
+class CohortJobStatusCounts(BaseModel):
+    pending: int = 0
+    claimed: int = 0
+    running: int = 0
+    completed: int = 0
+    failed: int = 0
+
+
+class CohortFailureByProcessRow(BaseModel):
+    process: str
+    failed_count: int = Field(description="Total FAILED/ABORTED process_completed events.")
+    sample_count: int = Field(description="Distinct samples with at least one failure at this process.")
+
+
+class CohortSummaryResponse(BaseModel):
+    collection_id: str
+    source: str
+    label: Optional[str] = None
+    workflow_id: Optional[str] = None
+    workflow_version: Optional[str] = None
+    sample_count: int = Field(description="Total samples in the cohort.")
+    total_jobs: int = Field(description="Total jobs across all statuses, after the workflow filter is applied.")
+    job_status_counts: CohortJobStatusCounts
+    completion_pct: float = Field(description="completed / total_jobs × 100. Zero when total_jobs is 0.")
+    failure_by_process: list[CohortFailureByProcessRow]
+    generated_at_utc: datetime.datetime
+
+
+class CohortFailureRow(BaseModel):
+    telemetry_id: int
+    sample_id: Optional[str] = None
+    run_name: str
+    utc_time: datetime.datetime
+    task_name: Optional[str] = None
+    task_hash: Optional[str] = Field(default=None, description="Nextflow work dir hash; use with /task-logs to fetch logs.")
+    status: str
+    exit_code: Optional[str] = None
+    attempt: int
+
+
+class CohortFailuresResponse(BaseModel):
+    collection_id: str
+    process: str
+    rows: list[CohortFailureRow]
+
+
+def create_cohorts_router(engine: AsyncEngine) -> APIRouter:
+    router = APIRouter(prefix="/cohorts", tags=["cohorts"])
+    svc = CohortService(engine=engine)
+
+    @router.get(
+        "",
+        response_model=list[CohortListItem],
+        summary="List cohorts",
+        description="Returns every collection (cohort) with its current sample count, newest first.",
+    )
+    async def list_cohorts() -> list[CohortListItem]:
+        rows = await svc.list_cohorts()
+        return [CohortListItem(**r) for r in rows]
+
+    @router.get(
+        "/{collection_id}/summary",
+        response_model=CohortSummaryResponse,
+        summary="Cohort summary: completion %, status counts, and failure-by-process",
+        description=(
+            "Aggregates job status across all samples in the cohort and identifies "
+            "which Nextflow processes are producing the most failures. Filter by "
+            "`workflow_id` and `workflow_version` to scope to a specific pipeline; "
+            "omit them for an all-workflows view."
+        ),
+    )
+    async def get_summary(
+        collection_id: Annotated[str, Path(description="Collection identifier (e.g. PRJNA123456).")],
+        workflow_id: Annotated[Optional[str], Query(description="Restrict to a single workflow.")] = None,
+        workflow_version: Annotated[Optional[str], Query(description="Restrict to a specific workflow version.")] = None,
+    ) -> CohortSummaryResponse:
+        summary = await svc.summary(collection_id, workflow_id, workflow_version)
+        if summary is None:
+            raise HTTPException(status_code=404, detail=f"Cohort '{collection_id}' not found.")
+        return CohortSummaryResponse.model_validate(summary)
+
+    @router.get(
+        "/{collection_id}/failures",
+        response_model=CohortFailuresResponse,
+        summary="Failed tasks for a (cohort, process) — click-through drill-down",
+        description=(
+            "Returns up to `limit` failed `process_completed` events for the given "
+            "process within the cohort, newest first. `task_hash` joins to "
+            "`/task-logs/{run_name}/{task_hash}` for the log viewer."
+        ),
+    )
+    async def get_failures(
+        collection_id: Annotated[str, Path(description="Collection identifier.")],
+        process: Annotated[str, Query(description="Fully-qualified Nextflow process name (e.g. `FETCH_READS`).")],
+        workflow_id: Annotated[Optional[str], Query()] = None,
+        workflow_version: Annotated[Optional[str], Query()] = None,
+        limit: Annotated[int, Query(ge=1, le=1000, description="Max rows.")] = 200,
+    ) -> CohortFailuresResponse:
+        rows = await svc.failures_for_process(
+            collection_id, process, workflow_id, workflow_version, limit=limit
+        )
+        return CohortFailuresResponse(
+            collection_id=collection_id,
+            process=process,
+            rows=[CohortFailureRow(**r) for r in rows],
+        )
+
+    return router

--- a/src/nextflow_telemetry/services/cohort.py
+++ b/src/nextflow_telemetry/services/cohort.py
@@ -1,0 +1,188 @@
+"""Cohort (collection) summary service.
+
+A "cohort" is a collection — the existing collections / collection_samples
+tables already provide a many-to-many sample grouping, so the cohort summary
+view layers on top without new schema.
+
+This service answers two questions:
+
+1. *How is the cohort doing for a given workflow?* — total samples, job-status
+   breakdown, completion percentage, and which Nextflow processes are
+   producing the most failures.
+2. *Which specific samples failed at a given process?* — drill-down for the
+   click-through-to-inspect flow on the cohort summary page.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+
+_JOB_STATUSES = ("pending", "claimed", "running", "completed", "failed")
+
+
+@dataclass
+class CohortService:
+    engine: AsyncEngine
+
+    async def list_cohorts(self) -> list[dict]:
+        """Return all collections with sample counts, ordered newest first."""
+        sql = text(
+            """
+            SELECT c.collection_id, c.source, c.label, c.created_at, c.updated_at,
+                   COUNT(cs.sample_id) AS sample_count
+            FROM collections c
+            LEFT JOIN collection_samples cs USING (collection_id)
+            GROUP BY c.collection_id, c.source, c.label, c.created_at, c.updated_at
+            ORDER BY c.created_at DESC
+            """
+        )
+        async with self.engine.connect() as conn:
+            return [dict(r) for r in (await conn.execute(sql)).mappings()]
+
+    async def summary(
+        self,
+        collection_id: str,
+        workflow_id: str | None,
+        workflow_version: str | None,
+    ) -> dict | None:
+        """Return cohort summary or None if the collection does not exist."""
+        async with self.engine.connect() as conn:
+            exists = (
+                await conn.execute(
+                    text(
+                        "SELECT collection_id, source, label "
+                        "FROM collections WHERE collection_id = :cid"
+                    ),
+                    {"cid": collection_id},
+                )
+            ).mappings().first()
+            if not exists:
+                return None
+
+            sample_count = (
+                await conn.execute(
+                    text(
+                        "SELECT COUNT(*) AS n FROM collection_samples WHERE collection_id = :cid"
+                    ),
+                    {"cid": collection_id},
+                )
+            ).scalar() or 0
+
+            params: dict = {"cid": collection_id}
+            wf_filter = ""
+            if workflow_id:
+                wf_filter += " AND j.workflow_id = :workflow_id"
+                params["workflow_id"] = workflow_id
+            if workflow_version:
+                wf_filter += " AND j.workflow_version = :workflow_version"
+                params["workflow_version"] = workflow_version
+
+            status_rows = (
+                await conn.execute(
+                    text(
+                        f"""
+                        SELECT j.status, COUNT(*) AS n
+                        FROM jobs j
+                        JOIN collection_samples cs ON cs.sample_id = j.sample_id
+                        WHERE cs.collection_id = :cid
+                          {wf_filter}
+                        GROUP BY j.status
+                        """
+                    ),
+                    params,
+                )
+            ).mappings().all()
+            counts = {s: 0 for s in _JOB_STATUSES}
+            for r in status_rows:
+                if r["status"] in counts:
+                    counts[r["status"]] = r["n"]
+            total = sum(counts.values())
+            completion_pct = (counts["completed"] / total * 100.0) if total > 0 else 0.0
+
+            failure_rows = (
+                await conn.execute(
+                    text(
+                        f"""
+                        SELECT t.trace->>'process' AS process,
+                               COUNT(*) AS failed_count,
+                               COUNT(DISTINCT t.sample_id) AS sample_count
+                        FROM telemetry t
+                        JOIN collection_samples cs ON cs.sample_id = t.sample_id
+                        WHERE cs.collection_id = :cid
+                          AND t.event = 'process_completed'
+                          AND t.trace->>'status' IN ('FAILED', 'ABORTED')
+                          {("AND t.workflow_id = :workflow_id" if workflow_id else "")}
+                          {("AND t.workflow_version = :workflow_version" if workflow_version else "")}
+                          AND t.trace->>'process' IS NOT NULL
+                        GROUP BY t.trace->>'process'
+                        ORDER BY failed_count DESC, process
+                        """
+                    ),
+                    params,
+                )
+            ).mappings().all()
+
+        return {
+            "collection_id": collection_id,
+            "source": exists["source"],
+            "label": exists["label"],
+            "workflow_id": workflow_id,
+            "workflow_version": workflow_version,
+            "sample_count": sample_count,
+            "job_status_counts": counts,
+            "total_jobs": total,
+            "completion_pct": round(completion_pct, 2),
+            "failure_by_process": [dict(r) for r in failure_rows],
+            "generated_at_utc": datetime.now(timezone.utc),
+        }
+
+    async def failures_for_process(
+        self,
+        collection_id: str,
+        process: str,
+        workflow_id: str | None,
+        workflow_version: str | None,
+        limit: int = 200,
+    ) -> list[dict]:
+        """Return failed task occurrences for a given (cohort, process).
+
+        One row per process_completed FAILED/ABORTED event. Includes task_hash
+        so the UI can link straight to the existing log viewer.
+        """
+        params: dict = {"cid": collection_id, "process": process, "limit": limit}
+        wf_filter = ""
+        if workflow_id:
+            wf_filter += " AND t.workflow_id = :workflow_id"
+            params["workflow_id"] = workflow_id
+        if workflow_version:
+            wf_filter += " AND t.workflow_version = :workflow_version"
+            params["workflow_version"] = workflow_version
+
+        sql = text(
+            f"""
+            SELECT t.id AS telemetry_id,
+                   t.sample_id,
+                   t.run_name,
+                   t.utc_time,
+                   t.trace->>'name'   AS task_name,
+                   t.trace->>'hash'   AS task_hash,
+                   t.trace->>'status' AS status,
+                   t.trace->>'exit'   AS exit_code,
+                   coalesce(nullif(t.trace->>'attempt',''),'0')::int AS attempt
+            FROM telemetry t
+            JOIN collection_samples cs ON cs.sample_id = t.sample_id
+            WHERE cs.collection_id = :cid
+              AND t.event = 'process_completed'
+              AND t.trace->>'status' IN ('FAILED', 'ABORTED')
+              AND t.trace->>'process' = :process
+              {wf_filter}
+            ORDER BY t.utc_time DESC
+            LIMIT :limit
+            """
+        )
+        async with self.engine.connect() as conn:
+            return [dict(r) for r in (await conn.execute(sql, params)).mappings()]

--- a/src/nextflow_telemetry/services/cohort.py
+++ b/src/nextflow_telemetry/services/cohort.py
@@ -140,6 +140,16 @@ class CohortService:
             "generated_at_utc": datetime.now(timezone.utc),
         }
 
+    async def cohort_exists(self, collection_id: str) -> bool:
+        async with self.engine.connect() as conn:
+            row = (
+                await conn.execute(
+                    text("SELECT 1 FROM collections WHERE collection_id = :cid"),
+                    {"cid": collection_id},
+                )
+            ).first()
+            return row is not None
+
     async def failures_for_process(
         self,
         collection_id: str,
@@ -151,7 +161,9 @@ class CohortService:
         """Return failed task occurrences for a given (cohort, process).
 
         One row per process_completed FAILED/ABORTED event. Includes task_hash
-        so the UI can link straight to the existing log viewer.
+        so the UI can link straight to the existing log viewer. Caller is
+        responsible for checking that the cohort exists (use cohort_exists)
+        — this method returns an empty list for unknown cohorts.
         """
         params: dict = {"cid": collection_id, "process": process, "limit": limit}
         wf_filter = ""

--- a/tests/test_cohorts_router.py
+++ b/tests/test_cohorts_router.py
@@ -325,6 +325,13 @@ def test_summary_excludes_samples_not_in_cohort(integration_client, db_url, coho
 # /cohorts/{id}/failures (drill-down)
 # ---------------------------------------------------------------------------
 
+def test_failures_404_for_unknown_cohort(integration_client):
+    """Match /summary semantics — unknown cohort is 404, not 200 with empty rows."""
+    client, _ = integration_client
+    resp = client.get("/api/cohorts/does-not-exist-cohort/failures?process=FETCH_READS")
+    assert resp.status_code == 404
+
+
 def test_failures_returns_per_task_rows_with_task_hash(integration_client, db_url, cohort_data):
     client, _ = integration_client
     tag = cohort_data

--- a/tests/test_cohorts_router.py
+++ b/tests/test_cohorts_router.py
@@ -1,0 +1,348 @@
+"""Integration tests for the cohort summary router (issue #36).
+
+Uses the shared testcontainers postgres fixture from conftest.py.
+
+Each test scopes its data with a unique TAG (random hex). The `cohort_data`
+fixture cleans up rows tagged with that suffix after the test, so leftover
+samples don't poison reconcile-driven tests elsewhere in the suite.
+"""
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import insert, select, text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+
+def _ts() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+async def _exec(db_url: str, *stmts):
+    engine = create_async_engine(db_url)
+    try:
+        async with engine.begin() as conn:
+            for stmt in stmts:
+                await conn.execute(stmt)
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture()
+def cohort_data(db_url):
+    """Provides a unique tag and tears down all rows that include it.
+
+    Sample IDs, collection IDs, and workflow IDs created via the test helpers
+    must all contain the tag so cleanup is reliable.
+    """
+    tag = uuid.uuid4().hex[:10]
+
+    yield tag
+
+    pat = f"%{tag}%"
+    cleanup = [
+        text("DELETE FROM telemetry WHERE sample_id LIKE :p OR run_name LIKE :p OR workflow_id LIKE :p").bindparams(p=pat),
+        text("DELETE FROM jobs WHERE sample_id LIKE :p OR workflow_id LIKE :p").bindparams(p=pat),
+        text("DELETE FROM collection_samples WHERE collection_id LIKE :p OR sample_id LIKE :p").bindparams(p=pat),
+        text("DELETE FROM collections WHERE collection_id LIKE :p").bindparams(p=pat),
+        text("DELETE FROM samples WHERE sample_id LIKE :p").bindparams(p=pat),
+        text("DELETE FROM workflows WHERE workflow_id LIKE :p").bindparams(p=pat),
+    ]
+    _run(_exec(db_url, *cleanup))
+
+
+def _seed_cohort(db_url: str, *, collection_id: str, sample_ids: list[str]) -> None:
+    """Insert a collection plus the listed samples and their join rows."""
+    from nextflow_telemetry.db import (
+        collection_samples_tbl,
+        collections_tbl,
+        samples_tbl,
+    )
+
+    now = _ts()
+    stmts = [
+        insert(collections_tbl).values(
+            collection_id=collection_id,
+            source="manual",
+            label=f"label-{collection_id}",
+            created_at=now,
+            updated_at=now,
+        )
+    ]
+    for sid in sample_ids:
+        stmts.append(
+            insert(samples_tbl).values(
+                sample_id=sid,
+                ncbi_accession=None,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+        stmts.append(
+            insert(collection_samples_tbl).values(
+                collection_id=collection_id, sample_id=sid
+            )
+        )
+    _run(_exec(db_url, *stmts))
+
+
+def _seed_jobs(db_url: str, sample_id: str, status: str, *, workflow_id: str, workflow_version: str = "1.0.0") -> None:
+    from nextflow_telemetry.db import jobs_tbl, workflows_tbl
+
+    now = _ts()
+    # workflows row needs to exist for the FK on workflow_pk
+    engine = create_async_engine(db_url)
+
+    async def _do():
+        async with engine.begin() as conn:
+            # upsert workflow
+            existing = (await conn.execute(
+                select(workflows_tbl).where(
+                    workflows_tbl.c.workflow_id == workflow_id,
+                    workflows_tbl.c.version == workflow_version,
+                )
+            )).mappings().first()
+            if not existing:
+                await conn.execute(
+                    insert(workflows_tbl).values(
+                        workflow_id=workflow_id,
+                        version=workflow_version,
+                        repository_url="https://example.com/wf",
+                        revision="main",
+                        max_retries=3,
+                        status="active",
+                        created_at=now,
+                        updated_at=now,
+                    )
+                )
+                wf_pk = (await conn.execute(
+                    select(workflows_tbl.c.id).where(
+                        workflows_tbl.c.workflow_id == workflow_id,
+                        workflows_tbl.c.version == workflow_version,
+                    )
+                )).scalar_one()
+            else:
+                wf_pk = existing["id"]
+            await conn.execute(
+                insert(jobs_tbl).values(
+                    sample_id=sample_id,
+                    workflow_pk=wf_pk,
+                    workflow_id=workflow_id,
+                    workflow_version=workflow_version,
+                    status=status,
+                    retry_count=0,
+                    created_at=now,
+                )
+            )
+    try:
+        _run(_do())
+    finally:
+        _run(engine.dispose())
+
+
+def _seed_telemetry_failure(
+    db_url: str,
+    *,
+    sample_id: str,
+    process: str,
+    workflow_id: str,
+    run_name: str = "run-1",
+    workflow_version: str = "1.0.0",
+    status: str = "FAILED",
+    task_hash: str = "ab/cd1234",
+    exit_code: str = "1",
+) -> None:
+    from nextflow_telemetry.db import telemetry_tbl
+
+    _run(_exec(
+        db_url,
+        insert(telemetry_tbl).values(
+            run_id=str(uuid.uuid4()),
+            run_name=run_name,
+            event="process_completed",
+            utc_time=_ts(),
+            sample_id=sample_id,
+            workflow_id=workflow_id,
+            workflow_version=workflow_version,
+            metadata_=None,
+            trace={
+                "process": process,
+                "status": status,
+                "name": f"{process} ({sample_id})",
+                "hash": task_hash,
+                "exit": exit_code,
+                "task_id": "1",
+            },
+        ),
+    ))
+
+
+# ---------------------------------------------------------------------------
+# /cohorts (list)
+# ---------------------------------------------------------------------------
+
+def test_list_cohorts_returns_collections_with_sample_counts(integration_client, db_url, cohort_data):
+    client, _ = integration_client
+    tag = cohort_data
+    cid = f"COHORT-{tag}"
+    _seed_cohort(db_url, collection_id=cid, sample_ids=[f"S-{tag}-{i}" for i in range(3)])
+
+    resp = client.get("/api/cohorts")
+    assert resp.status_code == 200
+    rows = resp.json()
+    match = [r for r in rows if r["collection_id"] == cid]
+    assert len(match) == 1
+    assert match[0]["sample_count"] == 3
+    assert match[0]["source"] == "manual"
+
+
+# ---------------------------------------------------------------------------
+# /cohorts/{id}/summary
+# ---------------------------------------------------------------------------
+
+def test_summary_404_for_unknown_cohort(integration_client):
+    client, _ = integration_client
+    resp = client.get("/api/cohorts/does-not-exist/summary")
+    assert resp.status_code == 404
+
+
+def test_summary_counts_jobs_by_status(integration_client, db_url, cohort_data):
+    client, _ = integration_client
+    tag = cohort_data
+    cid = f"COHORT-{tag}"
+    wf = f"wf-{tag}"
+    samples = [f"S-{tag}-{i}" for i in range(4)]
+    _seed_cohort(db_url, collection_id=cid, sample_ids=samples)
+
+    _seed_jobs(db_url, samples[0], "completed", workflow_id=wf)
+    _seed_jobs(db_url, samples[1], "completed", workflow_id=wf)
+    _seed_jobs(db_url, samples[2], "failed",    workflow_id=wf)
+    _seed_jobs(db_url, samples[3], "pending",   workflow_id=wf)
+
+    resp = client.get(f"/api/cohorts/{cid}/summary")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["sample_count"] == 4
+    assert body["total_jobs"] == 4
+    assert body["job_status_counts"]["completed"] == 2
+    assert body["job_status_counts"]["failed"] == 1
+    assert body["job_status_counts"]["pending"] == 1
+    assert body["completion_pct"] == 50.0
+
+
+def test_summary_zero_jobs_returns_zero_completion(integration_client, db_url, cohort_data):
+    client, _ = integration_client
+    tag = cohort_data
+    cid = f"COHORT-{tag}"
+    _seed_cohort(db_url, collection_id=cid, sample_ids=[f"S-{tag}-0"])
+
+    # Filter to a workflow that doesn't exist so the empty-cohort branch is exercised
+    # even if reconcile in another test created jobs against this sample.
+    resp = client.get(f"/api/cohorts/{cid}/summary?workflow_id=does-not-exist-{tag}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total_jobs"] == 0
+    assert body["completion_pct"] == 0.0
+
+
+def test_summary_failure_by_process_aggregates(integration_client, db_url, cohort_data):
+    client, _ = integration_client
+    tag = cohort_data
+    cid = f"COHORT-{tag}"
+    wf = f"wf-{tag}"
+    samples = [f"S-{tag}-{i}" for i in range(3)]
+    _seed_cohort(db_url, collection_id=cid, sample_ids=samples)
+
+    _seed_telemetry_failure(db_url, sample_id=samples[0], process="FETCH_READS", workflow_id=wf, run_name=f"run-{tag}-1")
+    _seed_telemetry_failure(db_url, sample_id=samples[1], process="FETCH_READS", workflow_id=wf, run_name=f"run-{tag}-2")
+    _seed_telemetry_failure(db_url, sample_id=samples[1], process="KNEADDATA",   workflow_id=wf, run_name=f"run-{tag}-3")
+    _seed_telemetry_failure(db_url, sample_id=samples[2], process="KNEADDATA",   workflow_id=wf, status="ABORTED", run_name=f"run-{tag}-4")
+
+    resp = client.get(f"/api/cohorts/{cid}/summary?workflow_id={wf}&workflow_version=1.0.0")
+    assert resp.status_code == 200
+    body = resp.json()
+    by_proc = {row["process"]: row for row in body["failure_by_process"]}
+    assert by_proc["FETCH_READS"]["failed_count"] == 2
+    assert by_proc["FETCH_READS"]["sample_count"] == 2
+    assert by_proc["KNEADDATA"]["failed_count"] == 2  # FAILED + ABORTED both count
+    assert by_proc["KNEADDATA"]["sample_count"] == 2
+
+
+def test_summary_workflow_filter_excludes_other_workflows(integration_client, db_url, cohort_data):
+    client, _ = integration_client
+    tag = cohort_data
+    cid = f"COHORT-{tag}"
+    wfA = f"wfA-{tag}"
+    wfB = f"wfB-{tag}"
+    samples = [f"S-{tag}-{i}" for i in range(2)]
+    _seed_cohort(db_url, collection_id=cid, sample_ids=samples)
+
+    _seed_jobs(db_url, samples[0], "completed", workflow_id=wfA)
+    _seed_jobs(db_url, samples[1], "failed",    workflow_id=wfB)
+
+    resp = client.get(f"/api/cohorts/{cid}/summary?workflow_id={wfA}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total_jobs"] == 1
+    assert body["job_status_counts"]["completed"] == 1
+
+
+def test_summary_excludes_samples_not_in_cohort(integration_client, db_url, cohort_data):
+    client, _ = integration_client
+    tag = cohort_data
+    cid = f"COHORT-{tag}"
+    wf = f"wf-{tag}"
+    sid_in = f"S-{tag}-in"
+    sid_out = f"S-{tag}-out"
+    _seed_cohort(db_url, collection_id=cid, sample_ids=[sid_in])
+
+    # sid_out has a job and a failure but is NOT in the cohort
+    from nextflow_telemetry.db import samples_tbl
+    _run(_exec(
+        db_url,
+        insert(samples_tbl).values(sample_id=sid_out, created_at=_ts(), updated_at=_ts()),
+    ))
+    _seed_jobs(db_url, sid_in, "completed", workflow_id=wf)
+    _seed_jobs(db_url, sid_out, "failed",   workflow_id=wf)
+    _seed_telemetry_failure(db_url, sample_id=sid_out, process="KNEADDATA", workflow_id=wf, run_name=f"run-{tag}")
+
+    resp = client.get(f"/api/cohorts/{cid}/summary?workflow_id={wf}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total_jobs"] == 1
+    assert body["job_status_counts"]["completed"] == 1
+    assert body["failure_by_process"] == []
+
+
+# ---------------------------------------------------------------------------
+# /cohorts/{id}/failures (drill-down)
+# ---------------------------------------------------------------------------
+
+def test_failures_returns_per_task_rows_with_task_hash(integration_client, db_url, cohort_data):
+    client, _ = integration_client
+    tag = cohort_data
+    cid = f"COHORT-{tag}"
+    wf = f"wf-{tag}"
+    samples = [f"S-{tag}-{i}" for i in range(2)]
+    _seed_cohort(db_url, collection_id=cid, sample_ids=samples)
+
+    _seed_telemetry_failure(db_url, sample_id=samples[0], process="FETCH_READS", workflow_id=wf, run_name=f"run-{tag}-1", task_hash="aa/000001")
+    _seed_telemetry_failure(db_url, sample_id=samples[1], process="FETCH_READS", workflow_id=wf, run_name=f"run-{tag}-2", task_hash="bb/000002")
+    _seed_telemetry_failure(db_url, sample_id=samples[0], process="KNEADDATA",   workflow_id=wf, run_name=f"run-{tag}-1", task_hash="cc/000003")
+
+    resp = client.get(f"/api/cohorts/{cid}/failures?process=FETCH_READS&workflow_id={wf}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["process"] == "FETCH_READS"
+    assert len(body["rows"]) == 2
+    hashes = {r["task_hash"] for r in body["rows"]}
+    assert hashes == {"aa/000001", "bb/000002"}
+    sample_set = {r["sample_id"] for r in body["rows"]}
+    assert sample_set == set(samples)


### PR DESCRIPTION
Closes #36 (extends with overnight-requested cohort summary scope). 

## Summary

- **GET /api/cohorts** — list collections (cohorts) with sample counts
- **GET /api/cohorts/{id}/summary** — completion %, job status counts, failure-by-process aggregation
- **GET /api/cohorts/{id}/failures?process=...** — drill-down to failed task rows (with task_hash for log lookup)
- **Frontend** new CohortsPage with cohort/workflow selectors, status chip strip, per-process failure bars, and a failed-task table that links into the existing log viewer.
- **No schema changes** — uses the existing \`collections\` + \`collection_samples\` tables added in PR #44, sidestepping the open many-to-one vs many-to-many question on #36.

## Decoupling note

I deliberately decoupled the cohort summary view from the data-model question raised in the original #36 description. Whatever decision is made about a first-class \"cohort\" concept later, this view will keep working — it queries collections directly.

## Test plan

- [x] \`just typecheck\` clean (35 source files)
- [x] \`just test\` — 71 passed (8 new), 3 skipped
- [x] Frontend \`npm run build\` clean (no TS errors)
- [x] cohort_data fixture cleans up tagged rows so cohort tests don't pollute reconcile-driven tests elsewhere in the suite
- [ ] After deploy: pick a real cohort (PRJNA…) on the new page, verify completion %, click a failing process, verify the task list links to log viewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)