### PR TITLE
docs: clarify SQLAlchemy Core vs raw text() convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,15 @@ Two packages in one repo:
 - **`services/`** — Business logic as `@dataclass` classes holding an `AsyncEngine`. All DB work is done with `async with engine.begin() as conn`.
 - **`migrations/`** — Alembic async migrations. Name format: `YYYYMMDD_<hash>_<description>.py`.
 
+### SQL style: SQLAlchemy Core vs raw `text()`
+
+Both styles are used and that's deliberate. Pick by the SQL, not by file:
+
+- **Core constructs** (`insert(tbl)`, `select(tbl.c.x)`, `update(tbl)`) for simple typed CRUD where you want column references and `.returning(*tbl.c)`. See `services/telemetry.py`, `routers/dispatch.py`.
+- **Raw `text()`** when the query leans on Postgres-specific shapes Core handles awkwardly: `ON CONFLICT ON CONSTRAINT`, JSONB operators (`trace->>'process'`), `INSERT…SELECT` with cross joins, conditional WHERE chunks built by f-string, multi-aggregate analytical queries. See `services/process_metrics.py`, `services/cohort.py`, `services/reconcile.py`, `routers/task_logs.py`.
+
+When using raw `text()`, **always pass user-derived values as `:name` bind parameters** — never f-string interpolation. F-strings are fine for static SQL fragments (e.g. optionally appending `AND foo = :foo` based on whether `foo` was supplied), but the values themselves go through bind params.
+
 ### Job lifecycle
 
 ```


### PR DESCRIPTION
## Summary

The codebase mixes SQLAlchemy Core (\`insert\`/\`select\`/\`update\`) and raw \`text()\` SQL deliberately. Documents the heuristic in CLAUDE.md so it doesn't drift and so contributors know which to reach for.

- **Core** — simple typed CRUD where column references and \`.returning(*tbl.c)\` are useful (\`telemetry\`, dispatch).
- **Raw \`text()\`** — for Postgres-specific shapes Core handles awkwardly: \`ON CONFLICT ON CONSTRAINT\`, JSONB operators, \`INSERT…SELECT\` cross joins, conditional WHERE chunks built by f-string, analytical queries (\`process_metrics\`, \`cohort\`, \`reconcile\`).
- **Hard rule:** user-derived values must go through \`:name\` bind parameters even when surrounding SQL is f-string-built.

## Test plan

- [x] Doc-only change; no code, no tests required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)