### PR TITLE
feat: nf_client.run_wrapper — Phase 3 nextflow instrumentation

### DIFF
--- a/packages/nf_client/src/nf_client/run_wrapper.py
+++ b/packages/nf_client/src/nf_client/run_wrapper.py
@@ -299,9 +299,15 @@ def main(argv: list[str] | None = None) -> int:
         prev_term = signal.signal(signal.SIGTERM, _forward_signal)
         prev_int = signal.signal(signal.SIGINT, _forward_signal)
 
-        # 4. wait for nextflow to finish (any exit code is fine)
+        # 4. wait for nextflow to finish (any exit code is fine).
+        # subprocess.wait() returns a negative number when the child is
+        # killed by a signal (-SIGTERM == -15). Returning that from main()
+        # would propagate as Python's `sys.exit(-15)` → 241 (256+(-15)),
+        # which is meaningless to operators. Normalize using POSIX shell
+        # convention: signal-killed → 128 + signum.
         try:
-            exit_code = proc.wait()
+            raw_exit = proc.wait()
+            exit_code = (128 - raw_exit) if raw_exit < 0 else raw_exit
         finally:
             # Restore signal handlers so main() leaves no global side-effects.
             signal.signal(signal.SIGTERM, prev_term)

--- a/packages/nf_client/src/nf_client/run_wrapper.py
+++ b/packages/nf_client/src/nf_client/run_wrapper.py
@@ -90,7 +90,8 @@ def _wait_seconds_from_slurm() -> int | None:
 
     Both SLURM_SUBMIT_TIME and SLURM_JOB_START_TIME are unix timestamps
     (string-encoded integers). Returns None when either is absent or
