### PR TITLE
feat: jobs.submitted status to surface queue wait

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,10 +68,10 @@ pending → claimed → submitted → running → completed
 
 - `pending`: created by `reconcile_jobs()` (cross-product of samples × active workflows)
 - `claimed`: `POST /dispatch/batch` atomically selects jobs with `SELECT ... FOR UPDATE SKIP LOCKED` and creates a `workflow_run` record
-- `submitted`: `POST /dispatch/submitted` confirms the executor accepted the job
-- `running`: set when Nextflow sends a `started` weblog event to `POST /telemetry`
+- `submitted`: `POST /dispatch/submitted` confirms the executor accepted the job. Distinct from `running`: a SLURM job that's queued but not yet started sits in `submitted` for the queue-wait duration. The gap between `submitted` and `running` is the scheduler queue wait; surfacing it separately is what allows dashboards to distinguish "slow pipeline" from "slow cluster."
+- `running`: set when Nextflow sends a `started` weblog event to `POST /telemetry` (transitions from `submitted` in the normal flow; defensively also accepts `claimed` for out-of-order events).
 - `completed`: set when Nextflow sends `process_completed` for the `MARK_COMPLETE` sentinel process with `status=COMPLETED`
-- On run `completed` event: `sweep_run_incomplete()` retries jobs within `max_retries` budget or routes to DLQ
+- On run `completed` event: `sweep_run_incomplete()` retries jobs within `max_retries` budget or routes to DLQ. Sweep covers `claimed`, `submitted`, *and* `running` jobs.
 
 ### nf-client
 

