### PR TITLE
perf: default 7-day window + functional JSONB indexes on telemetry

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -198,6 +198,7 @@ export interface TimelineRow {
 
 export interface ProcessTimelineResponse {
   generated_at_utc: string
+  window_days: number | null
   bucket: string
   rows: TimelineRow[]
 }
@@ -295,6 +296,7 @@ export interface TaskRow {
 
 export interface TasksResponse {
   generated_at_utc: string
+  window_days: number | null
   total: number
   limit: number
   offset: number

--- a/src/nextflow_telemetry/migrations/versions/20260510_c1d2e3f4_telemetry_jsonb_indexes.py
+++ b/src/nextflow_telemetry/migrations/versions/20260510_c1d2e3f4_telemetry_jsonb_indexes.py
@@ -11,11 +11,18 @@ services/process_metrics.py and services/cohort.py are:
   - trace->>'process'   (the Nextflow process name)
   - trace->>'status'    (COMPLETED / FAILED / ABORTED)
 
-We only need them for `event = 'process_completed' AND trace IS NOT NULL`
-rows: the other event types don't carry a useful trace.process, and the
-analytical queries already filter on `trace IS NOT NULL`. Tightening
-the partial predicate to match the queries keeps the index small and
-keeps it eligible for the planner.
+We only need them for `event = 'process_completed'` rows since the
+other event types don't carry a useful trace.process. Partial indexes
+on that predicate alone keep the index small (this filter accounts for
+~all the trace volume) and the predicate is one Postgres can prove
+holds for any analytical query that has `event = 'process_completed'`
+in its WHERE — no need for the queries to repeat any extra condition.
+
+A tighter `AND trace IS NOT NULL` partial was considered but rejected:
+not every cohort/analytics query repeats that check explicitly, and
+when the partial predicate has more conjuncts than the query, the
+planner has to *prove* the implication, which it doesn't always do.
+Dropping the extra conjunct keeps the index broadly usable.
 
 Created CONCURRENTLY so the migration doesn't take a long lock on the
 table when applied to a production database with ongoing writes. Alembic
@@ -45,7 +52,7 @@ def upgrade() -> None:
             [sa.text("(trace->>'process')")],
             unique=False,
             postgresql_concurrently=True,
-            postgresql_where=sa.text("event = 'process_completed' AND trace IS NOT NULL"),
+            postgresql_where=sa.text("event = 'process_completed'"),
             if_not_exists=True,
         )
         op.create_index(
@@ -54,7 +61,7 @@ def upgrade() -> None:
             [sa.text("(trace->>'status')")],
             unique=False,
             postgresql_concurrently=True,
-            postgresql_where=sa.text("event = 'process_completed' AND trace IS NOT NULL"),
+            postgresql_where=sa.text("event = 'process_completed'"),
             if_not_exists=True,
         )
 

--- a/src/nextflow_telemetry/migrations/versions/20260510_c1d2e3f4_telemetry_jsonb_indexes.py
+++ b/src/nextflow_telemetry/migrations/versions/20260510_c1d2e3f4_telemetry_jsonb_indexes.py
@@ -15,14 +15,17 @@ We only need them for `event = 'process_completed'` rows since the other
 event types don't carry a useful trace.process. Partial indexes on that
 predicate keep the index small and the planner happy.
 
-If/when the telemetry table grows large enough that CREATE INDEX becomes
-disruptive, future migrations should use CREATE INDEX CONCURRENTLY (which
-requires running outside a transaction; see Alembic's autocommit_block).
+Created CONCURRENTLY so the migration doesn't take a long lock on the
+table when applied to a production database with ongoing writes. Alembic
+runs each migration inside a transaction by default, but
+CREATE INDEX CONCURRENTLY can't run in a transaction — autocommit_block
+takes us out of the surrounding transaction for the duration.
 """
 from __future__ import annotations
 
 from typing import Sequence, Union
 
+import sqlalchemy as sa
 from alembic import op
 
 
@@ -33,22 +36,38 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.execute(
-        """
-        CREATE INDEX IF NOT EXISTS ix_telemetry_trace_process
-          ON telemetry ((trace->>'process'))
-          WHERE event = 'process_completed'
-        """
-    )
-    op.execute(
-        """
-        CREATE INDEX IF NOT EXISTS ix_telemetry_trace_status
-          ON telemetry ((trace->>'status'))
-          WHERE event = 'process_completed'
-        """
-    )
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_telemetry_trace_process",
+            "telemetry",
+            [sa.text("(trace->>'process')")],
+            unique=False,
+            postgresql_concurrently=True,
+            postgresql_where=sa.text("event = 'process_completed'"),
+            if_not_exists=True,
+        )
+        op.create_index(
+            "ix_telemetry_trace_status",
+            "telemetry",
+            [sa.text("(trace->>'status')")],
+            unique=False,
+            postgresql_concurrently=True,
+            postgresql_where=sa.text("event = 'process_completed'"),
+            if_not_exists=True,
+        )
 
 
 def downgrade() -> None:
-    op.execute("DROP INDEX IF EXISTS ix_telemetry_trace_status")
-    op.execute("DROP INDEX IF EXISTS ix_telemetry_trace_process")
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "ix_telemetry_trace_status",
+            table_name="telemetry",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+        op.drop_index(
+            "ix_telemetry_trace_process",
+            table_name="telemetry",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )

--- a/src/nextflow_telemetry/migrations/versions/20260510_c1d2e3f4_telemetry_jsonb_indexes.py
+++ b/src/nextflow_telemetry/migrations/versions/20260510_c1d2e3f4_telemetry_jsonb_indexes.py
@@ -1,0 +1,54 @@
+"""telemetry_jsonb_indexes
+
+Revision ID: c1d2e3f4
+Revises: b1c2d3e4
+Create Date: 2026-05-10
+
+Adds functional indexes on telemetry.trace JSONB fields used by the
+analytical query path (#71). The two key fields hit by every query in
+services/process_metrics.py and services/cohort.py are:
+
+  - trace->>'process'   (the Nextflow process name)
+  - trace->>'status'    (COMPLETED / FAILED / ABORTED)
+
+We only need them for `event = 'process_completed'` rows since the other
+event types don't carry a useful trace.process. Partial indexes on that
+predicate keep the index small and the planner happy.
+
+If/when the telemetry table grows large enough that CREATE INDEX becomes
+disruptive, future migrations should use CREATE INDEX CONCURRENTLY (which
+requires running outside a transaction; see Alembic's autocommit_block).
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "c1d2e3f4"
+down_revision: Union[str, Sequence[str], None] = "b1c2d3e4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS ix_telemetry_trace_process
+          ON telemetry ((trace->>'process'))
+          WHERE event = 'process_completed'
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS ix_telemetry_trace_status
+          ON telemetry ((trace->>'status'))
+          WHERE event = 'process_completed'
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_telemetry_trace_status")
+    op.execute("DROP INDEX IF EXISTS ix_telemetry_trace_process")

--- a/src/nextflow_telemetry/migrations/versions/20260510_c1d2e3f4_telemetry_jsonb_indexes.py
+++ b/src/nextflow_telemetry/migrations/versions/20260510_c1d2e3f4_telemetry_jsonb_indexes.py
@@ -11,9 +11,11 @@ services/process_metrics.py and services/cohort.py are:
   - trace->>'process'   (the Nextflow process name)
   - trace->>'status'    (COMPLETED / FAILED / ABORTED)
 
-We only need them for `event = 'process_completed'` rows since the other
-event types don't carry a useful trace.process. Partial indexes on that
-predicate keep the index small and the planner happy.
+We only need them for `event = 'process_completed' AND trace IS NOT NULL`
+rows: the other event types don't carry a useful trace.process, and the
+analytical queries already filter on `trace IS NOT NULL`. Tightening
+the partial predicate to match the queries keeps the index small and
+keeps it eligible for the planner.
 
 Created CONCURRENTLY so the migration doesn't take a long lock on the
 table when applied to a production database with ongoing writes. Alembic
@@ -43,7 +45,7 @@ def upgrade() -> None:
             [sa.text("(trace->>'process')")],
             unique=False,
             postgresql_concurrently=True,
-            postgresql_where=sa.text("event = 'process_completed'"),
+            postgresql_where=sa.text("event = 'process_completed' AND trace IS NOT NULL"),
             if_not_exists=True,
         )
         op.create_index(
@@ -52,7 +54,7 @@ def upgrade() -> None:
             [sa.text("(trace->>'status')")],
             unique=False,
             postgresql_concurrently=True,
-            postgresql_where=sa.text("event = 'process_completed'"),
+            postgresql_where=sa.text("event = 'process_completed' AND trace IS NOT NULL"),
             if_not_exists=True,
         )
 

--- a/src/nextflow_telemetry/models.py
+++ b/src/nextflow_telemetry/models.py
@@ -252,6 +252,7 @@ class TimelineRow(BaseModel):
 class ProcessTimelineResponse(BaseModel):
     """Response from GET /metrics/processes/timeline."""
     generated_at_utc: datetime.datetime
+    window_days: Optional[int] = Field(default=None, description="Effective time window applied (default 7 days when no time filter is supplied).")
     bucket: str
     rows: list[TimelineRow]
 
@@ -285,6 +286,7 @@ class TaskRow(BaseModel):
 class TasksResponse(BaseModel):
     """Response from GET /metrics/processes/tasks."""
     generated_at_utc: datetime.datetime
+    window_days: Optional[int] = Field(default=None, description="Effective time window applied (default 7 days when no time filter is supplied).")
     total: int = Field(description="Total matching rows (before pagination).")
     limit: int
     offset: int

--- a/src/nextflow_telemetry/models.py
+++ b/src/nextflow_telemetry/models.py
@@ -252,7 +252,7 @@ class TimelineRow(BaseModel):
 class ProcessTimelineResponse(BaseModel):
     """Response from GET /metrics/processes/timeline."""
     generated_at_utc: datetime.datetime
-    window_days: Optional[int] = Field(default=None, description="Effective time window applied (default 7 days when no time filter is supplied).")
+    window_days: Optional[int] = Field(description="Effective time window applied (default 7 days when no time filter is supplied; null only when since/until or window_hours was used instead).")
     bucket: str
     rows: list[TimelineRow]
 
@@ -286,7 +286,7 @@ class TaskRow(BaseModel):
 class TasksResponse(BaseModel):
     """Response from GET /metrics/processes/tasks."""
     generated_at_utc: datetime.datetime
-    window_days: Optional[int] = Field(default=None, description="Effective time window applied (default 7 days when no time filter is supplied).")
+    window_days: Optional[int] = Field(description="Effective time window applied (default 7 days when no time filter is supplied; null only when since/until or window_hours was used instead).")
     total: int = Field(description="Total matching rows (before pagination).")
     limit: int
     offset: int

--- a/src/nextflow_telemetry/models.py
+++ b/src/nextflow_telemetry/models.py
@@ -132,7 +132,7 @@ class TopFailureExitCodeRow(BaseModel):
 class ProcessSummaryResponse(BaseModel):
     """Response from GET /metrics/processes/summary."""
     generated_at_utc: datetime.datetime = Field(description="Server time when the query ran.")
-    window_days: Optional[int] = Field(description="Query window in days; null means all-time.")
+    window_days: Optional[int] = Field(description="Effective time window applied (default 7 days when no time filter is supplied; null only when since/until or window_hours was used instead).")
     cards: ProcessSummaryCards
     event_mix: list[EventMixRow]
     top_failures: list[TopFailureRow]
@@ -172,7 +172,7 @@ class RetryByProcessRow(BaseModel):
 class ProcessRetriesResponse(BaseModel):
     """Response from GET /metrics/processes/retries."""
     generated_at_utc: datetime.datetime
-    window_days: Optional[int]
+    window_days: Optional[int] = Field(description="Effective time window applied (default 7 days when no time filter is supplied; null only when since/until or window_hours was used instead).")
     summary: RetrySummary
     by_attempt: list[RetryByAttemptRow]
     by_process: list[RetryByProcessRow]
@@ -203,7 +203,7 @@ class ResourceByAttemptRow(BaseModel):
 class ProcessResourcesByAttemptResponse(BaseModel):
     """Response from GET /metrics/processes/resources-by-attempt."""
     generated_at_utc: datetime.datetime
-    window_days: Optional[int]
+    window_days: Optional[int] = Field(description="Effective time window applied (default 7 days when no time filter is supplied; null only when since/until or window_hours was used instead).")
     rows: list[ResourceByAttemptRow]
 
 
@@ -221,7 +221,7 @@ class ProcessFailuresRow(BaseModel):
 class ProcessFailuresResponse(BaseModel):
     """Response from GET /metrics/processes/failures."""
     generated_at_utc: datetime.datetime
-    window_days: Optional[int]
+    window_days: Optional[int] = Field(description="Effective time window applied (default 7 days when no time filter is supplied; null only when since/until or window_hours was used instead).")
     rows: list[ProcessFailuresRow]
 
 
@@ -236,7 +236,7 @@ class FailureSignatureRow(BaseModel):
 class ProcessFailureSignaturesResponse(BaseModel):
     """Response from GET /metrics/processes/failure-signatures."""
     generated_at_utc: datetime.datetime
-    window_days: Optional[int]
+    window_days: Optional[int] = Field(description="Effective time window applied (default 7 days when no time filter is supplied; null only when since/until or window_hours was used instead).")
     rows: list[FailureSignatureRow]
 
 

--- a/src/nextflow_telemetry/routers/process_metrics.py
+++ b/src/nextflow_telemetry/routers/process_metrics.py
@@ -11,7 +11,7 @@ from ..services.process_metrics import ProcessMetricsService
 
 _WINDOW_DAYS_DESC = (
     "Limit results to events in the last N days. Mutually exclusive with "
-    "`window_hours` (a 422 is returned if both are supplied); composes "
+    "`window_hours` (a 400 is returned if both are supplied); composes "
     "additively with `since`/`until` if both are given (the intersection "
     "is queried). **When none of window_days, window_hours, since, or "
     "until is supplied, the server applies a default 7-day look-back** "

--- a/src/nextflow_telemetry/routers/process_metrics.py
+++ b/src/nextflow_telemetry/routers/process_metrics.py
@@ -9,10 +9,20 @@ from fastapi import APIRouter, HTTPException, Query
 from .. import models
 from ..services.process_metrics import ProcessMetricsService
 
-_WINDOW_DAYS_DESC = "Limit results to events in the last N days. Cannot be combined with window_hours, since, or until."
-_WINDOW_HOURS_DESC = "Limit results to events in the last N hours. Cannot be combined with window_days."
-_SINCE_DESC = "Inclusive lower bound (UTC ISO-8601). Can be combined with until."
-_UNTIL_DESC = "Inclusive upper bound (UTC ISO-8601). Can be combined with since."
+_WINDOW_DAYS_DESC = (
+    "Limit results to events in the last N days. Cannot be combined with "
+    "window_hours, since, or until. **When none of window_days, window_hours, "
+    "since, or until is supplied, the server applies a default 7-day look-back** "
+    "to keep the query bounded as event volume grows. Pass an explicit large "
+    "value (e.g. 10000) for an effectively all-time window. The effective "
+    "value is echoed back in the response's `window_days` field."
+)
+_WINDOW_HOURS_DESC = (
+    "Limit results to events in the last N hours. Cannot be combined with window_days. "
+    "See window_days for the default-window behaviour when no time filter is supplied."
+)
+_SINCE_DESC = "Inclusive lower bound (UTC ISO-8601). Can be combined with until. See window_days for the default-window behaviour when no time filter is supplied."
+_UNTIL_DESC = "Inclusive upper bound (UTC ISO-8601). Can be combined with since. See window_days for the default-window behaviour when no time filter is supplied."
 _WORKFLOW_ID_DESC = "Filter to a specific workflow (e.g. 'cmgd_nextflow')."
 _WORKFLOW_VERSION_DESC = "Filter to a specific workflow version. Only meaningful with workflow_id."
 _RUN_NAME_DESC = "Filter to a single Nextflow run_name."

--- a/src/nextflow_telemetry/routers/process_metrics.py
+++ b/src/nextflow_telemetry/routers/process_metrics.py
@@ -10,19 +10,21 @@ from .. import models
 from ..services.process_metrics import ProcessMetricsService
 
 _WINDOW_DAYS_DESC = (
-    "Limit results to events in the last N days. Cannot be combined with "
-    "window_hours, since, or until. **When none of window_days, window_hours, "
-    "since, or until is supplied, the server applies a default 7-day look-back** "
-    "to keep the query bounded as event volume grows. Pass an explicit large "
-    "value (e.g. 10000) for an effectively all-time window. The effective "
-    "value is echoed back in the response's `window_days` field."
+    "Limit results to events in the last N days. Mutually exclusive with "
+    "`window_hours` (a 422 is returned if both are supplied); composes "
+    "additively with `since`/`until` if both are given (the intersection "
+    "is queried). **When none of window_days, window_hours, since, or "
+    "until is supplied, the server applies a default 7-day look-back** "
+    "to keep the query bounded as event volume grows. Pass an explicit "
+    "large value (e.g. 10000) for an effectively all-time window. The "
+    "effective value is echoed back in the response's `window_days` field."
 )
 _WINDOW_HOURS_DESC = (
-    "Limit results to events in the last N hours. Cannot be combined with window_days. "
+    "Limit results to events in the last N hours. Mutually exclusive with `window_days`. "
     "See window_days for the default-window behaviour when no time filter is supplied."
 )
-_SINCE_DESC = "Inclusive lower bound (UTC ISO-8601). Can be combined with until. See window_days for the default-window behaviour when no time filter is supplied."
-_UNTIL_DESC = "Inclusive upper bound (UTC ISO-8601). Can be combined with since. See window_days for the default-window behaviour when no time filter is supplied."
+_SINCE_DESC = "Inclusive lower bound (UTC ISO-8601). Composes with `until` and with `window_*` filters as a logical AND. See window_days for the default-window behaviour when no time filter is supplied."
+_UNTIL_DESC = "Inclusive upper bound (UTC ISO-8601). Composes with `since` and with `window_*` filters as a logical AND. See window_days for the default-window behaviour when no time filter is supplied."
 _WORKFLOW_ID_DESC = "Filter to a specific workflow (e.g. 'cmgd_nextflow')."
 _WORKFLOW_VERSION_DESC = "Filter to a specific workflow version. Only meaningful with workflow_id."
 _RUN_NAME_DESC = "Filter to a single Nextflow run_name."

--- a/src/nextflow_telemetry/services/process_metrics.py
+++ b/src/nextflow_telemetry/services/process_metrics.py
@@ -9,6 +9,9 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 
+_DEFAULT_WINDOW_DAYS = 7
+
+
 @dataclass
 class ProcessMetricsService:
     engine: AsyncEngine
@@ -26,13 +29,26 @@ class ProcessMetricsService:
         sample_id: str | None = None,
         table_alias: str = "t",
     ) -> tuple[str, dict[str, Any]]:
-        """Build a composable WHERE fragment and bind-params dict for telemetry queries."""
+        """Build a composable WHERE fragment and bind-params dict for telemetry queries.
+
+        If no time-bound filter is supplied (no window_*, no since/until), a
+        default look-back of `_DEFAULT_WINDOW_DAYS` is applied. This prevents
+        an unparameterised metrics endpoint from scanning the entire
+        telemetry table once event volume grows. Callers that explicitly
+        want all-time data should pass `window_days=10000` or similar.
+        """
         clauses: list[str] = []
         params: dict[str, Any] = {}
         a = table_alias
 
         if window_days is not None and window_hours is not None:
             raise ValueError("Provide only one of window_days or window_hours, not both.")
+
+        if (
+            window_days is None and window_hours is None
+            and since is None and until is None
+        ):
+            window_days = _DEFAULT_WINDOW_DAYS
 
         if window_days is not None:
             if window_days < 1:

--- a/src/nextflow_telemetry/services/process_metrics.py
+++ b/src/nextflow_telemetry/services/process_metrics.py
@@ -21,9 +21,12 @@ def _normalize_window(
 ) -> tuple[int | None, int | None]:
     """Apply the default 7-day window when no time filter was supplied.
 
-    Public service methods call this at entry so the effective value flows
-    into both the SQL filter and the response payload — clients see the
-    actual window the query used, not None.
+    Public service methods call this at entry and pass the effective
+    `window_days` into the response payload (where the response model
+    has a `window_days` field). Today every metrics endpoint surfaces
+    the field, so a client that doesn't pass a time filter sees
+    `window_days: 7` rather than `null`. `window_hours` / `since` /
+    `until` are echoed only on endpoints that already accepted them.
 
     Callers that explicitly want all-time data should pass
     `window_days=10000` or similar; the default only applies when every
@@ -687,6 +690,7 @@ class ProcessMetricsService:
 
         return {
             "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+            "window_days": window_days,
             "bucket": bucket,
             "rows": rows,
         }
@@ -839,6 +843,7 @@ class ProcessMetricsService:
 
         return {
             "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+            "window_days": window_days,
             "total": total,
             "limit": limit,
             "offset": offset,

--- a/src/nextflow_telemetry/services/process_metrics.py
+++ b/src/nextflow_telemetry/services/process_metrics.py
@@ -21,12 +21,12 @@ def _normalize_window(
 ) -> tuple[int | None, int | None]:
     """Apply the default 7-day window when no time filter was supplied.
 
-    Public service methods call this at entry and pass the effective
-    `window_days` into the response payload (where the response model
-    has a `window_days` field). Today every metrics endpoint surfaces
-    the field, so a client that doesn't pass a time filter sees
-    `window_days: 7` rather than `null`. `window_hours` / `since` /
-    `until` are echoed only on endpoints that already accepted them.
+    Public methods that accept a time filter (summary/retries/failures/
+    failure_signatures/timeline/tasks/resources_by_attempt) call this at
+    entry and pass the effective `window_days` into the response payload,
+    so a client that doesn't supply a time filter sees `window_days: 7`
+    rather than `null`. `running()` does not accept time filters and is
+    not affected.
 
     Callers that explicitly want all-time data should pass
     `window_days=10000` or similar; the default only applies when every

--- a/src/nextflow_telemetry/services/process_metrics.py
+++ b/src/nextflow_telemetry/services/process_metrics.py
@@ -12,6 +12,28 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 _DEFAULT_WINDOW_DAYS = 7
 
 
+def _normalize_window(
+    *,
+    window_days: int | None,
+    window_hours: int | None,
+    since: dt.datetime | None,
+    until: dt.datetime | None,
+) -> tuple[int | None, int | None]:
+    """Apply the default 7-day window when no time filter was supplied.
+
+    Public service methods call this at entry so the effective value flows
+    into both the SQL filter and the response payload — clients see the
+    actual window the query used, not None.
+
+    Callers that explicitly want all-time data should pass
+    `window_days=10000` or similar; the default only applies when every
+    time field is None.
+    """
+    if window_days is None and window_hours is None and since is None and until is None:
+        return _DEFAULT_WINDOW_DAYS, window_hours
+    return window_days, window_hours
+
+
 @dataclass
 class ProcessMetricsService:
     engine: AsyncEngine
@@ -29,26 +51,13 @@ class ProcessMetricsService:
         sample_id: str | None = None,
         table_alias: str = "t",
     ) -> tuple[str, dict[str, Any]]:
-        """Build a composable WHERE fragment and bind-params dict for telemetry queries.
-
-        If no time-bound filter is supplied (no window_*, no since/until), a
-        default look-back of `_DEFAULT_WINDOW_DAYS` is applied. This prevents
-        an unparameterised metrics endpoint from scanning the entire
-        telemetry table once event volume grows. Callers that explicitly
-        want all-time data should pass `window_days=10000` or similar.
-        """
+        """Build a composable WHERE fragment and bind-params dict for telemetry queries."""
         clauses: list[str] = []
         params: dict[str, Any] = {}
         a = table_alias
 
         if window_days is not None and window_hours is not None:
             raise ValueError("Provide only one of window_days or window_hours, not both.")
-
-        if (
-            window_days is None and window_hours is None
-            and since is None and until is None
-        ):
-            window_days = _DEFAULT_WINDOW_DAYS
 
         if window_days is not None:
             if window_days < 1:
@@ -108,6 +117,10 @@ class ProcessMetricsService:
         if limit < 1:
             raise ValueError("limit must be >= 1")
 
+        window_days, window_hours = _normalize_window(
+            window_days=window_days, window_hours=window_hours,
+            since=since, until=until,
+        )
         fc, params = self._filter_clause(
             window_days=window_days, window_hours=window_hours,
             since=since, until=until,
@@ -224,7 +237,7 @@ class ProcessMetricsService:
             from telemetry t
             where t.event = 'process_completed'
               and t.trace is not null
-              and coalesce(t.trace->>'status','') in ('FAILED', 'ABORTED')
+              and t.trace->>'status' in ('FAILED', 'ABORTED')
               {fc}
             group by exit_code
             order by failures desc, exit_code
@@ -279,6 +292,10 @@ class ProcessMetricsService:
         if limit < 1:
             raise ValueError("limit must be >= 1")
 
+        window_days, window_hours = _normalize_window(
+            window_days=window_days, window_hours=window_hours,
+            since=since, until=until,
+        )
         fc, params = self._filter_clause(
             window_days=window_days, window_hours=window_hours,
             since=since, until=until,
@@ -386,6 +403,10 @@ class ProcessMetricsService:
         if limit < 1:
             raise ValueError("limit must be >= 1")
 
+        window_days, window_hours = _normalize_window(
+            window_days=window_days, window_hours=window_hours,
+            since=since, until=until,
+        )
         fc, params = self._filter_clause(
             window_days=window_days, window_hours=window_hours,
             since=since, until=until,
@@ -470,6 +491,10 @@ class ProcessMetricsService:
         if limit < 1:
             raise ValueError("limit must be >= 1")
 
+        window_days, window_hours = _normalize_window(
+            window_days=window_days, window_hours=window_hours,
+            since=since, until=until,
+        )
         fc, params = self._filter_clause(
             window_days=window_days, window_hours=window_hours,
             since=since, until=until,
@@ -566,6 +591,10 @@ class ProcessMetricsService:
         if limit < 1:
             raise ValueError("limit must be >= 1")
 
+        window_days, window_hours = _normalize_window(
+            window_days=window_days, window_hours=window_hours,
+            since=since, until=until,
+        )
         fc, params = self._filter_clause(
             window_days=window_days, window_hours=window_hours,
             since=since, until=until,
@@ -584,7 +613,7 @@ class ProcessMetricsService:
             from telemetry t
             where t.event = 'process_completed'
               and t.trace is not null
-              and coalesce(t.trace->>'status','') in ('FAILED', 'ABORTED')
+              and t.trace->>'status' in ('FAILED', 'ABORTED')
               {fc}
             group by process, exit_code, error_action
             order by failures desc, process, exit_code
@@ -616,6 +645,10 @@ class ProcessMetricsService:
         if bucket not in ("hour", "day", "week"):
             raise ValueError("bucket must be 'hour', 'day', or 'week'")
 
+        window_days, window_hours = _normalize_window(
+            window_days=window_days, window_hours=window_hours,
+            since=since, until=until,
+        )
         fc, params = self._filter_clause(
             window_days=window_days, window_hours=window_hours,
             since=since, until=until,
@@ -738,6 +771,10 @@ class ProcessMetricsService:
         if offset < 0:
             raise ValueError("offset must be >= 0")
 
+        window_days, window_hours = _normalize_window(
+            window_days=window_days, window_hours=window_hours,
+            since=since, until=until,
+        )
         fc, params = self._filter_clause(
             window_days=window_days, window_hours=window_hours,
             since=since, until=until,
@@ -751,7 +788,7 @@ class ProcessMetricsService:
             extra_clauses += " and t.trace->>'process' = :process"
             params["process"] = process
         if status is not None:
-            extra_clauses += " and coalesce(t.trace->>'status','') = :status"
+            extra_clauses += " and t.trace->>'status' = :status"
             params["status"] = status
 
         sql = text(

--- a/tests/test_process_metrics_router.py
+++ b/tests/test_process_metrics_router.py
@@ -125,6 +125,7 @@ class FakeProcessMetricsService:
     async def timeline(self, *, bucket="hour", **kwargs):
         return {
             "generated_at_utc": "2026-01-01T00:00:00Z",
+            "window_days": kwargs.get("window_days"),
             "bucket": bucket,
             "rows": [
                 {"bucket_start": "2026-01-01T00:00:00Z", "total": 10, "success": 8, "failed": 2, "failure_pct": 20.0}
@@ -134,6 +135,7 @@ class FakeProcessMetricsService:
     async def tasks(self, *, limit=50, offset=0, **kwargs):
         return {
             "generated_at_utc": "2026-01-01T00:00:00Z",
+            "window_days": kwargs.get("window_days"),
             "total": 1,
             "limit": limit,
             "offset": offset,

--- a/tests/test_process_metrics_service.py
+++ b/tests/test_process_metrics_service.py
@@ -1,0 +1,85 @@
+"""Unit + service-level tests for ProcessMetricsService default-window behaviour.
+
+The default-window default (7 days, applied when no time filter is supplied)
+prevents unparameterised metrics calls from scanning the full telemetry table
+once event volume grows. These tests lock in the behaviour so a regression
+back to "all-time" is caught at PR time.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import insert
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from nextflow_telemetry.services.process_metrics import (
+    _DEFAULT_WINDOW_DAYS,
+    _normalize_window,
+    ProcessMetricsService,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure unit tests for _normalize_window
+# ---------------------------------------------------------------------------
+
+def test_normalize_window_applies_default_when_all_time_filters_none():
+    out = _normalize_window(window_days=None, window_hours=None, since=None, until=None)
+    assert out == (_DEFAULT_WINDOW_DAYS, None)
+
+
+def test_normalize_window_passes_through_explicit_window_days():
+    out = _normalize_window(window_days=30, window_hours=None, since=None, until=None)
+    assert out == (30, None)
+
+
+def test_normalize_window_passes_through_explicit_window_hours():
+    out = _normalize_window(window_days=None, window_hours=12, since=None, until=None)
+    assert out == (None, 12)
+
+
+def test_normalize_window_passes_through_when_since_supplied():
+    """Any time filter present should suppress the default."""
+    since = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    out = _normalize_window(window_days=None, window_hours=None, since=since, until=None)
+    assert out == (None, None)
+
+
+def test_normalize_window_passes_through_when_until_supplied():
+    until = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    out = _normalize_window(window_days=None, window_hours=None, since=None, until=until)
+    assert out == (None, None)
+
+
+# ---------------------------------------------------------------------------
+# Service-level integration: bare call returns window_days=7 in payload
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_bare_summary_call_reports_default_window_in_response(db_url):
+    """Exercising one representative method end-to-end with no time args.
+
+    The empty DB has no telemetry rows so the SQL just returns zeros, but
+    we don't care about the row counts — we care that the response payload
+    echoes back `window_days = _DEFAULT_WINDOW_DAYS`. That's what tells a
+    client whether all-time data was scanned or just the default window.
+    """
+    engine = create_async_engine(db_url)
+    try:
+        svc = ProcessMetricsService(engine=engine)
+        result = await svc.summary()
+        assert result["window_days"] == _DEFAULT_WINDOW_DAYS
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_explicit_window_days_overrides_default(db_url):
+    engine = create_async_engine(db_url)
+    try:
+        svc = ProcessMetricsService(engine=engine)
+        result = await svc.summary(window_days=30)
+        assert result["window_days"] == 30
+    finally:
+        await engine.dispose()

--- a/tests/test_process_metrics_service.py
+++ b/tests/test_process_metrics_service.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 import pytest
-from sqlalchemy import insert
 from sqlalchemy.ext.asyncio import create_async_engine
 
 from nextflow_telemetry.services.process_metrics import (


### PR DESCRIPTION
Closes #71.

## Summary

- **Default 7-day window** in \`ProcessMetricsService._filter_clause\` when no time filter is supplied. Bare \`/api/metrics/processes/summary\` no longer scans the full telemetry table.
- **Two partial functional indexes** on \`telemetry.trace\` JSONB extractions used by cohort + process metrics queries: \`(trace->>'process')\` and \`(trace->>'status')\`, both partial on \`event = 'process_completed'\` to keep the indexes small.

## Test plan

- [x] \`just check\` — 85 passed, 3 skipped
- [ ] Apply migration to prod, then \`EXPLAIN ANALYZE\` the cohort failure aggregation: should see Index Scan, not Seq Scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)