### PR TITLE
fix: CohortsPage drill-down survives poll ticks

### DIFF
--- a/frontend/src/pages/CohortsPage.tsx
+++ b/frontend/src/pages/CohortsPage.tsx
@@ -153,10 +153,14 @@ export default function CohortsPage({ pollInterval = 30_000 }: { pollInterval?: 
     return { workflowId, workflowVersion }
   }, [workflowKey])
 
-  // Reset the in-process selection only when the user changes cohort or
-  // workflow filter. We deliberately do NOT depend on `tick` here — that
-  // would wipe a user's drill-down every poll interval.
+  // Reset selection AND clear the previously-shown summary whenever the
+  // user changes cohort or workflow filter. Clearing summary prevents
+  // flashing stale data (counts/failure_by_process from the old cohort)
+  // during the brief window between selection change and the new fetch
+  // resolving. We deliberately do NOT depend on `tick` here — that would
+  // wipe a user's drill-down every poll interval.
   useEffect(() => {
+    setSummary(null)
     setSelectedProcess('')
     setFailures([])
   }, [selectedCohort, workflowKey])

--- a/frontend/src/pages/CohortsPage.tsx
+++ b/frontend/src/pages/CohortsPage.tsx
@@ -153,14 +153,24 @@ export default function CohortsPage({ pollInterval = 30_000 }: { pollInterval?: 
     return { workflowId, workflowVersion }
   }, [workflowKey])
 
+  // Reset the in-process selection only when the user changes cohort or
+  // workflow filter. We deliberately do NOT depend on `tick` here — that
+  // would wipe a user's drill-down every poll interval.
   useEffect(() => {
-    if (!selectedCohort) return
-    setSummary(null)
     setSelectedProcess('')
     setFailures([])
+  }, [selectedCohort, workflowKey])
+
+  // Refresh the summary on every relevant change, including poll ticks.
+  // The summary itself is replaced atomically by setSummary, so a poll
+  // refresh is invisible unless the data actually changed.
+  useEffect(() => {
+    if (!selectedCohort) return
     api.cohorts.summary(selectedCohort, wfFilter).then(setSummary).catch(console.error)
   }, [selectedCohort, workflowKey, tick])
 
+  // Same pattern for the failed-task drill-down: refresh on poll, but
+  // never lose the user's selectedProcess just because the timer fired.
   useEffect(() => {
     if (!selectedCohort || !selectedProcess) return
     setLoadingFailures(true)

--- a/frontend/src/pages/CohortsPage.tsx
+++ b/frontend/src/pages/CohortsPage.tsx
@@ -166,22 +166,32 @@ export default function CohortsPage({ pollInterval = 30_000 }: { pollInterval?: 
   }, [selectedCohort, workflowKey])
 
   // Refresh the summary on every relevant change, including poll ticks.
-  // The summary itself is replaced atomically by setSummary, so a poll
-  // refresh is invisible unless the data actually changed.
+  // Each invocation owns an `ignore` flag so a slow response from a
+  // previous cohort/workflow can't repopulate `summary` after the user
+  // has switched (the cleanup on the next render flips ignore=true,
+  // and the resolved promise no-ops).
   useEffect(() => {
     if (!selectedCohort) return
-    api.cohorts.summary(selectedCohort, wfFilter).then(setSummary).catch(console.error)
+    let ignore = false
+    api.cohorts.summary(selectedCohort, wfFilter).then(s => {
+      if (!ignore) setSummary(s)
+    }).catch(console.error)
+    return () => { ignore = true }
   }, [selectedCohort, workflowKey, tick])
 
   // Same pattern for the failed-task drill-down: refresh on poll, but
-  // never lose the user's selectedProcess just because the timer fired.
+  // never lose the user's selectedProcess just because the timer fired,
+  // and never let a stale response repopulate failures after the user
+  // has changed cohort/process.
   useEffect(() => {
     if (!selectedCohort || !selectedProcess) return
+    let ignore = false
     setLoadingFailures(true)
     api.cohorts.failures(selectedCohort, selectedProcess, wfFilter)
-      .then(r => setFailures(r.rows))
+      .then(r => { if (!ignore) setFailures(r.rows) })
       .catch(console.error)
-      .finally(() => setLoadingFailures(false))
+      .finally(() => { if (!ignore) setLoadingFailures(false) })
+    return () => { ignore = true }
   }, [selectedCohort, selectedProcess, workflowKey, tick])
 
   const totalFailedAcrossProcesses = summary?.failure_by_process.reduce((s, r) => s + r.failed_count, 0) ?? 0


### PR DESCRIPTION
Closes #72.

## Summary

Split the cohort summary effect into two: selection reset depends on \`[selectedCohort, workflowKey]\` only, refresh depends on \`[selectedCohort, workflowKey, tick]\`. The user's drill-down selection no longer disappears on every 30s poll.

## Test plan

- [x] \`npm run build\` clean
- [ ] Manual: pick a cohort → click a failed process → wait through one poll cycle → verify drill-down is still there

🤖 Generated with [Claude Code](https://claude.com/claude-code)