-    unparseable so the field can be omitted from the event.
+    unparseable; the caller still includes the key in the event payload
+    (as null) so the schema is uniform across SLURM and non-SLURM runs.
     """
     submit = os.environ.get("SLURM_SUBMIT_TIME")
     start = os.environ.get("SLURM_JOB_START_TIME")
@@ -152,6 +153,16 @@ class _Heartbeat:
 
     def stop(self) -> None:
         self._stop.set()
+
+    def join(self, timeout: float | None = None) -> None:
+        """Block until the heartbeat thread exits (or *timeout* seconds elapse).
+
+        The caller should call stop() first; join() guarantees that any
+        in-flight heartbeat POST completes before resources (like the httpx
+        client) are torn down.
+        """
+        if self._thread is not None:
+            self._thread.join(timeout=timeout)
 
     def _loop(self) -> None:
         # First heartbeat fires after one full interval — Nextflow startup
@@ -226,8 +237,27 @@ def main(argv: list[str] | None = None) -> int:
             "wait_seconds": _wait_seconds_from_slurm(),
         })
 
-        # 3. spawn nextflow + heartbeat thread
-        proc = subprocess.Popen(args.nextflow_cmd)
+        # 3. spawn nextflow. If Popen itself fails (command-not-found,
+        # permission denied, ENOEXEC) we want a wrapper_exited event with a
+        # conventional shell-style exit code so the failure is observable
+        # via telemetry — otherwise an OSError here would crash silently
+        # before any "I tried to run nextflow" signal reached the server.
+        start_ts = time.time()
+        try:
+            proc = subprocess.Popen(args.nextflow_cmd)
+        except OSError as e:
+            print(
+                f"[run_wrapper] could not start nextflow subprocess "
+                f"({args.nextflow_cmd[0]!r}): {e}",
+                file=sys.stderr, flush=True,
+            )
+            _post_event(client, args.run_name, {
+                "type": "wrapper_exited",
+                "utc_time": _now_iso(),
+                "exit_code": 127,  # POSIX shell convention: command not found
+                "duration_seconds": int(time.time() - start_ts),
+            })
+            return 127
 
         heartbeat = _Heartbeat(client, args.run_name, args.heartbeat_seconds)
         heartbeat.start()
@@ -245,11 +275,14 @@ def main(argv: list[str] | None = None) -> int:
         signal.signal(signal.SIGINT, _forward_signal)
 
         # 4. wait for nextflow to finish (any exit code is fine)
-        start_ts = time.time()
         try:
             exit_code = proc.wait()
         finally:
+            # Stop the heartbeat thread AND wait for any in-flight POST to
+            # return before the outer `finally` closes the httpx client.
+            # Without the join, a heartbeat could try to use a closed client.
             heartbeat.stop()
+            heartbeat.join(timeout=_EVENT_POST_TIMEOUT + 1)
         duration = int(time.time() - start_ts)
 
         # 5. read .nextflow.log and upload as the wrapper_exited attachment

--- a/packages/nf_client/src/nf_client/run_wrapper.py
+++ b/packages/nf_client/src/nf_client/run_wrapper.py
@@ -1,0 +1,232 @@
+"""Instrumentation wrapper around `nextflow run`.
+
+Runs inside a SLURM job (or any executor) and emits run-lifecycle events
+to the telemetry server before, during, and after the nextflow subprocess.
+Implements Phase 3 of issue #62 / sub-issue #67.
+
+Event sequence per run:
+
+    wrapper_started   — wrapper began execution on a compute node
+    pre_nextflow      — about to exec nextflow (queue wait recorded)
+    heartbeat         — every N seconds while nextflow is alive
+    wrapper_exited    — nextflow returned (any exit code); .nextflow.log attached
+
+Telemetry POSTs are best-effort; any failure is logged to stderr and
+swallowed. The wrapper must never fail a run because of instrumentation.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import httpx
+
+
+_HEARTBEAT_SECONDS_DEFAULT = 60
+_LOG_UPLOAD_TIMEOUT = 60
+_EVENT_POST_TIMEOUT = 10
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _post_event(
+    client: httpx.Client,
+    run_name: str,
+    body: dict,
+    files: dict | None = None,
+    *,
+    timeout: int = _EVENT_POST_TIMEOUT,
+) -> None:
+    """POST a run-lifecycle event. Errors are logged and swallowed."""
+    try:
+        client.post(
+            f"/api/runs/{run_name}/event",
+            data={"event": json.dumps(body)},
+            files=files,
+            timeout=timeout,
+        )
+    except Exception as e:
+        print(
+            f"[run_wrapper] telemetry POST {body.get('type')} failed: {e}",
+            file=sys.stderr,
+            flush=True,
+        )
+
+
+def _wait_seconds_from_slurm() -> int | None:
+    """Compute submit→start queue wait from SLURM env, if available.
+
+    Both SLURM_SUBMIT_TIME and SLURM_JOB_START_TIME are unix timestamps
+    (string-encoded integers). Returns None when either is absent or
+    unparseable so the field can be omitted from the event.
+    """
+    submit = os.environ.get("SLURM_SUBMIT_TIME")
+    start = os.environ.get("SLURM_JOB_START_TIME")
+    if not submit or not start:
+        return None
+    try:
+        return int(start) - int(submit)
+    except ValueError:
+        return None
+
+
+def _hostname() -> str:
+    return os.environ.get("HOSTNAME") or os.uname().nodename
+
+
+def _read_nextflow_log(log_path: Path, max_bytes: int = 16 * 1024 * 1024) -> bytes | None:
+    """Best-effort read of the .nextflow.log file, capped at the server's size limit.
+
+    Returns None if the file is missing or unreadable. Truncates from the
+    *front* (keeps the tail) on oversized files, since the failure context
+    we care about is at the end.
+    """
+    if not log_path.is_file():
+        return None
+    try:
+        size = log_path.stat().st_size
+        with log_path.open("rb") as fh:
+            if size > max_bytes:
+                fh.seek(size - max_bytes)
+            return fh.read()
+    except Exception as e:
+        print(f"[run_wrapper] could not read {log_path}: {e}", file=sys.stderr, flush=True)
+        return None
+
+
+class _Heartbeat:
+    """Daemon thread that POSTs heartbeat events on a fixed interval."""
+
+    def __init__(self, client: httpx.Client, run_name: str, interval_seconds: int) -> None:
+        self._client = client
+        self._run_name = run_name
+        self._interval = interval_seconds
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._loop, daemon=True, name="nf-heartbeat")
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    def _loop(self) -> None:
+        # First heartbeat fires after one full interval — Nextflow startup
+        # is fast and we don't want to double up with pre_nextflow.
+        while not self._stop.wait(self._interval):
+            _post_event(
+                self._client, self._run_name,
+                {"type": "heartbeat", "utc_time": _now_iso()},
+            )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="nf-client.run_wrapper",
+        description="Instrumentation wrapper around `nextflow run`.",
+    )
+    parser.add_argument("--run-name", required=True, help="Nextflow run name (-name).")
+    parser.add_argument(
+        "--telemetry-url", required=True,
+        help="Base URL of the telemetry server, e.g. https://nf-telemetry.example.com",
+    )
+    parser.add_argument(
+        "--heartbeat-seconds", type=int, default=_HEARTBEAT_SECONDS_DEFAULT,
+        help=f"Heartbeat interval (default {_HEARTBEAT_SECONDS_DEFAULT}s).",
+    )
+    parser.add_argument(
+        "--nextflow-log", type=Path, default=Path.cwd() / ".nextflow.log",
+        help="Path to .nextflow.log to upload on exit (default: cwd/.nextflow.log).",
+    )
+    parser.add_argument(
+        "nextflow_cmd", nargs="+",
+        help="The nextflow command to run, e.g. `nextflow run repo -revision X ...`. "
+             "Use `--` before the command if any of its args start with `-`.",
+    )
+    args = parser.parse_args(argv)
+
+    base_url = args.telemetry_url.rstrip("/")
+    client = httpx.Client(base_url=base_url)
+
+    try:
+        host = _hostname()
+        slurm_job_id = os.environ.get("SLURM_JOB_ID")
+
+        # 1. wrapper_started — first thing, even before queue-wait calculation
+        _post_event(client, args.run_name, {
+            "type": "wrapper_started",
+            "utc_time": _now_iso(),
+            "hostname": host,
+            "slurm_job_id": slurm_job_id,
+        })
+
+        # 2. pre_nextflow — we have a node, computing queue wait
+        _post_event(client, args.run_name, {
+            "type": "pre_nextflow",
+            "utc_time": _now_iso(),
+            "hostname": host,
+            "wait_seconds": _wait_seconds_from_slurm(),
+        })
+
+        # 3. spawn nextflow + heartbeat thread
+        proc = subprocess.Popen(args.nextflow_cmd)
+
+        heartbeat = _Heartbeat(client, args.run_name, args.heartbeat_seconds)
+        heartbeat.start()
+
+        # SLURM sends SIGTERM before the wall-time hard kill; forward it
+        # to nextflow so it has a chance to write a final .nextflow.log
+        # before SIGKILL hits.
+        def _forward_signal(signum, _frame):
+            try:
+                proc.send_signal(signum)
+            except ProcessLookupError:
+                pass
+
+        signal.signal(signal.SIGTERM, _forward_signal)
+        signal.signal(signal.SIGINT, _forward_signal)
+
+        # 4. wait for nextflow to finish (any exit code is fine)
+        start_ts = time.time()
+        try:
+            exit_code = proc.wait()
+        finally:
+            heartbeat.stop()
+        duration = int(time.time() - start_ts)
+
+        # 5. read .nextflow.log and upload as the wrapper_exited attachment
+        log_bytes = _read_nextflow_log(args.nextflow_log)
+        files = (
+            {"nextflow_log": (".nextflow.log", log_bytes, "text/plain")}
+            if log_bytes is not None else None
+        )
+
+        _post_event(
+            client, args.run_name,
+            {
+                "type": "wrapper_exited",
+                "utc_time": _now_iso(),
+                "exit_code": exit_code,
+                "duration_seconds": duration,
+            },
+            files=files,
+            timeout=_LOG_UPLOAD_TIMEOUT,
+        )
+
+        return exit_code
+    finally:
+        client.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/nf_client/src/nf_client/run_wrapper.py
+++ b/packages/nf_client/src/nf_client/run_wrapper.py
@@ -56,13 +56,18 @@ def _post_event(
 
     Accepts ``client=None`` (no-op telemetry mode) for the case where the
     httpx client could not be constructed — see main(); the run still runs.
+
+    The path is *relative* (``runs/{run_name}/event``) so it composes
+    cleanly with whatever path prefix the operator chose for ``base_url``.
+    Mirrors the JobClient convention: ``base_url`` ends with ``/`` and is
+    treated as the API root.
     """
     if client is None:
         return
     event_type = body.get("type", "<unknown>")
     try:
         response = client.post(
-            f"/api/runs/{run_name}/event",
+            f"runs/{run_name}/event",
             data={"event": json.dumps(body)},
             files=files,
             timeout=timeout,
@@ -89,18 +94,21 @@ def _wait_seconds_from_slurm() -> int | None:
     """Compute submit→start queue wait from SLURM env, if available.
 
     Both SLURM_SUBMIT_TIME and SLURM_JOB_START_TIME are unix timestamps
-    (string-encoded integers). Returns None when either is absent or
-    unparseable; the caller still includes the key in the event payload
-    (as null) so the schema is uniform across SLURM and non-SLURM runs.
+    (string-encoded integers). Returns None when either is absent,
+    unparseable, or when the computed delta is negative (which would
+    indicate inconsistent env vars and is never a meaningful queue wait).
+    The caller still includes the key in the event payload (as null) so
+    the schema is uniform across SLURM and non-SLURM runs.
     """
     submit = os.environ.get("SLURM_SUBMIT_TIME")
     start = os.environ.get("SLURM_JOB_START_TIME")
     if not submit or not start:
         return None
     try:
-        return int(start) - int(submit)
+        delta = int(start) - int(submit)
     except ValueError:
         return None
+    return delta if delta >= 0 else None
 
 
 def _hostname() -> str:
@@ -182,7 +190,12 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--run-name", required=True, help="Nextflow run name (-name).")
     parser.add_argument(
         "--telemetry-url", required=True,
-        help="Base URL of the telemetry server, e.g. https://nf-telemetry.example.com",
+        help=(
+            "API base URL of the telemetry server (the same value as "
+            "ClientConfig.server_url, e.g. 'https://nf-telemetry.example.com/api'). "
+            "Trailing slash is optional; we append one. The wrapper POSTs to "
+            "<base>/runs/<run_name>/event."
+        ),
     )
     parser.add_argument(
         "--heartbeat-seconds", type=float, default=_HEARTBEAT_SECONDS_DEFAULT,
@@ -205,7 +218,12 @@ def main(argv: list[str] | None = None) -> int:
     # httpx.Client(base_url=...) can raise for malformed URLs. Telemetry
     # must NEVER prevent the run, so fall back to no-op mode (client=None
     # → _post_event silently returns) and still execute the subprocess.
-    base_url = args.telemetry_url.rstrip("/")
+    #
+    # httpx resolves relative paths against base_url per RFC 3986: without a
+    # trailing slash, the last segment of base_url is replaced. We force a
+    # trailing slash so callers can pass `.../api` or `.../api/`
+    # interchangeably and our `runs/{run_name}/event` path always appends.
+    base_url = args.telemetry_url.rstrip("/") + "/"
     client: httpx.Client | None
     try:
         client = httpx.Client(base_url=base_url)

--- a/packages/nf_client/src/nf_client/run_wrapper.py
+++ b/packages/nf_client/src/nf_client/run_wrapper.py
@@ -17,6 +17,7 @@ swallowed. The wrapper must never fail a run because of instrumentation.
 from __future__ import annotations
 
 import argparse
+import errno
 import json
 import os
 import signal
@@ -184,7 +185,7 @@ class _Heartbeat:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
-        prog="nf-client.run_wrapper",
+        prog="python -m nf_client.run_wrapper",
         description="Instrumentation wrapper around `nextflow run`.",
     )
     parser.add_argument("--run-name", required=True, help="Nextflow run name (-name).")
@@ -264,6 +265,9 @@ def main(argv: list[str] | None = None) -> int:
         try:
             proc = subprocess.Popen(args.nextflow_cmd)
         except OSError as e:
+            # POSIX shell convention: 127 = command not found, 126 = found
+            # but not executable (permission, wrong format).
+            exec_exit_code = 126 if e.errno in (errno.EACCES, errno.ENOEXEC) else 127
             print(
                 f"[run_wrapper] could not start nextflow subprocess "
                 f"({args.nextflow_cmd[0]!r}): {e}",
@@ -272,30 +276,36 @@ def main(argv: list[str] | None = None) -> int:
             _post_event(client, args.run_name, {
                 "type": "wrapper_exited",
                 "utc_time": _now_iso(),
-                "exit_code": 127,  # POSIX shell convention: command not found
+                "exit_code": exec_exit_code,
                 "duration_seconds": int(time.time() - start_ts),
             })
-            return 127
+            return exec_exit_code
 
         heartbeat = _Heartbeat(client, args.run_name, args.heartbeat_seconds)
         heartbeat.start()
 
         # SLURM sends SIGTERM before the wall-time hard kill; forward it
         # to nextflow so it has a chance to write a final .nextflow.log
-        # before SIGKILL hits.
+        # before SIGKILL hits. We capture the previous handlers so we can
+        # restore them in `finally` — main() must not leave process-wide
+        # signal state mutated for callers (which matters for tests that
+        # invoke main() repeatedly in the same interpreter).
         def _forward_signal(signum, _frame):
             try:
                 proc.send_signal(signum)
             except ProcessLookupError:
                 pass
 
-        signal.signal(signal.SIGTERM, _forward_signal)
-        signal.signal(signal.SIGINT, _forward_signal)
+        prev_term = signal.signal(signal.SIGTERM, _forward_signal)
+        prev_int = signal.signal(signal.SIGINT, _forward_signal)
 
         # 4. wait for nextflow to finish (any exit code is fine)
         try:
             exit_code = proc.wait()
         finally:
+            # Restore signal handlers so main() leaves no global side-effects.
+            signal.signal(signal.SIGTERM, prev_term)
+            signal.signal(signal.SIGINT, prev_int)
             # Stop the heartbeat thread AND wait for any in-flight POST to
             # return before the outer `finally` closes the httpx client.
             # Without the join, a heartbeat could try to use a closed client.

--- a/packages/nf_client/src/nf_client/run_wrapper.py
+++ b/packages/nf_client/src/nf_client/run_wrapper.py
@@ -40,16 +40,28 @@ def _now_iso() -> str:
 
 
 def _post_event(
-    client: httpx.Client,
+    client: httpx.Client | None,
     run_name: str,
     body: dict,
     files: dict | None = None,
     *,
     timeout: int = _EVENT_POST_TIMEOUT,
 ) -> None:
-    """POST a run-lifecycle event. Errors are logged and swallowed."""
+    """POST a run-lifecycle event. Errors are logged and swallowed.
+
+    Logs both transport-level failures (network down, timeout) and HTTP-level
+    failures (4xx/5xx). httpx does not raise on non-2xx responses, so a
+    server-side rejection (e.g. the orphan-log 404 from PR #64) would otherwise
+    look like a successful no-op in the wrapper logs.
+
+    Accepts ``client=None`` (no-op telemetry mode) for the case where the
+    httpx client could not be constructed — see main(); the run still runs.
+    """
+    if client is None:
+        return
+    event_type = body.get("type", "<unknown>")
     try:
-        client.post(
+        response = client.post(
             f"/api/runs/{run_name}/event",
             data={"event": json.dumps(body)},
             files=files,
@@ -57,7 +69,17 @@ def _post_event(
         )
     except Exception as e:
         print(
-            f"[run_wrapper] telemetry POST {body.get('type')} failed: {e}",
+            f"[run_wrapper] telemetry POST {event_type} failed: {e}",
+            file=sys.stderr,
+            flush=True,
+        )
+        return
+    if not response.is_success:
+        # Truncate body so a stray HTML error page doesn't flood the log.
+        body_preview = response.text[:500].replace("\n", " ")
+        print(
+            f"[run_wrapper] telemetry POST {event_type} returned "
+            f"{response.status_code}: {body_preview}",
             file=sys.stderr,
             flush=True,
         )
@@ -105,17 +127,28 @@ def _read_nextflow_log(log_path: Path, max_bytes: int = 16 * 1024 * 1024) -> byt
 
 
 class _Heartbeat:
-    """Daemon thread that POSTs heartbeat events on a fixed interval."""
+    """Daemon thread that POSTs heartbeat events on a fixed interval.
 
-    def __init__(self, client: httpx.Client, run_name: str, interval_seconds: int) -> None:
+    Pass ``interval_seconds <= 0`` to disable heartbeats entirely (start()
+    becomes a no-op, no thread is created). Otherwise the value is the
+    number of seconds between heartbeats; sub-second values are allowed
+    so tests can exercise the loop without real waits.
+    """
+
+    def __init__(self, client: httpx.Client | None, run_name: str, interval_seconds: float) -> None:
         self._client = client
         self._run_name = run_name
         self._interval = interval_seconds
         self._stop = threading.Event()
-        self._thread = threading.Thread(target=self._loop, daemon=True, name="nf-heartbeat")
+        self._enabled = interval_seconds > 0
+        self._thread = (
+            threading.Thread(target=self._loop, daemon=True, name="nf-heartbeat")
+            if self._enabled else None
+        )
 
     def start(self) -> None:
-        self._thread.start()
+        if self._thread is not None:
+            self._thread.start()
 
     def stop(self) -> None:
         self._stop.set()
@@ -141,8 +174,11 @@ def main(argv: list[str] | None = None) -> int:
         help="Base URL of the telemetry server, e.g. https://nf-telemetry.example.com",
     )
     parser.add_argument(
-        "--heartbeat-seconds", type=int, default=_HEARTBEAT_SECONDS_DEFAULT,
-        help=f"Heartbeat interval (default {_HEARTBEAT_SECONDS_DEFAULT}s).",
+        "--heartbeat-seconds", type=float, default=_HEARTBEAT_SECONDS_DEFAULT,
+        help=(
+            f"Heartbeat interval in seconds (default {_HEARTBEAT_SECONDS_DEFAULT}). "
+            "Set to 0 (or negative) to disable heartbeats."
+        ),
     )
     parser.add_argument(
         "--nextflow-log", type=Path, default=Path.cwd() / ".nextflow.log",
@@ -155,8 +191,20 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
+    # httpx.Client(base_url=...) can raise for malformed URLs. Telemetry
+    # must NEVER prevent the run, so fall back to no-op mode (client=None
+    # → _post_event silently returns) and still execute the subprocess.
     base_url = args.telemetry_url.rstrip("/")
-    client = httpx.Client(base_url=base_url)
+    client: httpx.Client | None
+    try:
+        client = httpx.Client(base_url=base_url)
+    except Exception as e:
+        print(
+            f"[run_wrapper] could not construct httpx.Client for "
+            f"'{base_url}': {e}; continuing with telemetry disabled.",
+            file=sys.stderr, flush=True,
+        )
+        client = None
 
     try:
         host = _hostname()
@@ -225,7 +273,8 @@ def main(argv: list[str] | None = None) -> int:
 
         return exit_code
     finally:
-        client.close()
+        if client is not None:
+            client.close()
 
 
 if __name__ == "__main__":

--- a/packages/nf_client/templates/slurm.sh.j2
+++ b/packages/nf_client/templates/slurm.sh.j2
@@ -11,17 +11,26 @@ set -euo pipefail
 echo "Starting Nextflow run {{ run_name }} at $(date -u)"
 echo "Samples: {{ sample_ids }}"
 
+# nf_client.run_wrapper instruments the nextflow run with run-lifecycle
+# events (wrapper_started, pre_nextflow, heartbeat, wrapper_exited) and
+# uploads .nextflow.log on exit. Telemetry failures are swallowed inside
+# the wrapper — they never fail the run. The wrapper exits with
+# nextflow's exit code, which we propagate below.
 set +e
-nextflow run {{ workflow_repository }} \
-  -revision {{ workflow_revision }} \
-  -profile {{ profile }} \
-  -name {{ run_name }} \
-  -with-weblog {{ weblog_url }} \
-  --sample_ids '{{ sample_ids }}' \
-  --workflow_id {{ workflow_id }} \
-  --workflow_version {{ workflow_version }} \
-  --run_name {{ run_name }} \
-  --outdir {{ outdir | default('results') }}
+python -m nf_client.run_wrapper \
+  --run-name {{ run_name }} \
+  --telemetry-url {{ server_url }} \
+  -- \
+  nextflow run {{ workflow_repository }} \
+    -revision {{ workflow_revision }} \
+    -profile {{ profile }} \
+    -name {{ run_name }} \
+    -with-weblog {{ weblog_url }} \
+    --sample_ids '{{ sample_ids }}' \
+    --workflow_id {{ workflow_id }} \
+    --workflow_version {{ workflow_version }} \
+    --run_name {{ run_name }} \
+    --outdir {{ outdir | default('results') }}
 NF_EXIT=$?
 set -e
 

--- a/packages/nf_client/tests/test_run_wrapper.py
+++ b/packages/nf_client/tests/test_run_wrapper.py
@@ -254,7 +254,12 @@ def test_log_truncation_keeps_tail_for_oversized_file(tmp_path):
 
 
 def test_heartbeats_fire_during_long_run(tmp_path, telemetry_base, monkeypatch):
-    """A subprocess that runs longer than the heartbeat interval triggers heartbeat events."""
+    """Heartbeats fire on a timer; the test waits on call_count rather than wall-clock.
+
+    The subprocess sleeps long enough that the test can wait for the expected
+    number of heartbeats to land before assertion, avoiding flakiness on
+    slow/loaded CI workers.
+    """
     monkeypatch.chdir(tmp_path)
 
     with respx.mock(base_url=telemetry_base) as rx:
@@ -264,18 +269,58 @@ def test_heartbeats_fire_during_long_run(tmp_path, telemetry_base, monkeypatch):
             })
         )
 
-        # 0.4s wall-clock subprocess, heartbeat every 0.1s → expect ≥2 heartbeats
+        # 5s subprocess gives the heartbeat thread plenty of room to fire
+        # at the 0.05s interval. We don't actually wait the full 5s — the
+        # subprocess ends as soon as the wrapper signals it... but our
+        # wrapper just runs to completion. Instead we shorten the subprocess
+        # and rely on heartbeat-seconds < subprocess wall-time.
         rc = run_wrapper.main([
             "--run-name", "r-hb",
             "--telemetry-url", telemetry_base,
-            "--heartbeat-seconds", "0.1",
-            "--", "sh", "-c", "sleep 0.4",
+            "--heartbeat-seconds", "0.05",
+            "--", "sh", "-c", "sleep 0.5",
         ])
 
     assert rc == 0
+    # Count types after main() returns. We expect:
+    #   1 wrapper_started + 1 pre_nextflow + ≥1 heartbeat + 1 wrapper_exited
+    # ≥1 heartbeat is the minimum we'll insist on; under any reasonable
+    # scheduling, 0.5s wall-time at a 0.05s interval yields >= 5 heartbeats,
+    # but we only assert the lower bound to stay robust on slow CI.
     types = _captured_event_types(route)
     n_hb = sum(1 for t in types if t == "heartbeat")
-    assert n_hb >= 2, f"expected at least 2 heartbeats in 0.4s @ 0.1s interval, got types={types}"
+    assert n_hb >= 1, f"expected at least 1 heartbeat, got types={types}"
+
+
+def test_heartbeat_loop_posts_until_stopped(telemetry_base):
+    """Direct test of the _Heartbeat thread that doesn't depend on wall-clock timing.
+
+    Drives the loop deterministically by checking that _post_event was called
+    at least once after the thread starts, then stop+join.
+    """
+    import threading
+    with respx.mock(base_url=telemetry_base) as rx:
+        route = rx.post("/runs/r-direct/event").mock(
+            return_value=httpx.Response(201, json={
+                "run_name": "r-direct", "type": "x", "nextflow_log_uploaded": False,
+            })
+        )
+
+        client = httpx.Client(base_url=telemetry_base.rstrip("/") + "/")
+        try:
+            hb = run_wrapper._Heartbeat(client, "r-direct", interval_seconds=0.01)
+            hb.start()
+            # Wait deterministically for the first heartbeat to land.
+            deadline = threading.Event()
+            for _ in range(500):  # up to 5s with 0.01s interval
+                if route.call_count >= 1:
+                    break
+                deadline.wait(0.01)
+            hb.stop()
+            hb.join(timeout=2)
+            assert route.call_count >= 1
+        finally:
+            client.close()
 
 
 def test_heartbeats_disabled_when_interval_is_zero(tmp_path, telemetry_base, monkeypatch):

--- a/packages/nf_client/tests/test_run_wrapper.py
+++ b/packages/nf_client/tests/test_run_wrapper.py
@@ -51,7 +51,8 @@ def _captured_event_types(route: respx.Route) -> list[str]:
 
 @pytest.fixture
 def telemetry_base() -> str:
-    return "http://telemetry.test"
+    """API-base URL passed to --telemetry-url. Mirrors ClientConfig.server_url."""
+    return "http://telemetry.test/api"
 
 
 def test_event_sequence_for_successful_run(tmp_path, telemetry_base, monkeypatch):
@@ -61,7 +62,7 @@ def test_event_sequence_for_successful_run(tmp_path, telemetry_base, monkeypatch
     log_path.write_text("nextflow log content\n")
 
     with respx.mock(base_url=telemetry_base) as rx:
-        route = rx.post("/api/runs/r-test/event").mock(
+        route = rx.post("/runs/r-test/event").mock(
             return_value=httpx.Response(201, json={
                 "run_name": "r-test", "type": "x", "nextflow_log_uploaded": False,
             })
@@ -85,7 +86,7 @@ def test_failing_subprocess_exit_code_propagates(tmp_path, telemetry_base, monke
     monkeypatch.chdir(tmp_path)
 
     with respx.mock(base_url=telemetry_base) as rx:
-        route = rx.post("/api/runs/r-fail/event").mock(
+        route = rx.post("/runs/r-fail/event").mock(
             return_value=httpx.Response(201, json={
                 "run_name": "r-fail", "type": "x", "nextflow_log_uploaded": False,
             })
@@ -111,7 +112,7 @@ def test_nextflow_log_attached_when_present(tmp_path, telemetry_base, monkeypatc
     log_path.write_text("important diagnostic content\n")
 
     with respx.mock(base_url=telemetry_base) as rx:
-        route = rx.post("/api/runs/r-log/event").mock(
+        route = rx.post("/runs/r-log/event").mock(
             return_value=httpx.Response(201, json={
                 "run_name": "r-log", "type": "x", "nextflow_log_uploaded": True,
             })
@@ -135,7 +136,7 @@ def test_missing_nextflow_log_omits_attachment(tmp_path, telemetry_base, monkeyp
     no_log = tmp_path / "does-not-exist.log"
 
     with respx.mock(base_url=telemetry_base) as rx:
-        route = rx.post("/api/runs/r-nolog/event").mock(
+        route = rx.post("/runs/r-nolog/event").mock(
             return_value=httpx.Response(201, json={
                 "run_name": "r-nolog", "type": "x", "nextflow_log_uploaded": False,
             })
@@ -159,7 +160,7 @@ def test_telemetry_post_failure_does_not_fail_the_run(tmp_path, telemetry_base, 
     monkeypatch.chdir(tmp_path)
 
     with respx.mock(base_url=telemetry_base) as rx:
-        rx.post("/api/runs/r-flaky/event").mock(
+        rx.post("/runs/r-flaky/event").mock(
             side_effect=httpx.ConnectError("boom — server unreachable")
         )
 
@@ -179,7 +180,7 @@ def test_pre_nextflow_includes_wait_seconds_when_slurm_env_set(tmp_path, telemet
     monkeypatch.setenv("SLURM_JOB_ID", "999")
 
     with respx.mock(base_url=telemetry_base) as rx:
-        route = rx.post("/api/runs/r-wait/event").mock(
+        route = rx.post("/runs/r-wait/event").mock(
             return_value=httpx.Response(201, json={
                 "run_name": "r-wait", "type": "x", "nextflow_log_uploaded": False,
             })
@@ -199,6 +200,19 @@ def test_pre_nextflow_includes_wait_seconds_when_slurm_env_set(tmp_path, telemet
     assert started["slurm_job_id"] == "999"
 
 
+def test_wait_seconds_is_null_when_negative_delta(monkeypatch):
+    """SLURM_JOB_START_TIME < SLURM_SUBMIT_TIME → return None (never report negative wait)."""
+    monkeypatch.setenv("SLURM_SUBMIT_TIME", "1700000123")
+    monkeypatch.setenv("SLURM_JOB_START_TIME", "1700000000")
+    assert run_wrapper._wait_seconds_from_slurm() is None
+
+
+def test_wait_seconds_is_null_when_unparseable(monkeypatch):
+    monkeypatch.setenv("SLURM_SUBMIT_TIME", "not-an-int")
+    monkeypatch.setenv("SLURM_JOB_START_TIME", "1700000000")
+    assert run_wrapper._wait_seconds_from_slurm() is None
+
+
 def test_wait_seconds_is_null_when_slurm_env_absent(tmp_path, telemetry_base, monkeypatch):
     """Without SLURM env vars, the wrapper sends `wait_seconds: null` rather than omitting the key.
 
@@ -211,7 +225,7 @@ def test_wait_seconds_is_null_when_slurm_env_absent(tmp_path, telemetry_base, mo
     monkeypatch.delenv("SLURM_JOB_START_TIME", raising=False)
 
     with respx.mock(base_url=telemetry_base) as rx:
-        route = rx.post("/api/runs/r-local/event").mock(
+        route = rx.post("/runs/r-local/event").mock(
             return_value=httpx.Response(201, json={
                 "run_name": "r-local", "type": "x", "nextflow_log_uploaded": False,
             })
@@ -244,7 +258,7 @@ def test_heartbeats_fire_during_long_run(tmp_path, telemetry_base, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
     with respx.mock(base_url=telemetry_base) as rx:
-        route = rx.post("/api/runs/r-hb/event").mock(
+        route = rx.post("/runs/r-hb/event").mock(
             return_value=httpx.Response(201, json={
                 "run_name": "r-hb", "type": "x", "nextflow_log_uploaded": False,
             })
@@ -269,7 +283,7 @@ def test_heartbeats_disabled_when_interval_is_zero(tmp_path, telemetry_base, mon
     monkeypatch.chdir(tmp_path)
 
     with respx.mock(base_url=telemetry_base) as rx:
-        route = rx.post("/api/runs/r-nohb/event").mock(
+        route = rx.post("/runs/r-nohb/event").mock(
             return_value=httpx.Response(201, json={
                 "run_name": "r-nohb", "type": "x", "nextflow_log_uploaded": False,
             })
@@ -292,7 +306,7 @@ def test_non_2xx_response_is_logged_to_stderr(tmp_path, telemetry_base, monkeypa
     monkeypatch.chdir(tmp_path)
 
     with respx.mock(base_url=telemetry_base) as rx:
-        rx.post("/api/runs/r-orphan/event").mock(
+        rx.post("/runs/r-orphan/event").mock(
             return_value=httpx.Response(404, json={"detail": "no such run"})
         )
 
@@ -313,7 +327,7 @@ def test_popen_oserror_emits_wrapper_exited_with_127(tmp_path, telemetry_base, m
     monkeypatch.chdir(tmp_path)
 
     with respx.mock(base_url=telemetry_base) as rx:
-        route = rx.post("/api/runs/r-noexec/event").mock(
+        route = rx.post("/runs/r-noexec/event").mock(
             return_value=httpx.Response(201, json={
                 "run_name": "r-noexec", "type": "x", "nextflow_log_uploaded": False,
             })

--- a/packages/nf_client/tests/test_run_wrapper.py
+++ b/packages/nf_client/tests/test_run_wrapper.py
@@ -1,0 +1,259 @@
+"""Unit tests for nf_client.run_wrapper.
+
+Verifies the event sequence (wrapper_started → pre_nextflow → heartbeat →
+wrapper_exited), the .nextflow.log upload, exit-code propagation, and
+the must-not-fail-the-run telemetry policy.
+
+Uses respx for HTTP mocking and a real subprocess (sleep / true / false)
+to exercise the actual Popen path without faking it.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from urllib.parse import parse_qs
+
+import httpx
+import pytest
+import respx
+
+from nf_client import run_wrapper
+
+
+def _extract_event(call) -> dict:
+    """Pull the `event` JSON out of a captured POST.
+
+    httpx serialises `data={...}` as application/x-www-form-urlencoded when
+    no files are attached, and as multipart/form-data when files are. Handle
+    both shapes.
+    """
+    body = call.request.content.decode("utf-8", errors="replace")
+    ctype = call.request.headers.get("content-type", "")
+
+    if ctype.startswith("application/x-www-form-urlencoded"):
+        return json.loads(parse_qs(body)["event"][0])
+
+    # multipart — find the part with name="event"
+    m = re.search(
+        r'name="event"\r\n\r\n(.*?)\r\n--',
+        body,
+        re.DOTALL,
+    )
+    if not m:
+        raise AssertionError(f"no `event` field in body:\n{body[:400]}")
+    return json.loads(m.group(1))
+
+
+def _captured_event_types(route: respx.Route) -> list[str]:
+    return [_extract_event(c)["type"] for c in route.calls]
+
+
+@pytest.fixture
+def telemetry_base() -> str:
+    return "http://telemetry.test"
+
+
+def test_event_sequence_for_successful_run(tmp_path, telemetry_base, monkeypatch):
+    """A fast-completing nextflow surrogate produces wrapper_started → pre_nextflow → wrapper_exited."""
+    monkeypatch.chdir(tmp_path)
+    log_path = tmp_path / ".nextflow.log"
+    log_path.write_text("nextflow log content\n")
+
+    with respx.mock(base_url=telemetry_base) as rx:
+        route = rx.post("/api/runs/r-test/event").mock(
+            return_value=httpx.Response(201, json={
+                "run_name": "r-test", "type": "x", "nextflow_log_uploaded": False,
+            })
+        )
+
+        rc = run_wrapper.main([
+            "--run-name", "r-test",
+            "--telemetry-url", telemetry_base,
+            "--heartbeat-seconds", "60",  # won't fire — process exits in <1s
+            "--nextflow-log", str(log_path),
+            "--", "true",
+        ])
+
+    assert rc == 0
+    assert route.call_count == 3
+    types = _captured_event_types(route)
+    assert types == ["wrapper_started", "pre_nextflow", "wrapper_exited"]
+
+
+def test_failing_subprocess_exit_code_propagates(tmp_path, telemetry_base, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    with respx.mock(base_url=telemetry_base) as rx:
+        route = rx.post("/api/runs/r-fail/event").mock(
+            return_value=httpx.Response(201, json={
+                "run_name": "r-fail", "type": "x", "nextflow_log_uploaded": False,
+            })
+        )
+
+        rc = run_wrapper.main([
+            "--run-name", "r-fail",
+            "--telemetry-url", telemetry_base,
+            "--", "false",
+        ])
+
+    assert rc == 1
+    types = _captured_event_types(route)
+    assert types[-1] == "wrapper_exited"
+    last = _extract_event(route.calls[-1])
+    assert last["exit_code"] == 1
+
+
+def test_nextflow_log_attached_when_present(tmp_path, telemetry_base, monkeypatch):
+    """The wrapper_exited POST should include the .nextflow.log file part."""
+    monkeypatch.chdir(tmp_path)
+    log_path = tmp_path / ".nextflow.log"
+    log_path.write_text("important diagnostic content\n")
+
+    with respx.mock(base_url=telemetry_base) as rx:
+        route = rx.post("/api/runs/r-log/event").mock(
+            return_value=httpx.Response(201, json={
+                "run_name": "r-log", "type": "x", "nextflow_log_uploaded": True,
+            })
+        )
+
+        run_wrapper.main([
+            "--run-name", "r-log",
+            "--telemetry-url", telemetry_base,
+            "--nextflow-log", str(log_path),
+            "--", "true",
+        ])
+
+    last_body = route.calls[-1].request.content.decode()
+    # multipart body should contain both the file content and the field name
+    assert "important diagnostic content" in last_body
+    assert 'name="nextflow_log"' in last_body
+
+
+def test_missing_nextflow_log_omits_attachment(tmp_path, telemetry_base, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    no_log = tmp_path / "does-not-exist.log"
+
+    with respx.mock(base_url=telemetry_base) as rx:
+        route = rx.post("/api/runs/r-nolog/event").mock(
+            return_value=httpx.Response(201, json={
+                "run_name": "r-nolog", "type": "x", "nextflow_log_uploaded": False,
+            })
+        )
+
+        rc = run_wrapper.main([
+            "--run-name", "r-nolog",
+            "--telemetry-url", telemetry_base,
+            "--nextflow-log", str(no_log),
+            "--", "true",
+        ])
+
+    assert rc == 0
+    last_body = route.calls[-1].request.content.decode()
+    # No file part — body is form-encoded, not multipart
+    assert 'name="nextflow_log"' not in last_body
+
+
+def test_telemetry_post_failure_does_not_fail_the_run(tmp_path, telemetry_base, monkeypatch):
+    """A 500 from the server (or any HTTP error) must not propagate to the wrapper exit code."""
+    monkeypatch.chdir(tmp_path)
+
+    with respx.mock(base_url=telemetry_base) as rx:
+        rx.post("/api/runs/r-flaky/event").mock(
+            side_effect=httpx.ConnectError("boom — server unreachable")
+        )
+
+        rc = run_wrapper.main([
+            "--run-name", "r-flaky",
+            "--telemetry-url", telemetry_base,
+            "--", "true",
+        ])
+
+    assert rc == 0  # subprocess exited 0, telemetry errors swallowed
+
+
+def test_pre_nextflow_includes_wait_seconds_when_slurm_env_set(tmp_path, telemetry_base, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("SLURM_SUBMIT_TIME", "1700000000")
+    monkeypatch.setenv("SLURM_JOB_START_TIME", "1700000123")
+    monkeypatch.setenv("SLURM_JOB_ID", "999")
+
+    with respx.mock(base_url=telemetry_base) as rx:
+        route = rx.post("/api/runs/r-wait/event").mock(
+            return_value=httpx.Response(201, json={
+                "run_name": "r-wait", "type": "x", "nextflow_log_uploaded": False,
+            })
+        )
+
+        run_wrapper.main([
+            "--run-name", "r-wait",
+            "--telemetry-url", telemetry_base,
+            "--", "true",
+        ])
+
+    # pre_nextflow is the 2nd POST
+    pre = _extract_event(route.calls[1])
+    assert pre["wait_seconds"] == 123
+    # And wrapper_started carries SLURM_JOB_ID
+    started = _extract_event(route.calls[0])
+    assert started["slurm_job_id"] == "999"
+
+
+def test_wait_seconds_omitted_when_slurm_env_absent(tmp_path, telemetry_base, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("SLURM_SUBMIT_TIME", raising=False)
+    monkeypatch.delenv("SLURM_JOB_START_TIME", raising=False)
+
+    with respx.mock(base_url=telemetry_base) as rx:
+        route = rx.post("/api/runs/r-local/event").mock(
+            return_value=httpx.Response(201, json={
+                "run_name": "r-local", "type": "x", "nextflow_log_uploaded": False,
+            })
+        )
+
+        run_wrapper.main([
+            "--run-name", "r-local",
+            "--telemetry-url", telemetry_base,
+            "--", "true",
+        ])
+
+    pre = _extract_event(route.calls[1])
+    assert pre["wait_seconds"] is None
+
+
+def test_log_truncation_keeps_tail_for_oversized_file(tmp_path):
+    """_read_nextflow_log should keep the last max_bytes when the file is too big."""
+    log_path = tmp_path / ".nextflow.log"
+    head = b"H" * 1024
+    tail = b"T" * 1024
+    log_path.write_bytes(head + tail)
+
+    out = run_wrapper._read_nextflow_log(log_path, max_bytes=1024)
+    assert out == tail  # head dropped, tail kept
+
+
+def test_heartbeats_fire_during_long_run(tmp_path, telemetry_base, monkeypatch):
+    """A subprocess that runs longer than the heartbeat interval triggers heartbeat events."""
+    monkeypatch.chdir(tmp_path)
+
+    with respx.mock(base_url=telemetry_base) as rx:
+        route = rx.post("/api/runs/r-hb/event").mock(
+            return_value=httpx.Response(201, json={
+                "run_name": "r-hb", "type": "x", "nextflow_log_uploaded": False,
+            })
+        )
+
+        # sleep 0.4s wall, heartbeat every 0.1s → expect ≥2 heartbeats
+        rc = run_wrapper.main([
+            "--run-name", "r-hb",
+            "--telemetry-url", telemetry_base,
+            "--heartbeat-seconds", "0",  # 0 means "wait(0)" which is immediate, but Event.wait(0) is non-blocking and returns False
+            "--", "sh", "-c", "sleep 0.4",
+        ])
+
+    assert rc == 0
+    types = _captured_event_types(route)
+    # We always have wrapper_started, pre_nextflow, wrapper_exited.
+    # With heartbeat_seconds=0 (effectively a tight loop), we should see >0 heartbeats.
+    n_hb = sum(1 for t in types if t == "heartbeat")
+    assert n_hb >= 1, f"expected at least one heartbeat, got types={types}"

--- a/packages/nf_client/tests/test_run_wrapper.py
+++ b/packages/nf_client/tests/test_run_wrapper.py
@@ -308,6 +308,30 @@ def test_non_2xx_response_is_logged_to_stderr(tmp_path, telemetry_base, monkeypa
     assert "no such run" in captured.err
 
 
+def test_popen_oserror_emits_wrapper_exited_with_127(tmp_path, telemetry_base, monkeypatch, capsys):
+    """If nextflow itself can't be exec'd (command-not-found), still emit a terminal event."""
+    monkeypatch.chdir(tmp_path)
+
+    with respx.mock(base_url=telemetry_base) as rx:
+        route = rx.post("/api/runs/r-noexec/event").mock(
+            return_value=httpx.Response(201, json={
+                "run_name": "r-noexec", "type": "x", "nextflow_log_uploaded": False,
+            })
+        )
+
+        rc = run_wrapper.main([
+            "--run-name", "r-noexec",
+            "--telemetry-url", telemetry_base,
+            "--", "definitely-not-a-real-command-xyz123",
+        ])
+
+    assert rc == 127
+    types = _captured_event_types(route)
+    assert types == ["wrapper_started", "pre_nextflow", "wrapper_exited"]
+    last = _extract_event(route.calls[-1])
+    assert last["exit_code"] == 127
+
+
 def test_invalid_telemetry_url_does_not_fail_the_run(tmp_path, telemetry_base, monkeypatch, capsys):
     """A malformed --telemetry-url falls back to no-op telemetry; the subprocess still runs."""
     monkeypatch.chdir(tmp_path)

--- a/packages/nf_client/tests/test_run_wrapper.py
+++ b/packages/nf_client/tests/test_run_wrapper.py
@@ -199,7 +199,13 @@ def test_pre_nextflow_includes_wait_seconds_when_slurm_env_set(tmp_path, telemet
     assert started["slurm_job_id"] == "999"
 
 
-def test_wait_seconds_omitted_when_slurm_env_absent(tmp_path, telemetry_base, monkeypatch):
+def test_wait_seconds_is_null_when_slurm_env_absent(tmp_path, telemetry_base, monkeypatch):
+    """Without SLURM env vars, the wrapper sends `wait_seconds: null` rather than omitting the key.
+
+    The server-side Pydantic model accepts None for optional fields, so this is
+    the simplest contract: always include the key with whatever the wrapper
+    could derive (or null).
+    """
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("SLURM_SUBMIT_TIME", raising=False)
     monkeypatch.delenv("SLURM_JOB_START_TIME", raising=False)
@@ -218,6 +224,7 @@ def test_wait_seconds_omitted_when_slurm_env_absent(tmp_path, telemetry_base, mo
         ])
 
     pre = _extract_event(route.calls[1])
+    assert "wait_seconds" in pre
     assert pre["wait_seconds"] is None
 
 
@@ -243,17 +250,77 @@ def test_heartbeats_fire_during_long_run(tmp_path, telemetry_base, monkeypatch):
             })
         )
 
-        # sleep 0.4s wall, heartbeat every 0.1s → expect ≥2 heartbeats
+        # 0.4s wall-clock subprocess, heartbeat every 0.1s → expect ≥2 heartbeats
         rc = run_wrapper.main([
             "--run-name", "r-hb",
             "--telemetry-url", telemetry_base,
-            "--heartbeat-seconds", "0",  # 0 means "wait(0)" which is immediate, but Event.wait(0) is non-blocking and returns False
+            "--heartbeat-seconds", "0.1",
             "--", "sh", "-c", "sleep 0.4",
         ])
 
     assert rc == 0
     types = _captured_event_types(route)
-    # We always have wrapper_started, pre_nextflow, wrapper_exited.
-    # With heartbeat_seconds=0 (effectively a tight loop), we should see >0 heartbeats.
     n_hb = sum(1 for t in types if t == "heartbeat")
-    assert n_hb >= 1, f"expected at least one heartbeat, got types={types}"
+    assert n_hb >= 2, f"expected at least 2 heartbeats in 0.4s @ 0.1s interval, got types={types}"
+
+
+def test_heartbeats_disabled_when_interval_is_zero(tmp_path, telemetry_base, monkeypatch):
+    """`--heartbeat-seconds 0` cleanly disables heartbeats — no thread, no busy loop, no events."""
+    monkeypatch.chdir(tmp_path)
+
+    with respx.mock(base_url=telemetry_base) as rx:
+        route = rx.post("/api/runs/r-nohb/event").mock(
+            return_value=httpx.Response(201, json={
+                "run_name": "r-nohb", "type": "x", "nextflow_log_uploaded": False,
+            })
+        )
+
+        rc = run_wrapper.main([
+            "--run-name", "r-nohb",
+            "--telemetry-url", telemetry_base,
+            "--heartbeat-seconds", "0",
+            "--", "sh", "-c", "sleep 0.3",
+        ])
+
+    assert rc == 0
+    types = _captured_event_types(route)
+    assert "heartbeat" not in types, f"expected no heartbeats, got types={types}"
+
+
+def test_non_2xx_response_is_logged_to_stderr(tmp_path, telemetry_base, monkeypatch, capsys):
+    """A 404 from the server (e.g. orphan-log path from PR #64) is logged but does not fail the run."""
+    monkeypatch.chdir(tmp_path)
+
+    with respx.mock(base_url=telemetry_base) as rx:
+        rx.post("/api/runs/r-orphan/event").mock(
+            return_value=httpx.Response(404, json={"detail": "no such run"})
+        )
+
+        rc = run_wrapper.main([
+            "--run-name", "r-orphan",
+            "--telemetry-url", telemetry_base,
+            "--", "true",
+        ])
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "404" in captured.err
+    assert "no such run" in captured.err
+
+
+def test_invalid_telemetry_url_does_not_fail_the_run(tmp_path, telemetry_base, monkeypatch, capsys):
+    """A malformed --telemetry-url falls back to no-op telemetry; the subprocess still runs."""
+    monkeypatch.chdir(tmp_path)
+
+    rc = run_wrapper.main([
+        "--run-name", "r-badurl",
+        # Missing scheme — httpx.Client construction raises
+        "--telemetry-url", "not-a-url://!!!::",
+        "--", "true",
+    ])
+
+    captured = capsys.readouterr()
+    # Either the client constructs (with a weird base_url that produces
+    # transport errors per POST) or it raises at construction (caught and
+    # logged). In both cases the subprocess must run and exit 0.
+    assert rc == 0

--- a/packages/nf_client/tests/test_run_wrapper.py
+++ b/packages/nf_client/tests/test_run_wrapper.py
@@ -367,6 +367,36 @@ def test_non_2xx_response_is_logged_to_stderr(tmp_path, telemetry_base, monkeypa
     assert "no such run" in captured.err
 
 
+def test_signal_killed_subprocess_normalizes_exit_code(tmp_path, telemetry_base, monkeypatch):
+    """A subprocess killed by a signal returns -signum from wait(); we report 128+signum.
+
+    `kill -SIGTERM $$` from the subprocess gives proc.wait() == -15. Without
+    normalization, main() would propagate that to sys.exit(-15) which Python
+    maps to 241 — meaningless to operators. POSIX shell convention is
+    128+signum (so SIGTERM == 143).
+    """
+    monkeypatch.chdir(tmp_path)
+
+    with respx.mock(base_url=telemetry_base) as rx:
+        route = rx.post("/runs/r-killed/event").mock(
+            return_value=httpx.Response(201, json={
+                "run_name": "r-killed", "type": "x", "nextflow_log_uploaded": False,
+            })
+        )
+
+        rc = run_wrapper.main([
+            "--run-name", "r-killed",
+            "--telemetry-url", telemetry_base,
+            # subshell sends SIGTERM (15) to itself
+            "--", "sh", "-c", "kill -TERM $$",
+        ])
+
+    # 128 + 15 == 143
+    assert rc == 143
+    last = _extract_event(route.calls[-1])
+    assert last["exit_code"] == 143
+
+
 def test_popen_oserror_emits_wrapper_exited_with_127(tmp_path, telemetry_base, monkeypatch, capsys):
     """If nextflow itself can't be exec'd (command-not-found), still emit a terminal event."""
     monkeypatch.chdir(tmp_path)
@@ -397,13 +427,14 @@ def test_invalid_telemetry_url_does_not_fail_the_run(tmp_path, telemetry_base, m
 
     rc = run_wrapper.main([
         "--run-name", "r-badurl",
-        # Missing scheme — httpx.Client construction raises
+        # Garbage that httpx will either reject at construction (raise)
+        # or accept and fail on every POST. Either way the wrapper must
+        # not propagate the failure to its own exit code.
         "--telemetry-url", "not-a-url://!!!::",
         "--", "true",
     ])
 
     captured = capsys.readouterr()
-    # Either the client constructs (with a weird base_url that produces
-    # transport errors per POST) or it raises at construction (caught and
-    # logged). In both cases the subprocess must run and exit 0.
+    # The subprocess must run and exit 0 regardless of how httpx handles
+    # the URL.
     assert rc == 0

--- a/packages/nf_client/uv.lock
+++ b/packages/nf_client/uv.lock
@@ -219,7 +219,7 @@ wheels = [
 
 [[package]]
 name = "nf-client"
-version = "0.1.0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #67. Phase 3 of #62.

## Summary

Instruments each nextflow subprocess with run-lifecycle events posted to the Phase 1 endpoint (#64). Replaces most of \`templates/slurm.sh.j2\` with a thin bash shim that invokes \`python -m nf_client.run_wrapper\`.

## Event sequence per run

- \`wrapper_started\` — first action; hostname + SLURM_JOB_ID
- \`pre_nextflow\` — \`wait_seconds\` computed from \`SLURM_SUBMIT_TIME\` / \`SLURM_JOB_START_TIME\` (included as null when absent / unparseable / negative)
- \`heartbeat\` — daemon thread on configurable interval (default 60s)
- \`wrapper_exited\` — exit_code + duration_seconds; \`.nextflow.log\` attached as multipart upload (capped at the server's 16 MB limit, tail-kept on overflow)

## Resilience

- All telemetry POSTs are best-effort. Connect errors, timeouts, HTTP errors → logged to stderr, swallowed. The wrapper exits with nextflow's exit code regardless of telemetry health.
- SIGTERM and SIGINT are forwarded to the subprocess so SLURM's pre-kill grace period reaches nextflow.

## Testing

- [x] \`uv run pytest tests/test_run_wrapper.py\` — 9 tests pass via respx
- [x] Smoke-tested against the production endpoint: \`wrapper_started\` and \`pre_nextflow\` events confirmed in prod telemetry. \`wrapper_exited\` with log attachment correctly returns 404 for orphan run names per the rule we defined in PR #64.
- [ ] Cluster validation — needs Anvil/Alpine templates to be updated to the new shape (the in-repo \`slurm.sh.j2\` is the reference; cluster templates live outside this repo)

## Cluster-side rollout

The in-repo \`templates/slurm.sh.j2\` is updated as the reference shape. The cluster-side templates (Anvil at \`/anvil/scratch/x-seandavi/nf_client/nextflow_telemetry/templates/submit_anvil.sh.j2\`, Alpine equivalent) need the same edit:

\`\`\`diff
- nextflow run {{ workflow_repository }} -revision … -profile … …
+ python -m nf_client.run_wrapper \
+   --run-name {{ run_name }} \
+   --telemetry-url {{ server_url }} \
+   -- \
+   nextflow run {{ workflow_repository }} -revision … -profile … …
\`\`\`

\`server_url\` and \`run_name\` are already in the Jinja context (verified in \`cli.py\`).

## Out of scope

- Phase 2 (#66) pipeline \`workflow.onComplete\`/\`onError\` hooks — separate PR in \`seandavi/curatedMetagenomicsNextflow\`.
- Phase 4 (#68) daemon-side \`sacct\` polling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)