--- a/frontend/src/pages/CohortsPage.tsx
+++ b/frontend/src/pages/CohortsPage.tsx
@@ -242,6 +242,7 @@ export default function CohortsPage({ pollInterval = 30_000 }: { pollInterval?: 
               <StatusChip label="Jobs total" count={summary.total_jobs} color={T.text} />
               <StatusChip label="Pending" count={counts?.pending ?? 0} color={T.muted} />
               <StatusChip label="Claimed" count={counts?.claimed ?? 0} color={T.blue} />
+              <StatusChip label="Submitted" count={counts?.submitted ?? 0} color={T.blue} />
               <StatusChip label="Running" count={counts?.running ?? 0} color={T.amber} />
               <StatusChip label="Completed" count={counts?.completed ?? 0} color={T.green} />
               <StatusChip label="Failed" count={counts?.failed ?? 0} color={T.red} />

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -32,6 +32,7 @@ export interface JobStats {
   total: number
   pending: number
   claimed?: number
+  submitted?: number
   running: number
   completed: number
   failed: number
@@ -308,6 +309,7 @@ export interface WorkflowJobSummary {
   total: number
   pending: number
   claimed: number
+  submitted: number
   running: number
   completed: number
   failed: number
@@ -348,6 +350,7 @@ export interface CohortListItem {
 export interface CohortJobStatusCounts {
   pending: number
   claimed: number
+  submitted: number
   running: number
   completed: number
   failed: number

--- a/src/nextflow_telemetry/models.py
+++ b/src/nextflow_telemetry/models.py
@@ -344,6 +344,7 @@ class WorkflowJobSummary(BaseModel):
     total: int = Field(description="Total number of jobs for this workflow.")
     pending: int = Field(description="Jobs waiting to be dispatched.")
     claimed: int = Field(description="Jobs claimed by a dispatcher but not yet submitted.")
+    submitted: int = Field(default=0, description="Jobs submitted to the executor (e.g. queued in SLURM) but not yet running in Nextflow.")
     running: int = Field(description="Jobs currently executing in Nextflow.")
     completed: int = Field(description="Jobs that completed successfully.")
     failed: int = Field(description="Jobs that exhausted retries and are marked failed.")

--- a/src/nextflow_telemetry/routers/cohorts.py
+++ b/src/nextflow_telemetry/routers/cohorts.py
@@ -32,6 +32,7 @@ class CohortListItem(BaseModel):
 class CohortJobStatusCounts(BaseModel):
     pending: int = 0
     claimed: int = 0
+    submitted: int = 0
     running: int = 0
     completed: int = 0
     failed: int = 0

--- a/src/nextflow_telemetry/routers/dispatch.py
+++ b/src/nextflow_telemetry/routers/dispatch.py
@@ -198,13 +198,17 @@ def create_dispatch_router(engine: AsyncEngine) -> APIRouter:
                     detail=f"No claimed run with name '{req.run_name}' found",
                 )
 
+            # Advance jobs from `claimed` to `submitted` — distinct from
+            # `running`, which is set only when the weblog `started` event
+            # arrives. The gap between the two is the scheduler queue wait,
+            # which the dashboard surfaces separately.
             await conn.execute(
                 update(jobs_tbl)
                 .where(
                     jobs_tbl.c.run_name == req.run_name,
                     jobs_tbl.c.status == "claimed",
                 )
-                .values(status="running")
+                .values(status="submitted")
             )
 
         return {"run_name": req.run_name, "status": "submitted"}

--- a/src/nextflow_telemetry/routers/workflows.py
+++ b/src/nextflow_telemetry/routers/workflows.py
@@ -194,10 +194,11 @@ def create_workflows_router(engine: AsyncEngine) -> APIRouter:
 
         pending   = counts.get("pending",   0)
         claimed   = counts.get("claimed",   0)
+        submitted = counts.get("submitted", 0)
         running   = counts.get("running",   0)
         completed = counts.get("completed", 0)
         failed    = counts.get("failed",    0)
-        total     = pending + claimed + running + completed + failed
+        total     = pending + claimed + submitted + running + completed + failed
         pct       = 100.0 * completed / total if total > 0 else 0.0
 
         return WorkflowJobSummary(
@@ -207,6 +208,7 @@ def create_workflows_router(engine: AsyncEngine) -> APIRouter:
             total=total,
             pending=pending,
             claimed=claimed,
+            submitted=submitted,
             running=running,
             completed=completed,
             failed=failed,

--- a/src/nextflow_telemetry/services/cohort.py
+++ b/src/nextflow_telemetry/services/cohort.py
@@ -21,7 +21,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 
-_JOB_STATUSES = ("pending", "claimed", "running", "completed", "failed")
+_JOB_STATUSES = ("pending", "claimed", "submitted", "running", "completed", "failed")
 
 
 @dataclass

--- a/src/nextflow_telemetry/services/reconcile.py
+++ b/src/nextflow_telemetry/services/reconcile.py
@@ -47,7 +47,7 @@ async def sweep_run_incomplete(conn: AsyncConnection, run_name: str, now: dateti
         update(jobs_tbl)
         .where(
             jobs_tbl.c.run_name == run_name,
-            jobs_tbl.c.status.in_(["running", "claimed"]),
+            jobs_tbl.c.status.in_(["running", "claimed", "submitted"]),
         )
         .values(
             retry_count=jobs_tbl.c.retry_count + 1,

--- a/src/nextflow_telemetry/services/telemetry.py
+++ b/src/nextflow_telemetry/services/telemetry.py
@@ -74,11 +74,15 @@ class TelemetryService:
                     .where(workflow_runs_tbl.c.run_name == event.run_name)
                     .values(run_id=event.run_id, status="running", started_at=now)
                 )
+                # Jobs reach `running` from either `submitted` (the
+                # normal flow once /dispatch/submitted has fired) or
+                # `claimed` (defensive: events out of order, or pre-#73
+                # jobs that haven't transitioned through submitted yet).
                 await conn.execute(
                     update(jobs_tbl)
                     .where(
                         jobs_tbl.c.run_name == event.run_name,
-                        jobs_tbl.c.status == "claimed",
+                        jobs_tbl.c.status.in_(["claimed", "submitted"]),
                     )
                     .values(status="running")
                 )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -395,14 +395,17 @@ def test_weblog_started_advances_submitted_jobs_to_running(integration_client, d
     client, _ = integration_client
     _, wf_id, _ = _seed_job(client)
 
-    batch = client.post("/api/dispatch/batch", json={"workflow_id": [wf_id], "limit": 10}).json()
+    batch_resp = client.post("/api/dispatch/batch", json={"workflow_id": [wf_id], "limit": 10})
+    assert batch_resp.status_code == 200, batch_resp.text
+    batch = batch_resp.json()
     run_name = batch["run_name"]
     sample_ids = [j["sample_id"] for j in batch["jobs"]]
 
     # claimed → submitted
-    client.post("/api/dispatch/submitted", json={
+    submitted_resp = client.post("/api/dispatch/submitted", json={
         "run_name": run_name, "executor_job_id": "SLURM_99", "sample_ids": sample_ids,
     })
+    assert submitted_resp.status_code == 200, submitted_resp.text
 
     # submitted → running (via weblog started event)
     run_id = str(uuid.uuid4())

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -393,7 +393,7 @@ def test_weblog_started_advances_submitted_jobs_to_running(integration_client, d
     from nextflow_telemetry.db import jobs_tbl, workflow_runs_tbl
 
     client, _ = integration_client
-    sample_id, wf_id, _ = _seed_job(client)
+    _, wf_id, _ = _seed_job(client)
 
     batch = client.post("/api/dispatch/batch", json={"workflow_id": [wf_id], "limit": 10}).json()
     run_name = batch["run_name"]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -383,6 +383,39 @@ def test_dispatch_submitted_transitions(integration_client, db_url):
     job_rows = _run(_query(db_url, select(jobs_tbl).where(
         jobs_tbl.c.run_name == run_name,
     )))
+    # Issue #73: jobs go to `submitted` here, not `running`. The transition to
+    # `running` happens later, on the weblog `started` event.
+    assert all(r["status"] == "submitted" for r in job_rows)
+
+
+def test_weblog_started_advances_submitted_jobs_to_running(integration_client, db_url):
+    """The full state machine: pending → claimed → submitted → running."""
+    from nextflow_telemetry.db import jobs_tbl, workflow_runs_tbl
+
+    client, _ = integration_client
+    sample_id, wf_id, _ = _seed_job(client)
+
+    batch = client.post("/api/dispatch/batch", json={"workflow_id": [wf_id], "limit": 10}).json()
+    run_name = batch["run_name"]
+    sample_ids = [j["sample_id"] for j in batch["jobs"]]
+
+    # claimed → submitted
+    client.post("/api/dispatch/submitted", json={
+        "run_name": run_name, "executor_job_id": "SLURM_99", "sample_ids": sample_ids,
+    })
+
+    # submitted → running (via weblog started event)
+    run_id = str(uuid.uuid4())
+    resp = client.post("/telemetry",
+                       json=_weblog_payload(run_id=run_id, run_name=run_name, event="started"))
+    assert resp.status_code == 200
+
+    run_rows = _run(_query(db_url, select(workflow_runs_tbl).where(
+        workflow_runs_tbl.c.run_name == run_name
+    )))
+    assert run_rows[0]["status"] == "running"
+
+    job_rows = _run(_query(db_url, select(jobs_tbl).where(jobs_tbl.c.run_name == run_name)))
     assert all(r["status"] == "running" for r in job_rows)
 
 


### PR DESCRIPTION
Closes #73.

## Summary

Adds \`submitted\` to the jobs state machine so the queue-wait period (claim → SLURM start) is distinct from execution. Today's flow set jobs to \`running\` at /dispatch/submitted time, hiding scheduler queue wait from dashboards.

\`\`\`
pending → claimed → submitted → running → completed
                                        ↘ failed → dead_letter
\`\`\`

* \`POST /dispatch/submitted\`: \`claimed → submitted\` (was: → running)
* weblog \`started\` event: \`submitted|claimed → running\` (defensively accepts both)
* \`sweep_run_incomplete\`: covers \`submitted\` jobs too
* \`WorkflowJobSummary\`, \`CohortJobStatusCounts\`, frontend types all updated
* \`CLAUDE.md\` state-machine description updated
* No DB migration — \`status\` is a plain string column

## Test plan

- [x] \`just check\` — 86 passed (1 new test for the full pending → claimed → submitted → running path)
- [x] Frontend builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)