### PR TITLE
perf: tighten dispatch FOR UPDATE to a single workflow batch

### DIFF
--- a/src/nextflow_telemetry/routers/dispatch.py
+++ b/src/nextflow_telemetry/routers/dispatch.py
@@ -103,7 +103,16 @@ def create_dispatch_router(engine: AsyncEngine) -> APIRouter:
                     jobs_tbl.c.workflow_id,
                     jobs_tbl.c.workflow_version,
                     jobs_tbl.c.created_at,
-                ).limit(1)
+                )
+                .limit(1)
+                # Skip rows another dispatcher is already claiming. Without
+                # this, a competing transaction holding a lock on the
+                # otherwise-first pending job would cause every subsequent
+                # caller to pick that workflow, fail step 2 (FOR UPDATE
+                # SKIP LOCKED returns 0 rows because all of that workflow's
+                # rows are locked too), and 204 → spin. SKIP LOCKED on
+                # pick steers us to a workflow that *has* claimable rows.
+                .with_for_update(of=jobs_tbl, skip_locked=True)
             )
 
             pick_row = (await conn.execute(pick_q)).mappings().first()

--- a/src/nextflow_telemetry/routers/dispatch.py
+++ b/src/nextflow_telemetry/routers/dispatch.py
@@ -80,8 +80,14 @@ def create_dispatch_router(engine: AsyncEngine) -> APIRouter:
         now = datetime.now(timezone.utc)
 
         async with engine.begin() as conn:
-            q = (
-                select(jobs_tbl, workflows_tbl)
+            # Two-step pick-then-lock: first decide *which* (workflow_id,
+            # workflow_version) batch to claim, then take a row-level lock
+            # only on jobs in that batch. Issue #74: a single FOR UPDATE
+            # SKIP LOCKED LIMIT N could lock rows across multiple workflows
+            # that we'd then narrow away in Python — those locks blocked
+            # other dispatchers needlessly.
+            pick_q = (
+                select(jobs_tbl.c.workflow_id, jobs_tbl.c.workflow_version)
                 .join(workflows_tbl, jobs_tbl.c.workflow_pk == workflows_tbl.c.id)
                 .where(
                     jobs_tbl.c.status == "pending",
@@ -89,25 +95,44 @@ def create_dispatch_router(engine: AsyncEngine) -> APIRouter:
                 )
             )
             if req.workflow_id:
-                q = q.where(jobs_tbl.c.workflow_id.in_(req.workflow_id))
+                pick_q = pick_q.where(jobs_tbl.c.workflow_id.in_(req.workflow_id))
             if req.workflow_version:
-                q = q.where(jobs_tbl.c.workflow_version == req.workflow_version)
+                pick_q = pick_q.where(jobs_tbl.c.workflow_version == req.workflow_version)
+            pick_q = (
+                pick_q.order_by(
+                    jobs_tbl.c.workflow_id,
+                    jobs_tbl.c.workflow_version,
+                    jobs_tbl.c.created_at,
+                ).limit(1)
+            )
 
-            result = await conn.execute(
-                q.order_by(jobs_tbl.c.workflow_id, jobs_tbl.c.workflow_version,
-                           jobs_tbl.c.created_at)
+            pick_row = (await conn.execute(pick_q)).mappings().first()
+            if pick_row is None:
+                return Response(status_code=204)
+            first_wf_id = pick_row["workflow_id"]
+            first_wf_ver = pick_row["workflow_version"]
+
+            # Step 2: lock and claim jobs in that single batch only.
+            # If a competing dispatcher swept through between step 1 and
+            # step 2, this returns nothing and the caller retries — the
+            # next pick may resolve to a different workflow.
+            claim_q = (
+                select(jobs_tbl, workflows_tbl)
+                .join(workflows_tbl, jobs_tbl.c.workflow_pk == workflows_tbl.c.id)
+                .where(
+                    jobs_tbl.c.status == "pending",
+                    workflows_tbl.c.status == "active",
+                    jobs_tbl.c.workflow_id == first_wf_id,
+                    jobs_tbl.c.workflow_version == first_wf_ver,
+                )
+                .order_by(jobs_tbl.c.created_at)
                 .limit(req.limit)
                 .with_for_update(of=jobs_tbl, skip_locked=True)
             )
-            rows = result.mappings().all()
+            rows = (await conn.execute(claim_q)).mappings().all()
 
             if not rows:
                 return Response(status_code=204)
-
-            first_wf_id = rows[0]["workflow_id"]
-            first_wf_ver = rows[0]["workflow_version"]
-            rows = [r for r in rows if r["workflow_id"] == first_wf_id
-                    and r["workflow_version"] == first_wf_ver]
 
             job_ids = [r["id"] for r in rows]
             run_name = "r" + str(_uuid7())

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -323,29 +323,45 @@ def _purge_test_dispatch_state(db_url: str, wf_ids: list[str], sample_ids: list[
 
     Without this, samples accumulate in the shared testcontainers DB and
     every subsequent reconcile cross-products them × the next test's
-    fresh workflow. The dispatcher's `LIMIT N` then returns N rows out of
-    a pile of rows-with-tied-created_at and the test's expected sample
-    may not be in the slice.
+    fresh workflow. The dispatcher's ``LIMIT N`` then returns N rows out
+    of a pile of rows-with-tied-created_at and the test's expected
+    sample may not be in the slice.
+
+    Uses Core ``in_()`` constructs so SQLAlchemy/asyncpg type the array
+    bind correctly — raw ``ANY(:s::text[])`` confuses the parameter
+    parser. The dead_letter delete covers both sample_ids and
+    workflow_ids so the FK on dead_letter.job_id can't block the
+    subsequent ``DELETE FROM jobs``.
     """
-    statements = [
-        text("DELETE FROM dead_letter WHERE sample_id = ANY(:s)"),
-        text("DELETE FROM jobs WHERE sample_id = ANY(:s) OR workflow_id = ANY(:w)"),
-        text("DELETE FROM workflow_runs WHERE workflow_id = ANY(:w)"),
-        text("DELETE FROM telemetry WHERE sample_id = ANY(:s)"),
-        text("DELETE FROM samples WHERE sample_id = ANY(:s)"),
-        text("DELETE FROM workflows WHERE workflow_id = ANY(:w)"),
+    from nextflow_telemetry.db import (
+        dead_letter_tbl,
+        jobs_tbl,
+        samples_tbl,
+        telemetry_tbl,
+        workflow_runs_tbl,
+        workflows_tbl,
+    )
+    from sqlalchemy import delete, or_
+
+    stmts = [
+        delete(dead_letter_tbl).where(
+            or_(
+                dead_letter_tbl.c.sample_id.in_(sample_ids),
+                dead_letter_tbl.c.workflow_id.in_(wf_ids),
+            )
+        ),
+        delete(jobs_tbl).where(
+            or_(
+                jobs_tbl.c.sample_id.in_(sample_ids),
+                jobs_tbl.c.workflow_id.in_(wf_ids),
+            )
+        ),
+        delete(workflow_runs_tbl).where(workflow_runs_tbl.c.workflow_id.in_(wf_ids)),
+        delete(telemetry_tbl).where(telemetry_tbl.c.sample_id.in_(sample_ids)),
+        delete(samples_tbl).where(samples_tbl.c.sample_id.in_(sample_ids)),
+        delete(workflows_tbl).where(workflows_tbl.c.workflow_id.in_(wf_ids)),
     ]
-    _run(_exec_with_params(db_url, statements, {"s": sample_ids, "w": wf_ids}))
-
-
-async def _exec_with_params(db_url, stmts, params):
-    engine = create_async_engine(db_url)
-    try:
-        async with engine.begin() as conn:
-            for stmt in stmts:
-                await conn.execute(stmt, params)
-    finally:
-        await engine.dispose()
+    _run(_exec(db_url, *stmts))
 
 
 def test_dispatch_skips_locked_workflow_and_picks_an_unlocked_one(integration_client, db_url):
@@ -424,6 +440,10 @@ def test_dispatch_skips_locked_workflow_and_picks_an_unlocked_one(integration_cl
     finally:
         proceed.set()
         holder.join(timeout=5.0)
+        # Be loud, not silent, if the lock-holder thread didn't exit.
+        # A stuck daemon would leak an open transaction/row locks into
+        # the session-scoped Postgres and break subsequent tests.
+        assert not holder.is_alive(), "lock-holder thread did not exit within 5s"
         _purge_test_dispatch_state(db_url, [wf_a, wf_b], [sample_a, sample_b])
 
     assert resp.status_code == 200, resp.text

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -317,6 +317,39 @@ def _seed_job(client, *, workflow_id: str | None = None, sample_suffix: str = ""
     return sample_id, wf_id, wf_pk
 
 
+def test_dispatch_batch_two_disjoint_workflow_filters_each_get_their_own(integration_client):
+    """Each dispatch response is scoped to its requested workflow_id (#74).
+
+    Pre-#74, FOR UPDATE locks could span multiple workflows before being
+    narrowed in Python — the pick-then-lock pattern in this PR locks
+    only the batch corresponding to the picked (workflow_id, version),
+    so disjoint workflow filters land in independent locked sets.
+
+    This test isn't a true concurrency stress test (TestClient runs
+    sequentially), but it does verify the contract: requesting workflow A
+    then workflow B in succession produces claims whose top-level
+    workflow_id matches the request, and the run_names are distinct.
+    Reconcile cross-products samples × workflows so both samples have
+    jobs for both workflows, which is fine — what matters is each
+    response is scoped correctly.
+    """
+    client, _ = integration_client
+    _, wf_a, _ = _seed_job(client)
+    _, wf_b, _ = _seed_job(client)
+
+    a_resp = client.post("/api/dispatch/batch", json={"workflow_id": [wf_a], "limit": 100})
+    assert a_resp.status_code == 200, a_resp.text
+    a_data = a_resp.json()
+    assert a_data["workflow_id"] == wf_a
+
+    b_resp = client.post("/api/dispatch/batch", json={"workflow_id": [wf_b], "limit": 100})
+    assert b_resp.status_code == 200, b_resp.text
+    b_data = b_resp.json()
+    assert b_data["workflow_id"] == wf_b
+
+    assert a_data["run_name"] != b_data["run_name"]
+
+
 def test_dispatch_batch_no_pending_returns_204(integration_client):
     client, _ = integration_client
     # Request a workflow_id that has no jobs

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -317,16 +317,6 @@ def _seed_job(client, *, workflow_id: str | None = None, sample_suffix: str = ""
     return sample_id, wf_id, wf_pk
 
 
-def _pause_workflow(client, wf_id: str) -> None:
-    """Test cleanup: flip a workflow to paused so subsequent reconcile-jobs
-    calls in later tests don't keep cross-producting it with new samples.
-    """
-    listing = client.get("/api/workflows", params={"status": "active"}).json()
-    matches = [w for w in listing if w["workflow_id"] == wf_id]
-    if matches:
-        client.patch(f"/api/workflows/{matches[0]['id']}/status", json={"status": "paused"})
-
-
 def _purge_test_dispatch_state(db_url: str, wf_ids: list[str], sample_ids: list[str]) -> None:
     """Delete jobs / workflow_runs / samples / workflows so subsequent
     reconcile-jobs calls don't see this test's leftovers.
@@ -358,30 +348,39 @@ async def _exec_with_params(db_url, stmts, params):
         await engine.dispose()
 
 
-def test_dispatch_disjoint_workflows_dont_block_each_other(integration_client, db_url):
-    """A real concurrency test for the #74 contract.
+def test_dispatch_skips_locked_workflow_and_picks_an_unlocked_one(integration_client, db_url):
+    """The #74 contract: a workflow whose rows are entirely locked must NOT
+    starve dispatchers that could otherwise have claimed a different one.
 
-    Spawns a background thread that opens its own async transaction,
-    `SELECT … FOR UPDATE` over every pending job for workflow A, and
-    holds those locks until the main thread releases it. While the
-    locks are held, the main thread calls /api/dispatch/batch for
-    workflow B — which should complete near-instantly since B's
-    rows are untouched.
+    Setup makes wf_a sort before wf_b alphabetically by workflow_id, so
+    the pick step's `ORDER BY workflow_id, workflow_version, created_at`
+    *would* pick wf_a if it ignored locks. We:
 
-    Pre-#74 this would have blocked: the original FOR UPDATE SKIP
-    LOCKED query scanned across both workflows in workflow_id order
-    before narrowing to one, and could land on rows the holder had
-    locked before SKIP LOCKED kicked in. The pick-then-lock pattern
-    plus SKIP LOCKED on the pick step makes the two paths
-    independent.
+      1. Spawn a background thread that locks every pending wf_a row
+         (`SELECT … FOR UPDATE`) in its own async transaction.
+      2. Filter the dispatch to `[wf_a, wf_b]` (both candidates) — so
+         the dispatcher is forced to choose between them. The naive
+         pick (no SKIP LOCKED) would land on wf_a, then claim_q would
+         find every wf_a row locked, return 0 rows, and 204.
+      3. Assert the response is 200 with workflow_id=wf_b — proving
+         the pick step skipped the entirely-locked wf_a and steered
+         to the unlocked wf_b.
+
+    Without `SKIP LOCKED` on the pick step (the round-2 fix in this
+    PR), this test would 204-and-spin under contention.
     """
     import asyncio
     import threading
     import time
 
     client, _ = integration_client
-    sample_a, wf_a, _ = _seed_job(client)
-    sample_b, wf_b, _ = _seed_job(client)
+    # Force alphabetical ordering: wf_a sorts before wf_b. The pick step
+    # default ORDER BY would land on wf_a if not for SKIP LOCKED.
+    aaa_id = "wf-aaaa-" + uuid.uuid4().hex[:6]
+    zzz_id = "wf-zzzz-" + uuid.uuid4().hex[:6]
+    sample_a, wf_a, _ = _seed_job(client, workflow_id=aaa_id)
+    sample_b, wf_b, _ = _seed_job(client, workflow_id=zzz_id)
+    assert wf_a < wf_b, "test setup invariant: wf_a must sort before wf_b"
 
     locked = threading.Event()
     proceed = threading.Event()
@@ -400,7 +399,6 @@ def test_dispatch_disjoint_workflows_dont_block_each_other(integration_client, d
                         {"w": wf_a},
                     )
                     locked.set()
-                    # Hold the transaction open until the main thread releases.
                     while not proceed.is_set():
                         await asyncio.sleep(0.05)
             finally:
@@ -414,9 +412,12 @@ def test_dispatch_disjoint_workflows_dont_block_each_other(integration_client, d
     assert locked.wait(timeout=5.0), "holder thread didn't acquire lock"
     try:
         t0 = time.time()
+        # Both workflows in the filter. Pre-fix: pick lands on wf_a
+        # (alphabetically first), claim_q finds it all locked, 204.
+        # Post-fix: pick SKIP LOCKED skips wf_a, picks wf_b, succeeds.
         resp = client.post(
             "/api/dispatch/batch",
-            json={"workflow_id": [wf_b], "limit": 100},
+            json={"workflow_id": [wf_a, wf_b], "limit": 100},
         )
         elapsed = time.time() - t0
     finally:
@@ -425,10 +426,10 @@ def test_dispatch_disjoint_workflows_dont_block_each_other(integration_client, d
         _purge_test_dispatch_state(db_url, [wf_a, wf_b], [sample_a, sample_b])
 
     assert resp.status_code == 200, resp.text
-    assert resp.json()["workflow_id"] == wf_b
-    # 2s ceiling is generous; should be milliseconds. If we ever block on
-    # the wf_a locks this assertion catches it.
-    assert elapsed < 2.0, f"dispatch blocked for {elapsed:.2f}s while wf_a was locked"
+    assert resp.json()["workflow_id"] == wf_b, (
+        f"expected dispatcher to pick the unlocked wf_b, got {resp.json()['workflow_id']}"
+    )
+    assert elapsed < 2.0, f"dispatch blocked for {elapsed:.2f}s under wf_a contention"
 
 
 def test_dispatch_batch_two_disjoint_workflow_filters_each_get_their_own(integration_client, db_url):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -10,7 +10,7 @@ import uuid
 from datetime import datetime, timezone
 
 import pytest
-from sqlalchemy import insert, select
+from sqlalchemy import insert, select, text
 from sqlalchemy.ext.asyncio import create_async_engine
 
 
@@ -317,7 +317,121 @@ def _seed_job(client, *, workflow_id: str | None = None, sample_suffix: str = ""
     return sample_id, wf_id, wf_pk
 
 
-def test_dispatch_batch_two_disjoint_workflow_filters_each_get_their_own(integration_client):
+def _pause_workflow(client, wf_id: str) -> None:
+    """Test cleanup: flip a workflow to paused so subsequent reconcile-jobs
+    calls in later tests don't keep cross-producting it with new samples.
+    """
+    listing = client.get("/api/workflows", params={"status": "active"}).json()
+    matches = [w for w in listing if w["workflow_id"] == wf_id]
+    if matches:
+        client.patch(f"/api/workflows/{matches[0]['id']}/status", json={"status": "paused"})
+
+
+def _purge_test_dispatch_state(db_url: str, wf_ids: list[str], sample_ids: list[str]) -> None:
+    """Delete jobs / workflow_runs / samples / workflows so subsequent
+    reconcile-jobs calls don't see this test's leftovers.
+
+    Without this, samples accumulate in the shared testcontainers DB and
+    every subsequent reconcile cross-products them × the next test's
+    fresh workflow. The dispatcher's `LIMIT N` then returns N rows out of
+    a pile of rows-with-tied-created_at and the test's expected sample
+    may not be in the slice.
+    """
+    statements = [
+        text("DELETE FROM dead_letter WHERE sample_id = ANY(:s)"),
+        text("DELETE FROM jobs WHERE sample_id = ANY(:s) OR workflow_id = ANY(:w)"),
+        text("DELETE FROM workflow_runs WHERE workflow_id = ANY(:w)"),
+        text("DELETE FROM telemetry WHERE sample_id = ANY(:s)"),
+        text("DELETE FROM samples WHERE sample_id = ANY(:s)"),
+        text("DELETE FROM workflows WHERE workflow_id = ANY(:w)"),
+    ]
+    _run(_exec_with_params(db_url, statements, {"s": sample_ids, "w": wf_ids}))
+
+
+async def _exec_with_params(db_url, stmts, params):
+    engine = create_async_engine(db_url)
+    try:
+        async with engine.begin() as conn:
+            for stmt in stmts:
+                await conn.execute(stmt, params)
+    finally:
+        await engine.dispose()
+
+
+def test_dispatch_disjoint_workflows_dont_block_each_other(integration_client, db_url):
+    """A real concurrency test for the #74 contract.
+
+    Spawns a background thread that opens its own async transaction,
+    `SELECT … FOR UPDATE` over every pending job for workflow A, and
+    holds those locks until the main thread releases it. While the
+    locks are held, the main thread calls /api/dispatch/batch for
+    workflow B — which should complete near-instantly since B's
+    rows are untouched.
+
+    Pre-#74 this would have blocked: the original FOR UPDATE SKIP
+    LOCKED query scanned across both workflows in workflow_id order
+    before narrowing to one, and could land on rows the holder had
+    locked before SKIP LOCKED kicked in. The pick-then-lock pattern
+    plus SKIP LOCKED on the pick step makes the two paths
+    independent.
+    """
+    import asyncio
+    import threading
+    import time
+
+    client, _ = integration_client
+    sample_a, wf_a, _ = _seed_job(client)
+    sample_b, wf_b, _ = _seed_job(client)
+
+    locked = threading.Event()
+    proceed = threading.Event()
+
+    def hold_wf_a_lock():
+        async def go():
+            engine = create_async_engine(db_url)
+            try:
+                async with engine.begin() as conn:
+                    await conn.execute(
+                        text(
+                            "SELECT id FROM jobs "
+                            "WHERE workflow_id = :w AND status = 'pending' "
+                            "FOR UPDATE"
+                        ),
+                        {"w": wf_a},
+                    )
+                    locked.set()
+                    # Hold the transaction open until the main thread releases.
+                    while not proceed.is_set():
+                        await asyncio.sleep(0.05)
+            finally:
+                await engine.dispose()
+
+        asyncio.run(go())
+
+    holder = threading.Thread(target=hold_wf_a_lock, daemon=True)
+    holder.start()
+
+    assert locked.wait(timeout=5.0), "holder thread didn't acquire lock"
+    try:
+        t0 = time.time()
+        resp = client.post(
+            "/api/dispatch/batch",
+            json={"workflow_id": [wf_b], "limit": 100},
+        )
+        elapsed = time.time() - t0
+    finally:
+        proceed.set()
+        holder.join(timeout=5.0)
+        _purge_test_dispatch_state(db_url, [wf_a, wf_b], [sample_a, sample_b])
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["workflow_id"] == wf_b
+    # 2s ceiling is generous; should be milliseconds. If we ever block on
+    # the wf_a locks this assertion catches it.
+    assert elapsed < 2.0, f"dispatch blocked for {elapsed:.2f}s while wf_a was locked"
+
+
+def test_dispatch_batch_two_disjoint_workflow_filters_each_get_their_own(integration_client, db_url):
     """Each dispatch response is scoped to its requested workflow_id (#74).
 
     Pre-#74, FOR UPDATE locks could span multiple workflows before being
@@ -334,20 +448,22 @@ def test_dispatch_batch_two_disjoint_workflow_filters_each_get_their_own(integra
     response is scoped correctly.
     """
     client, _ = integration_client
-    _, wf_a, _ = _seed_job(client)
-    _, wf_b, _ = _seed_job(client)
+    sample_a, wf_a, _ = _seed_job(client)
+    sample_b, wf_b, _ = _seed_job(client)
+    try:
+        a_resp = client.post("/api/dispatch/batch", json={"workflow_id": [wf_a], "limit": 100})
+        assert a_resp.status_code == 200, a_resp.text
+        a_data = a_resp.json()
+        assert a_data["workflow_id"] == wf_a
 
-    a_resp = client.post("/api/dispatch/batch", json={"workflow_id": [wf_a], "limit": 100})
-    assert a_resp.status_code == 200, a_resp.text
-    a_data = a_resp.json()
-    assert a_data["workflow_id"] == wf_a
+        b_resp = client.post("/api/dispatch/batch", json={"workflow_id": [wf_b], "limit": 100})
+        assert b_resp.status_code == 200, b_resp.text
+        b_data = b_resp.json()
+        assert b_data["workflow_id"] == wf_b
 
-    b_resp = client.post("/api/dispatch/batch", json={"workflow_id": [wf_b], "limit": 100})
-    assert b_resp.status_code == 200, b_resp.text
-    b_data = b_resp.json()
-    assert b_data["workflow_id"] == wf_b
-
-    assert a_data["run_name"] != b_data["run_name"]
+        assert a_data["run_name"] != b_data["run_name"]
+    finally:
+        _purge_test_dispatch_state(db_url, [wf_a, wf_b], [sample_a, sample_b])
 
 
 def test_dispatch_batch_no_pending_returns_204(integration_client):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -371,7 +371,6 @@ def test_dispatch_skips_locked_workflow_and_picks_an_unlocked_one(integration_cl
     """
     import asyncio
     import threading
-    import time
 
     client, _ = integration_client
     # Force alphabetical ordering: wf_a sorts before wf_b. The pick step
@@ -407,11 +406,14 @@ def test_dispatch_skips_locked_workflow_and_picks_an_unlocked_one(integration_cl
         asyncio.run(go())
 
     holder = threading.Thread(target=hold_wf_a_lock, daemon=True)
+    # Outer try/finally guarantees the holder thread is released and the
+    # test data is purged even if the lock-acquisition assertion fails or
+    # the dispatch call raises — otherwise a stuck daemon thread holding
+    # an open transaction would leak into the session-scoped Postgres.
     holder.start()
-
-    assert locked.wait(timeout=5.0), "holder thread didn't acquire lock"
     try:
-        t0 = time.time()
+        assert locked.wait(timeout=5.0), "holder thread didn't acquire lock"
+
         # Both workflows in the filter. Pre-fix: pick lands on wf_a
         # (alphabetically first), claim_q finds it all locked, 204.
         # Post-fix: pick SKIP LOCKED skips wf_a, picks wf_b, succeeds.
@@ -419,7 +421,6 @@ def test_dispatch_skips_locked_workflow_and_picks_an_unlocked_one(integration_cl
             "/api/dispatch/batch",
             json={"workflow_id": [wf_a, wf_b], "limit": 100},
         )
-        elapsed = time.time() - t0
     finally:
         proceed.set()
         holder.join(timeout=5.0)
@@ -429,7 +430,6 @@ def test_dispatch_skips_locked_workflow_and_picks_an_unlocked_one(integration_cl
     assert resp.json()["workflow_id"] == wf_b, (
         f"expected dispatcher to pick the unlocked wf_b, got {resp.json()['workflow_id']}"
     )
-    assert elapsed < 2.0, f"dispatch blocked for {elapsed:.2f}s under wf_a contention"
 
 
 def test_dispatch_batch_two_disjoint_workflow_filters_each_get_their_own(integration_client, db_url):


### PR DESCRIPTION
Closes #74.

## Summary

- Replaces the over-broad \`SELECT … FOR UPDATE SKIP LOCKED LIMIT N\` (which then narrowed to one workflow in Python) with a two-step pick-then-lock pattern: first pick the (workflow_id, workflow_version) of the next batch with `FOR UPDATE SKIP LOCKED LIMIT 1` (skipping rows another dispatcher already holds, so we never spin on a workflow whose rows are entirely locked), then \`SELECT … FOR UPDATE SKIP LOCKED\` only on jobs matching that pair.
- Locks no longer span multiple workflows. Dispatchers on disjoint workflows can run concurrently without contending.
- Python-side narrowing of rows by (workflow_id, version) is gone — step 2 already returns only matching rows.

## Race semantics

If a competing dispatcher claims the picked batch between step 1 and step 2, step 2 returns 0 rows and we 204. The caller retries; the next pick naturally lands on a different workflow. Same outcome as the existing race window in this code path.

## Test plan

- [x] \`just check\` — 95 passed, 3 skipped (2 new tests: response-scoping + a thread-driven concurrency test)
- [x] New \`test_dispatch_batch_two_disjoint_workflow_filters_each_get_their_own\` exercises the response-scoping contract
- [ ] Apply to prod and verify dispatch latency / lock-wait events stay clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)