### PR TITLE
deploy: docker-compose stack for self-hosting on onclappc02

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,6 +184,8 @@ timeline.html*
 trace.txt*
 .env
 .env.*
+!.env.example
+!.env.*.example
 *.db
 *.png
 *.jpg

--- a/README.md
+++ b/README.md
@@ -51,7 +51,19 @@ Registry of pipeline versions. Each workflow card shows:
 
 ### Samples
 
-Paginated catalog of all registered BioSample IDs with metadata and full-text search.
+Paginated catalog of all registered BioSample IDs with metadata and substring filtering by
+sample_id or cohort.
+
+### Cohorts
+
+Collection-level summary (`/api/cohorts`) for any registered group of samples — a
+BioProject, an SRA Study, or a manually-tagged cohort. Each cohort shows:
+
+- Completion percentage and counts (pending / claimed / submitted / running / completed /
+  failed) across the cohort's samples for a chosen workflow
+- A failure-by-process bar chart: which Nextflow process is killing samples, and how many
+- Click a process row to drill down to the failing task list, with deep-links into the
+  log viewer
 
 ---
 
@@ -61,8 +73,11 @@ Paginated catalog of all registered BioSample IDs with metadata and full-text se
 metadata. Each sample is processed once per active workflow version.
 
 **Job** — one processing attempt for a (sample, workflow version) pair. Lifecycle:
-`pending → claimed → running → completed | failed`. A job can be retried up to
-`max_retries` times before being written to the dead-letter table.
+`pending → claimed → submitted → running → completed | failed`. The gap between `submitted`
+(executor accepted) and `running` (Nextflow actually started) is the scheduler queue
+wait — kept separate so dashboards can distinguish a slow pipeline from a slow cluster.
+A job can be retried up to `max_retries` times before being written to the dead-letter
+table.
 
 **Workflow run** — a single Nextflow execution that processes a batch of samples together.
 The server dispatches runs in configurable batch sizes.
@@ -81,7 +96,7 @@ without it, the job is failed (or re-queued if retries remain).
 
 ```
                         ┌─────────────────────────────────┐
-                        │          Alpine HPC              │
+                        │       HPC cluster (Anvil/Alpine) │
                         │                                  │
   ┌──────────────┐      │  ┌───────────┐  SLURM submit    │
   │  nf-client   │──────┼─►│ sbatch    │──────────────►   │
@@ -95,8 +110,10 @@ without it, the job is failed (or re-queued if retries remain).
   │              FastAPI server + PostgreSQL          │
   │                                                  │
   │  /telemetry  ◄── Nextflow weblog events          │
+  │  /runs/…/event ◄── wrapper + pipeline hook events│
   │  /dispatch   ◄── nf-client claims & reports      │
   │  /metrics    ──► dashboard queries               │
+  │  /cohorts    ──► cohort summaries + drill-down   │
   │  /samples    ──► sample catalog                  │
   └──────────────────────────┬───────────────────────┘
                              │
@@ -109,19 +126,29 @@ without it, the job is failed (or re-queued if retries remain).
 **Data flow**
 
 1. Samples are registered in the server's catalog (BioSample IDs + NCBI accessions).
-2. `nf-client` (running as a daemon on the Alpine head node) claims batches of pending
-   samples from the server and submits a SLURM wrapper job for each batch.
-3. The wrapper job runs Nextflow, which submits individual compute tasks (downloading reads,
-   taxonomic profiling, etc.) back to SLURM via the `process.executor = 'slurm'` setting.
-4. Nextflow sends real-time weblog events to the server's `/telemetry` endpoint as each
-   task starts and finishes.
+2. `nf-client` (running as a daemon on each HPC head node — Anvil and Alpine) claims
+   batches of pending samples from the server and submits a SLURM wrapper job for each
+   batch.
+3. The wrapper job (`nf_client.run_wrapper`) emits run-lifecycle events to
+   `/api/runs/{run_name}/event` (wrapper_started, pre_nextflow with queue wait,
+   periodic heartbeats), then runs Nextflow under instrumentation.
+4. Nextflow submits individual compute tasks (downloading reads, taxonomic profiling,
+   etc.) back to SLURM via the `process.executor = 'slurm'` setting, and posts real-time
+   weblog events to `/telemetry` as each task starts and finishes.
 5. When the `MARK_COMPLETE` sentinel process fires for a sample, the server marks that
-   sample's job as `completed`. If the run ends without it, the job is swept to `failed`.
-6. The dashboard polls the server's metrics and status endpoints to render live progress.
+   sample's job as `completed`. If the run ends without it, the job is swept to `failed`
+   (or re-queued, within the workflow's retry budget).
+6. On exit, the wrapper posts `wrapper_exited` and uploads the `.nextflow.log` so the
+   diagnosis surface is complete even when the run dies before any weblog event.
+7. The dashboard polls the server's metrics, cohort, and status endpoints to render live
+   progress.
 
 **Storage** — all data lives in PostgreSQL. Raw Nextflow events are stored as JSONB in the
 `telemetry` table; sample, workflow, and job state live in their own relational tables.
-Process-level metrics are computed at query time from the raw event stream.
+Process-level metrics are computed at query time from the raw event stream, with partial
+functional indexes on `(trace->>'process')` and `(trace->>'status')` keeping the
+analytical queries fast. Metrics endpoints apply a 7-day default look-back when no time
+filter is supplied, so unparameterised calls stay bounded as event volume grows.
 
 ---
 
@@ -160,12 +187,17 @@ Interactive OpenAPI docs are available at `/docs` when the server is running.
 
 | Group | Endpoints |
 |-------|-----------|
-| Telemetry ingest | `POST /telemetry` |
+| Telemetry ingest | `POST /telemetry` (Nextflow `-with-weblog`) |
+| Run-lifecycle events | `POST /api/runs/{run_name}/event` (wrapper, pipeline hooks, daemon sacct polling) |
 | Dispatch | `POST /dispatch/batch`, `/dispatch/submitted`, `/dispatch/requeue-expired` |
-| Samples | `GET/POST /samples`, `GET /samples/{id}` |
-| Workflows | `GET/POST /workflows`, `PATCH /workflows/{pk}/status`, `GET /workflows/{pk}/job-summary` |
-| Process metrics | `GET /metrics/processes/running`, `/summary`, `/failures`, `/retries`, `/resources-by-attempt`, `/failure-signatures` |
-| Admin | `POST /admin/reconcile-jobs` |
+| Samples | `GET/POST /samples`, `GET /samples/{id}`, `GET /samples/by-srr/{srr}`, `GET /samples/by-biosample/{id}` |
+| Workflows | `GET/POST /workflows`, `PATCH /workflows/{pk}/status`, `/revision`, `GET /workflows/{pk}/job-summary` |
+| Cohorts | `GET /cohorts`, `/cohorts/{id}/summary`, `/cohorts/{id}/failures` |
+| Process metrics | `GET /metrics/processes/running`, `/summary`, `/failures`, `/retries`, `/resources-by-attempt`, `/failure-signatures`, `/timeline`, `/tasks` |
+| Task logs | `POST /task-logs`, `GET /task-logs/{run_name}/{task_hash}` |
+| Daemons | `GET /daemons/`, `POST /daemons/heartbeat` |
+| Curated | `GET/POST /curated/studies`, `/curated/samples` |
+| Admin | `POST /admin/reconcile-jobs`, `/admin/expire-stale-runs`, `GET /admin/stats` |
 
 ### nf-client (HPC orchestration)
 
@@ -177,7 +209,15 @@ uv pip install -e packages/nf_client
 nf-client daemon --config client-alpine.yaml
 ```
 
-For full Alpine SLURM deployment details see [docs/hpc-deployment.md](docs/hpc-deployment.md).
+The daemon's SLURM template invokes `python -m nf_client.run_wrapper` rather than
+`nextflow run` directly. The wrapper emits run-lifecycle events (wrapper_started,
+pre_nextflow with queue wait, periodic heartbeats, wrapper_exited with exit code and
+`.nextflow.log` upload), all best-effort and incapable of failing the run. This makes
+crashes visible end-to-end — including pre-Nextflow failures (module load, container
+pull) that the weblog stream can't see.
+
+For full Alpine / Anvil SLURM deployment details see
+[docs/hpc-deployment.md](docs/hpc-deployment.md).
 
 ### Test pipeline
 
@@ -193,9 +233,14 @@ The production stack runs on Google Cloud:
 
 | Component | Service |
 |-----------|---------|
-| API | Cloud Run |
-| Frontend | Firebase Hosting |
+| API | Cloud Run (`nf-telemetry.cancerdatasci.org`) |
+| Frontend | Firebase Hosting (`curatedmetagenomicdata.web.app`) |
 | Database | Cloud SQL (PostgreSQL) |
+
+A self-hosted alternative is in flight — see `deploy/onclappc02/` for the Docker Compose
+stack that runs the same image behind Traefik on the existing
+`pgducklake` / Postgres-18 instance. Cutover plan tracked in the project's GitHub issues
+(meta issue: self-host migration).
 
 ### Prerequisites
 
@@ -259,24 +304,24 @@ immediately.
 
 ### DNS
 
-The system uses two stable public hostnames. Both should be custom domains rather than
-the default Cloud Run / Firebase subdomains, so that HPC-submitted jobs always reach the
-right endpoint regardless of future infrastructure moves.
+The system uses two stable public hostnames, both custom domains rather than the default
+Cloud Run / Firebase subdomains so that HPC-submitted jobs always reach the right endpoint
+regardless of future infrastructure moves.
 
-| Hostname | Points to | Purpose |
-|----------|-----------|---------|
-| `api.yourdomain.com` | Cloud Run (custom domain mapping) | All API traffic, including Nextflow weblog POSTs from HPC |
-| `telemetry.yourdomain.com` | Firebase Hosting (custom domain) | React dashboard |
+| Hostname | Currently points to | Purpose |
+|----------|---------------------|---------|
+| `nf-telemetry.cancerdatasci.org` | Cloud Run (custom domain mapping) | All API traffic, including Nextflow weblog and wrapper-event POSTs from HPC |
+| `cmgd.cancerdatasci.org` | Firebase Hosting (custom domain) | React dashboard |
 
 **To add a custom domain to Cloud Run:**
 ```bash
 gcloud run domain-mappings create \
-  --service nextflow-telemetry-api \
-  --domain api.yourdomain.com \
+  --service nf-telemetry \
+  --domain nf-telemetry.cancerdatasci.org \
   --region $REGION
 ```
 Cloud Run will issue a managed TLS certificate automatically. Add the CNAME shown in the
-output to your DNS provider.
+output to your DNS provider (Cloudflare, DNS-only on the campus network).
 
 **To add a custom domain to Firebase Hosting:** run `firebase hosting:channel:deploy` or
 use the Firebase console; Firebase provisions the cert and provides the DNS records.
@@ -285,6 +330,7 @@ use the Firebase console; Firebase provisions the cert and provides the DNS reco
 > into SLURM scripts at submission time. Changing the API hostname mid-batch will silently
 > drop telemetry for all in-flight jobs. Always keep the old hostname resolving (or
 > redirect it) until all running Nextflow jobs have finished before cutting DNS over.
+> The same goes for the wrapper events that `nf_client.run_wrapper` posts.
 
 ### CORS
 
@@ -292,8 +338,8 @@ The API reads allowed origins from the `CORS_ORIGINS` environment variable
 (comma-separated). Set this in `deploy/cloudrun.yaml` to the frontend's domain:
 
 ```
-CORS_ORIGINS=https://telemetry.yourdomain.com
+CORS_ORIGINS=https://cmgd.cancerdatasci.org
 ```
 
-Nextflow weblog POSTs are server-to-server and are not subject to CORS, so the HPC
-endpoint does not need to be in the allowlist.
+Nextflow weblog POSTs and `nf_client.run_wrapper` events are server-to-server and are not
+subject to CORS, so the HPC endpoint does not need to be in the allowlist.

--- a/deploy/onclappc02/.env.example
+++ b/deploy/onclappc02/.env.example
@@ -1,0 +1,32 @@
+# Copy to `.env` and fill in. The compose file reads this automatically.
+
+# ---------------------------------------------------------------------------
+# Public hostnames (must have Cloudflare DNS records pointing at 140.226.4.71,
+# DNS-only / grey cloud, per the monode infrastructure constraints).
+# ---------------------------------------------------------------------------
+API_HOST=nf-telemetry.cancerdatasci.org
+FRONTEND_HOST=cmgd.cancerdatasci.org
+
+# ---------------------------------------------------------------------------
+# Postgres / pg_duckdb connection.
+#
+# Assumes the pg_duckdb container (monode/infrastructure/compose/pg_and_duckdb)
+# is running on the host with `ports: 5432:5432`. We reach it from inside
+# the proxy network via host.docker.internal (wired up in compose).
+#
+# Before first run, create the database and user inside the pg_duckdb
+# container:
+#
+#   docker exec -it pg_duckdb_18 psql -U postgres <<'SQL'
+#   CREATE USER nf_telemetry WITH PASSWORD '<some-password>';
+#   CREATE DATABASE nextflow_telemetry OWNER nf_telemetry;
+#   GRANT ALL PRIVILEGES ON DATABASE nextflow_telemetry TO nf_telemetry;
+#   SQL
+# ---------------------------------------------------------------------------
+SQLALCHEMY_URI=postgresql+asyncpg://nf_telemetry:CHANGEME@host.docker.internal:5432/nextflow_telemetry
+
+# ---------------------------------------------------------------------------
+# CORS — defaults to https://${FRONTEND_HOST}. Override if you serve the
+# frontend from a different origin (e.g. during cutover testing).
+# ---------------------------------------------------------------------------
+# CORS_ORIGINS=https://cmgd.cancerdatasci.org,https://curatedmetagenomicdata.web.app

--- a/deploy/onclappc02/Dockerfile.frontend
+++ b/deploy/onclappc02/Dockerfile.frontend
@@ -1,0 +1,29 @@
+# Multi-stage build for the Vite SPA. Stage 1 builds the static bundle
+# with VITE_API_URL baked in; stage 2 serves it with nginx. Total image
+# is ~50 MB (nginx:alpine).
+#
+# Context is the repo root (../.. in the compose file) so we can access
+# `frontend/` and friends in one COPY.
+
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+# Install deps first so the layer is cached when only source changes.
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci --no-audit --no-fund
+
+# Now the source + build.
+COPY frontend/ ./
+
+ARG VITE_API_URL
+ENV VITE_API_URL=${VITE_API_URL}
+RUN npm run build
+
+# Stage 2 — runtime nginx.
+FROM nginx:alpine
+
+COPY deploy/onclappc02/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+EXPOSE 80

--- a/deploy/onclappc02/README.md
+++ b/deploy/onclappc02/README.md
@@ -1,0 +1,135 @@
+# Self-host on onclappc02
+
+Production compose for the telemetry API + frontend, served via the
+existing Traefik on `cancerdatasci.org`. Postgres lives in the existing
+`pg_duckdb` container (see `monode/infrastructure/compose/pg_and_duckdb`).
+
+## Files
+
+- `docker-compose.yml` — API + frontend services, both labelled for Traefik
+- `Dockerfile.frontend` — multi-stage build (node → nginx:alpine)
+- `nginx.conf` — SPA config with sane caching headers
+- `.env.example` — fill in and copy to `.env`
+
+## First-time setup
+
+1. **Postgres DB + user**, inside the existing pg_duckdb container:
+   ```sh
+   docker exec -it pg_duckdb_18 psql -U postgres
+   ```
+   ```sql
+   CREATE USER nf_telemetry WITH PASSWORD '<choose-one>';
+   CREATE DATABASE nextflow_telemetry OWNER nf_telemetry;
+   GRANT ALL PRIVILEGES ON DATABASE nextflow_telemetry TO nf_telemetry;
+   ```
+
+2. **Cloudflare DNS** for both hostnames (DNS-only, grey cloud — required
+   on this network):
+   - `nf-telemetry.cancerdatasci.org` → `140.226.4.71`
+   - `cmgd.cancerdatasci.org` → `140.226.4.71`
+
+3. **`.env`** — copy `.env.example` and fill the password into `SQLALCHEMY_URI`.
+
+4. **Apply migrations** against the new empty DB, then **load data**.
+   See the cutover plan below.
+
+5. **Bring up the stack**:
+   ```sh
+   docker compose build           # ~2 min first time
+   docker compose up -d
+   docker compose logs -f nf_telemetry_api
+   ```
+   Traefik should auto-discover both services within a few seconds. First
+   request to each hostname triggers Let's Encrypt cert issuance (~5s).
+
+## Cloud Run → onclappc02 cutover
+
+Goal: zero-downtime DNS swap. The host changes underneath; the public
+URL stays the same.
+
+### Phase 1 — stable the URL (do this whenever)
+
+The current API URL is the GCP-issued `nf-telemetry-819875667022.us-central1.run.app`.
+This is sprinkled across pipeline configs and nf-client configs on the
+clusters. Before swapping hosts, get everyone pointing at a stable
+hostname *we own* so the second swap is just DNS.
+
+1. In Cloud Run, add a **custom domain mapping** for
+   `nf-telemetry.cancerdatasci.org` → the `nf-telemetry` service.
+   Cloud Run will instruct you to add a CNAME (or A record) at your
+   DNS provider; do that in Cloudflare (DNS-only).
+2. Wait for the cert in Cloud Run to go green (a few minutes).
+3. Verify: `curl https://nf-telemetry.cancerdatasci.org/health` returns
+   the existing service.
+4. Update everywhere the old URL appears:
+   - `seandavi/curatedMetagenomicsNextflow` `nextflow.config`:
+     `params.api_url`, the weblog hook URL
+   - nf-client configs on Anvil + Alpine (the `server_url` /
+     `weblog_url` fields in `client-*.yaml`)
+   - the frontend build's `VITE_API_URL` (rebuild + redeploy Firebase
+     Hosting once; this becomes irrelevant after Phase 3 since the
+     frontend moves on-prem)
+5. Run a sample dispatch end-to-end through the new hostname to confirm.
+
+After Phase 1 the only thing pinning you to GCP is the DNS record.
+
+### Phase 2 — replicate data to onclappc02
+
+1. Set up the DB + user (above).
+2. Run migrations against the new DB so the schema is current:
+   ```sh
+   cd /home/davsean/Documents/git/nextflow_telemetry
+   SQLALCHEMY_URI='postgresql+asyncpg://nf_telemetry:<pw>@localhost:5432/nextflow_telemetry' \
+     uv run alembic upgrade head
+   ```
+3. `pg_dump` from Cloud SQL and `pg_restore` into the new DB. Easiest
+   path: through the Cloud SQL proxy:
+   ```sh
+   # On a workstation with gcloud:
+   gcloud sql connect cmgd-prod ...                # discover host:port via the proxy
+   pg_dump -h <proxy-host> -U postgres -Fc cmgd_prod \
+     --no-owner --no-acl > cmgd_prod.dump
+
+   # On the server:
+   docker cp cmgd_prod.dump pg_duckdb_18:/tmp/
+   docker exec -it pg_duckdb_18 pg_restore \
+     -U nf_telemetry -d nextflow_telemetry \
+     --no-owner --role=nf_telemetry /tmp/cmgd_prod.dump
+   ```
+4. Spot-check that row counts match Cloud SQL.
+
+### Phase 3 — flip DNS
+
+1. Bring up the local stack with `docker compose up -d`. Traefik issues
+   a cert as soon as the first request lands; we'll get it after the
+   DNS flip.
+2. In Cloudflare, change `nf-telemetry.cancerdatasci.org` from the Cloud
+   Run target to an A record for `140.226.4.71`. DNS-only.
+3. Same for `cmgd.cancerdatasci.org` — point at `140.226.4.71`. (If you
+   want to keep the Firebase Hosting URL alive as a fallback, leave it
+   alone; the new hostname is the canonical one.)
+4. Within seconds the cluster nodes' POSTs land on Traefik → API
+   container → local Postgres. Watch logs for the first heartbeat.
+5. Once confident (an hour? a day?), turn off Cloud Run and Cloud SQL.
+
+### Rollback
+
+If anything goes wrong post-flip, flip the CNAME back at Cloudflare.
+The Cloud Run service and Cloud SQL stay healthy on idle until you
+delete them. Any writes that landed on onclappc02 between flip and
+rollback would be lost — pause the workflow first if that matters.
+
+## Operational notes
+
+- **No backups configured here.** Postgres backups should be handled at
+  the pg_duckdb container layer (WAL archive → MinIO?). That's separate
+  from this stack.
+- **Migrations** run from the workstation, not the API container — same
+  pattern as today. `uv run alembic upgrade head` with the right
+  `SQLALCHEMY_URI`.
+- **Pulling the latest API** is `docker compose build nf_telemetry_api &&
+  docker compose up -d nf_telemetry_api`. ~30s downtime; weblog clients
+  retry, but if you're paranoid pause the workflow first.
+- **Frontend updates** are baked at build time. If the API URL changes,
+  rebuild the frontend image; otherwise `git pull && docker compose
+  build nf_telemetry_frontend && docker compose up -d nf_telemetry_frontend`.

--- a/deploy/onclappc02/docker-compose.yml
+++ b/deploy/onclappc02/docker-compose.yml
@@ -1,0 +1,72 @@
+# Production compose for nextflow_telemetry on onclappc02 (cancerdatasci.org).
+#
+# Companion services (Traefik, Postgres + pg_duckdb) live in
+# monode/infrastructure/compose and are deployed independently. This file
+# only adds the telemetry API and the static-frontend container, both of
+# which join the existing `proxy` network so Traefik routes them
+# transparently.
+#
+# DB connectivity: the pg_duckdb container exposes :5432 on the host. The
+# API reaches it via `host.docker.internal`, which is wired up by
+# `extra_hosts: host-gateway` (Linux Docker doesn't resolve it natively).
+#
+# See ./README.md for first-time setup and the Cloud Run → onclappc02
+# cutover plan.
+
+services:
+  nf_telemetry_api:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    image: nf-telemetry-api:local
+    container_name: nf_telemetry_api
+    restart: unless-stopped
+    networks:
+      - proxy
+    environment:
+      SQLALCHEMY_URI: ${SQLALCHEMY_URI}
+      CORS_ORIGINS: ${CORS_ORIGINS:-https://${FRONTEND_HOST:-cmgd.cancerdatasci.org}}
+    extra_hosts:
+      # Lets `host.docker.internal` resolve to the docker host's gateway
+      # IP, so the SQLALCHEMY_URI can point at the pg_duckdb container
+      # listening on :5432 of the host without putting it on the proxy
+      # network.
+      - "host.docker.internal:host-gateway"
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request, sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/health', timeout=5).status == 200 else 1)\""]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.nf-telemetry-api.rule=Host(`${API_HOST:-nf-telemetry.cancerdatasci.org}`)"
+      - "traefik.http.routers.nf-telemetry-api.entrypoints=websecure"
+      - "traefik.http.routers.nf-telemetry-api.tls=true"
+      - "traefik.http.routers.nf-telemetry-api.tls.certresolver=cloudflare"
+      - "traefik.http.services.nf-telemetry-api.loadbalancer.server.port=8000"
+
+  nf_telemetry_frontend:
+    build:
+      context: ../..
+      dockerfile: deploy/onclappc02/Dockerfile.frontend
+      args:
+        # Baked into the bundle at build time. Must match the API host
+        # the frontend will talk to (CORS is enforced server-side, too).
+        VITE_API_URL: https://${API_HOST:-nf-telemetry.cancerdatasci.org}
+    image: nf-telemetry-frontend:local
+    container_name: nf_telemetry_frontend
+    restart: unless-stopped
+    networks:
+      - proxy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.nf-telemetry-frontend.rule=Host(`${FRONTEND_HOST:-cmgd.cancerdatasci.org}`)"
+      - "traefik.http.routers.nf-telemetry-frontend.entrypoints=websecure"
+      - "traefik.http.routers.nf-telemetry-frontend.tls=true"
+      - "traefik.http.routers.nf-telemetry-frontend.tls.certresolver=cloudflare"
+      - "traefik.http.services.nf-telemetry-frontend.loadbalancer.server.port=80"
+
+networks:
+  proxy:
+    external: true

--- a/deploy/onclappc02/nginx.conf
+++ b/deploy/onclappc02/nginx.conf
@@ -1,0 +1,41 @@
+# nginx config for the Vite SPA served on cmgd.cancerdatasci.org.
+# Traefik in front handles TLS, so this only listens on plain :80 inside
+# the proxy network.
+
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # SPA: any non-asset URL falls back to index.html so client-side
+    # routing works on refresh / direct navigation.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Aggressive caching for the hashed asset bundles (Vite emits
+    # content-hashed filenames so this is safe).
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        try_files $uri =404;
+    }
+
+    # Never cache index.html — that's how we ship new bundles.
+    location = /index.html {
+        add_header Cache-Control "no-cache";
+    }
+
+    # Basic security headers. TLS / HSTS belong on Traefik.
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+    # gzip is sufficient for our payload sizes; brotli adds complexity
+    # we don't need.
+    gzip on;
+    gzip_types text/plain text/css application/javascript application/json image/svg+xml;
+    gzip_min_length 1024;
+}

--- a/docs/orchestrator-architecture.md
+++ b/docs/orchestrator-architecture.md
@@ -1,0 +1,213 @@
+# Orchestrator architecture
+
+> Status: **draft** — control-plane design for HPC dispatch. Read alongside [`hpc-deployment.md`](./hpc-deployment.md) (operational guide for the current pull-mode setup) and [`publish-and-catalog-design.md`](./publish-and-catalog-design.md) (outputs catalog, unrelated to control plane).
+
+## Framing
+
+Today the orchestrator is one `nf-client` daemon per cluster, running on each cluster's login node inside a tmux session. The May 6 SSL crash on Alpine — silently dead for five days, only noticed when output stopped — is the load-bearing example of why this model has reached its limit. Login-node tmux is observable only by `ssh`-ing in; failure modes don't show up in any dashboard; restart requires a human at a terminal; auth state lives in unaudited shell profiles.
+
+The fix is to move the control plane off-cluster, into the same host that runs the API and Postgres (onclappc02). One process, one place to monitor, one place to redeploy. SSH into the cluster (`ssh + ControlPersist`) replaces "log in to tmux."
+
+But we also need to preserve the option of an on-cluster daemon, because we can't always SSH *in*. Long-term, the project will run on private clusters whose admins won't permit inbound SSH from an external orchestrator — same workload, but the control plane has to live inside the cluster's network. So this design supports **two deployment modes**, sharing as much code and identical API contracts.
+
+## Two modes
+
+```
+                     ┌──────────────────────────────────┐
+                     │  Telemetry API + Postgres        │
+                     │  (onclappc02)                    │
+                     │                                  │
+                     │  jobs:    pending → claimed →    │
+                     │           submitted → running →  │
+                     │           completed | failed     │
+                     └──────────┬───────────────────────┘
+                                │
+            ┌───────────────────┴───────────────────┐
+            │                                       │
+            ▼                                       ▼
+    ┌───────────────────┐                ┌─────────────────────┐
+    │  Push mode        │                │  Pull mode          │
+    │  Orchestrator     │                │  nf-client          │
+    │  on onclappc02    │                │  on cluster login   │
+    │                   │                │                     │
+    │  SSH → sbatch     │                │  local sbatch       │
+    │  SSH → sacct      │                │  local sacct        │
+    └───────┬───────────┘                └─────────┬───────────┘
+            │                                       │
+            ▼                                       ▼
+        login node                              login node
+            │                                       │
+            ▼                                       ▼
+        SLURM ─────────────► compute nodes ──────► weblog HTTPS push
+                                                       │
+                                                       └──► API
+```
+
+Both modes:
+
+- Claim work via `POST /api/dispatch/batch`
+- Confirm submission via `POST /api/dispatch/submitted`
+- Send daemon heartbeats and run-lifecycle events
+- Drive the same `jobs_tbl` state machine
+
+The only thing that differs is **where the daemon process lives** and **who initiates the SSH** (or whether SSH is involved at all). The API code is unchanged across modes.
+
+### Push mode (preferred where SSH is available)
+
+- One process on onclappc02 per cluster (or one process iterating clusters in series — TBD by polling cost).
+- Holds a ControlPersist'd SSH connection to the cluster's login node. Connection persists 10 min idle.
+- For each poll cycle: claim batch → ssh-submit `sbatch wrapper.sh` → record SLURM jobid → ssh-poll `sacct` on the standard interval.
+- Daemon is supervised by systemd on onclappc02. Failures are visible (`systemctl status`, journald, alerts).
+- Credentials: per-cluster SSH key on onclappc02, owned by a single service user. Keys are added to each cluster's `authorized_keys` once.
+
+### Pull mode (required where SSH-in isn't possible)
+
+- One `nf-client` process on the cluster's login node, supervised by whatever the cluster permits (tmux/screen/cron @reboot/user-systemd if available).
+- Same code path as today.
+- Polls the API for claimable work; submits locally; polls `sacct` locally.
+- Used for: private collaborator clusters; ACCESS sites that refuse inbound SSH; air-gapped or firewalled environments.
+
+### When to use which
+
+| Situation | Mode |
+|---|---|
+| ACCESS clusters we have SSH access to (Anvil, Alpine today) | push |
+| ACCESS clusters with restrictive inbound SSH (Bridges, TACC — TBD) | push if feasible, else pull |
+| Private collaborator clusters running private data | pull |
+| Local laptop / dev cluster | either (push usually simpler) |
+
+A cluster's mode is a deployment-time choice, not a per-job choice. The same cluster won't switch modes day to day.
+
+## Push-mode design
+
+### Where it runs
+
+Same host as API + Postgres + frontend (`onclappc02`). New systemd unit:
+
+```
+/etc/systemd/system/nf-orchestrator.service
+```
+
+One process, supervised. Restart-on-failure. Logs to journald. The orchestrator is a peer of the API container, not part of it — separate `docker-compose` service. Shares the `.env` for `SQLALCHEMY_URI` so it can write directly to Postgres or call the API, whichever proves simpler (likely API for consistency).
+
+### SSH posture
+
+`~/.ssh/config` on the service account:
+
+```
+Host anvil
+    HostName login07.anvil.rcac.purdue.edu
+    User x-seandavi
+    IdentityFile /etc/nf-orchestrator/keys/anvil_ed25519
+    ControlMaster auto
+    ControlPersist 10m
+    ControlPath /run/nf-orchestrator/cm-%r@%h:%p
+    ServerAliveInterval 30
+    ServerAliveCountMax 4
+
+Host alpine
+    HostName login-ci4.rc.colorado.edu
+    User seandavi@xsede.org
+    IdentityFile /etc/nf-orchestrator/keys/alpine_ed25519
+    ProxyJump dccapp720
+    ControlMaster auto
+    ControlPersist 10m
+    ControlPath /run/nf-orchestrator/cm-%r@%h:%p
+```
+
+`ControlPath` lives in a tmpfs (`/run/...`) so it doesn't survive reboot. ControlPersist keeps the connection warm during normal operation; the first command after a restart pays a single auth roundtrip.
+
+### Per-poll work
+
+Pseudocode:
+
+```python
+async def poll_cluster(cfg: ClusterConfig) -> None:
+    batch = await api.claim_batch(workflow_filter=cfg.workflow_filter,
+                                  size=cfg.batch_size)
+    for job in batch:
+        wrapper = render_wrapper(job, cfg)
+        slurm_id = await ssh.run(cfg.host, f"sbatch <<< '{wrapper}'")
+        await api.mark_submitted(job.id, slurm_id)
+
+    # On its own cadence (e.g. every 5 min), not every poll:
+    if time_to_poll_sacct(cfg):
+        states = await ssh.run(cfg.host,
+            f"sacct -j {','.join(active_ids)} --format=JobID,State,... --parsable2")
+        for jobid, state in parse_sacct(states):
+            await api.report_slurm_state(jobid, state)
+```
+
+The shape is essentially what `nf-client` does today, with `ssh.run(host, cmd)` substituted for local subprocess.
+
+### Cluster config
+
+YAML, one file per cluster, mounted into the orchestrator container:
+
+```yaml
+host: anvil
+workflow_filter:
+  - cmgd_nextflow
+  - cmgd_nextflow_with_rarefaction
+batch_size: 25
+max_concurrent_runs: 10
+sacct_interval_seconds: 300
+submit_rate_limit_seconds: 10
+
+submission:
+  template_path: templates/submit_anvil.sh.j2
+  defaults:
+    partition: shared
+    time: "23:00:00"
+    mem: 2G
+    cpus: 1
+    log_dir: /anvil/scratch/x-seandavi/cmgd/job_logs
+    singularity_cache: /anvil/scratch/x-seandavi/apptainer_cache
+    nxf_home: /anvil/scratch/x-seandavi/nf_home
+```
+
+Shape matches today's `client-alpine.yaml` / `client-anvil.yaml` — deliberately, so the code path is one substitution away from current. No adapter framework on day one; one cluster runner with config-driven differences.
+
+## Pull-mode design
+
+Unchanged from today. Documented in [`hpc-deployment.md`](./hpc-deployment.md). The `packages/nf_client` package stays as-is; its install path (cluster login node, supervised in tmux/screen/user-systemd) remains supported. No deprecation timeline.
+
+The only ongoing investment in pull mode is keeping it pinned to the same dispatch API contract as push mode. As long as both modes call the same `/api/dispatch/*` endpoints, they're interchangeable from the server's view, and we can deploy whichever fits the cluster's access posture.
+
+## Telemetry path is unchanged in both modes
+
+Compute nodes already POST per-task events to the API via Nextflow's `-with-weblog`. That path stays as-is:
+
+```
+compute node ──(HTTPS POST /telemetry)──► API
+```
+
+The orchestrator's `sacct` polling is a **scheduler-state** stream, complementary to weblog's **task-state** stream. Don't conflate them: weblog gives us per-process cpu/mem/exit at the moment the task finishes; sacct gives us the SLURM-side view (queued/running/failed/OOM) at 5-minute resolution. Both are needed for the current dashboards.
+
+## Open questions
+
+1. **SSH on PSC Bridges / TACC**: do they permit long-lived passwordless SSH from an external IP, or require Duo / SSH certs / Globus auth? Reconnaissance question, not a design question — but the answer determines whether those sites get push or pull mode. Defer until we actually have an allocation there.
+2. **Service-account credentials on each cluster**: today the keys are personal (your user account on Anvil, your user account on Alpine). Long-term, a shared service account per cluster is cleaner — survives team changes, can be audited. But ACCESS allocations are user-bound, so this may not be feasible at every site.
+3. **Orchestrator-to-API: REST or direct DB?** Same process boundary on onclappc02 means we could write to Postgres directly. Cleaner to keep going through the API — one source of business logic, no risk of orchestrator and API drifting in their state-machine interpretation. Lean: REST.
+4. **Adapter abstraction**: not on day one. Two clusters with config-driven differences is below the threshold for polymorphism. The third cluster (whether ACCESS or private) is the right time to decide whether a `ClusterAdapter` interface is paying for itself.
+5. **What happens when SSH is down**: orchestrator retries with backoff; nothing dispatches; `pending` queue grows. Eventually SSH recovers and dispatch resumes. No buffering needed beyond what the existing `jobs_tbl` already provides. Worth exercising in a test, but no code changes implied.
+6. **ControlPersist + Duo interaction at non-Anvil/Alpine sites**: ControlPersist saves you within its window, but the moment the daemon restarts you re-auth. If a site requires interactive Duo per fresh SSH, push mode is effectively unusable there.
+
+## What this design explicitly does NOT do
+
+- No queue middleware (NATS / RabbitMQ / SQS). The existing `jobs_tbl pending` query *is* the queue. Adding a broker on top of a SQL queue at this scale is pure complexity.
+- No replacement of weblog push with sacct pull. They observe different layers; keep both.
+- No `ClusterAdapter` framework until the third cluster forces real polymorphism.
+- No deprecation of pull mode. Both modes are first-class.
+- No change to the dispatch API contract. The whole point is that the API is mode-agnostic.
+
+## Suggested next steps
+
+Each independently shippable. Smallest first.
+
+1. **SSH reconnaissance from onclappc02** (xs). From `onclappc02`, can we `ssh anvil 'true'` and `ssh alpine 'true'` cleanly using a service-account key? Sets up the rest.
+2. **Lift current daemon into push mode** (medium). Most of the work is wrapping the current local `subprocess.run("sbatch ...")` into an `ssh.run(host, "sbatch ...")` over an asyncssh connection. ~200 lines of new code; the rest is config restructuring.
+3. **Systemd unit + docker-compose entry** for `nf-orchestrator` on onclappc02 (small).
+4. **Parity validation** (small): run push-mode orchestrator and one of the existing pull-mode daemons in parallel against the same cluster but disjoint `workflow_id` filters, compare event streams.
+5. **Decommission Anvil + Alpine tmux daemons** (xs), once push-mode parity is proven.
+6. **Revisit on cluster #3** (deferred): if it's another ACCESS site with SSH access, just add a config file. If it's a private cluster, deploy pull mode there. If it's something weirder (Bridges with Duo-per-auth?), that's when the adapter abstraction conversation happens.

--- a/docs/publish-and-catalog-design.md
+++ b/docs/publish-and-catalog-design.md
@@ -122,7 +122,7 @@ TSV.gz, read directly via DuckDB. **No conversion step.** The Nextflow pipeline'
 
 ### Logical tables
 
-DuckLake exposes one logical table per dataset (`marker_abundance`, `marker_presence`, `marker_rel_ab_w_read_stats`, `metaphlan_unknown_list`, `metaphlan_viruses_list`, future: `humann_genefamilies`, `humann_pathabundance`). Each is a DuckDB read over the union of TSV.gz files at the registered prefixes, joined to the catalog's identity columns (`sample_id`, `study_name`, `run_ids`).
+DuckLake exposes one logical table per dataset (`marker_abundance`, `marker_presence`, `marker_rel_ab_w_read_stats`, `metaphlan_unknown_list`, `metaphlan_viruses_list`, future: `humann_genefamilies`, `humann_pathabundance`). Each is a DuckDB read over the union of TSV.gz files at the registered prefixes, joined to the catalog's identity columns (`sample_id`, `study_name`, `run_ids`). The mapping from "files on disk" to "logical table" lives in the [output spec layer](#output-spec-layer).
 
 ### Other tenants
 
@@ -131,6 +131,62 @@ DuckLake exposes one logical table per dataset (`marker_abundance`, `marker_pres
 - **PMC fulltext** — pulled for harmonization downstream (see [`sample-metadata-design.md`](./sample-metadata-design.md)).
 
 All share the same DuckLake. Joins on accession (`run_id`, `study_id`, etc.) are first-class because every tenant publishes into the same catalog.
+
+## Output spec layer
+
+Telemetry stores `(workflow_id, version, sample_id)` and a deterministic publish prefix; it does **not** store which files exist under that prefix or how to parse them. Nextflow's `-with-weblog` reporter carries trace events but no file manifest, and the `trace` JSONB column has nothing publish-related in it. So between the publish prefix and a DuckLake logical table there's an irreducible mapping step: a per-workflow declaration of "these are the files we expect, and this is how to read them."
+
+### Shape
+
+A YAML spec per `(workflow_id, version)` lives in this repo at:
+
+```
+packages/cmgd_publish/specs/<workflow_id>/<version>.yaml
+```
+
+Each spec maps step outputs to logical tables and DuckDB `read_csv` config:
+
+```yaml
+workflow_id: cmgd_nextflow
+version: 1.6.0
+steps:
+  - name: marker_abundance
+    file_glob: "*_marker_abundance.tsv.gz"
+    branches: [full_data, rarefied_data]
+    read_csv:
+      delim: "\t"
+      header: true
+      compression: gzip
+      comment: "#"
+      types: {clade_name: VARCHAR, relative_abundance: DOUBLE}
+    logical_table: marker_abundance
+```
+
+Adding a new workflow = adding a YAML file. Adding a step = ~10 lines. Same pattern as Singer taps and Frictionless Data Resources. The spec is consumed by the publisher when registering a sample's outputs into DuckLake — it does not infer anything from the file itself at register-time.
+
+### File discovery
+
+Two ways to bridge "we have a publish prefix" → "we have a list of files":
+
+(a) **Glob the publish prefix** at register-time. Works against S3 LIST or POSIX; no pipeline change. One LIST per sample.
+(b) **Pipeline-emitted manifest** — a small `outputs.json` published alongside each sample's data, listing what was written. Authoritative, cheaper, but requires a pipeline change.
+
+Start with (a). Fall back to (b) if spec globs drift from reality enough to cause register-time errors.
+
+### Authoring the first spec
+
+Bootstrap: pull 5–10 completed samples' publish prefixes locally, inspect interactively, draft the YAML. Validate against a *different* held-out batch of 10; any `read_csv` failure means the spec was wrong. Don't ship on the first pass.
+
+Interactive authoring is the right form for the first workflow because conventions (delim, comment chars, which columns get explicit types vs. inferred) are being established. Once one spec exists as ground truth, the spec-discovery step is worth scripting:
+
+- **New-workflow onboarding**: an agentic sniffer reads a publish prefix, proposes YAML by structural similarity to existing specs, opens a draft PR for human review.
+- **Drift detection**: a scheduled job re-parses a held-out batch from the latest run and flags any `read_csv` failure or schema mismatch against the current spec.
+
+Both are HITL-on-output, not HITL-on-every-decision — which is what makes them worth scripting. The recurring scripted form would use the Claude Agent SDK with API credentials (separate from this repo's runtime), not the Max subscription.
+
+### Schema evolution
+
+When MetaPhlAn versions bump and column shapes change, **version is the dimension we use**: a new `1.7.0.yaml`, not a mutation of `1.6.0.yaml`. Logical tables become version-tagged (`marker_abundance_v4`, `marker_abundance_v5`) with a union view that consumers opt into. This is the concrete mechanism that resolves open question #3 in favor of partitioned-per-version tables.
 
 ## Public parquet artifact
 
@@ -167,9 +223,9 @@ Migration:
 
 ## Open questions
 
-1. **DuckLake's representation of TSV.gz as a logical table**: needs verification. DuckLake v1.0 is parquet-native; non-parquet inputs may need wrapping (a DuckDB view that reads via `read_csv`, registered as a logical table). Worst case we shim TSV.gz → parquet at registration time; that's a per-sample one-time cost, still no global ETL pass.
+1. **DuckLake's representation of TSV.gz as a logical table**: needs verification. DuckLake v1.0 is parquet-native; non-parquet inputs may need wrapping (a DuckDB view that reads via `read_csv`, registered as a logical table). Worst case we shim TSV.gz → parquet at registration time; that's a per-sample one-time cost, still no global ETL pass. The [output spec layer](#output-spec-layer) carries the `read_csv` config either way, so this is a question about *where* the wrapping happens, not whether the spec itself changes.
 2. **Catalog-write idempotency key**: probably `(workflow_id, workflow_version, sample_id)` — the same composite as `jobs_tbl`.
-3. **Schema evolution on MetaPhlAn version bumps**: if `marker_abundance` columns change, do we tag rows with the producing version, or partition logical tables per version so consumers opt in? Lean toward the latter — a `marker_abundance_v4` / `marker_abundance_v5` split with a union view. Avoids silent column drift across years of data.
+3. **Schema evolution on MetaPhlAn version bumps**: ~~if `marker_abundance` columns change, do we tag rows with the producing version, or partition logical tables per version so consumers opt in?~~ Resolved: partition logical tables per version (`marker_abundance_v4`, `marker_abundance_v5`) with a union view, mechanized via spec-per-`(workflow_id, version)` in the [output spec layer](#schema-evolution). Avoids silent column drift across years of data.
 4. **Branch dimension**: the `full_data` / `rarefied_data` path component currently splits each step's output. Expose as a partition column on the logical table, or as separate logical tables (`marker_abundance` vs `marker_abundance_rarefied`)? Lean partition column — it's a small dimension and consumers will want both reachable.
 5. **Catalog-write failure mode**: synchronous (blocks completion-write but logged) vs. async (fire-and-forget with reconcile). Position above is async. Worth pushback if there's a reason completion shouldn't be observable until cataloged.
 6. **Public parquet generator location**: in this repo (sibling to `nf_client`), in a separate package, or as a Dagster asset on the existing instance? Lean in this repo for now (`packages/cmgd_publish/`?) — small enough that a separate repo is overhead. Migrating to Dagster later is mechanical if the catalog grows complex enough.
@@ -184,9 +240,10 @@ Smallest first. Each independently shippable.
 2. **`GET /api/published`** (small). Read-only, joins existing tables. Useful pre-DuckLake.
 3. **DuckLake catalog DB scaffolding** (medium). New database, DuckDB-managed schema, connection settings.
 4. **Catalog-write hook on completion + reconcile sweep** (small). Mirrors existing service patterns.
-5. **Logical tables / views over pipeline outputs** (small per dataset).
-6. **Public parquet generator** (small). One `COPY` per dataset, scheduled.
-7. **Deprecate `curatedMetagenomicDataETL`** (after #6 is verified against the existing public artifact).
+5. **First output spec** (small). Pull 5–10 samples from `cmgd_nextflow` 1.6.0, draft `packages/cmgd_publish/specs/cmgd_nextflow/1.6.0.yaml` interactively, validate against a held-out 10-sample batch.
+6. **Logical tables / views over pipeline outputs** (small per dataset, driven by #5).
+7. **Public parquet generator** (small). One `COPY` per dataset, scheduled.
+8. **Deprecate `curatedMetagenomicDataETL`** (after #7 is verified against the existing public artifact).
 
 That's the full telemetry-side roadmap for catalog publishing.
 
@@ -199,5 +256,6 @@ That's the full telemetry-side roadmap for catalog publishing.
 - No coupling between telemetry uptime and catalog availability. Catalog write failure is async and recoverable.
 - No incremental public-parquet machinery. Full replace is simple and cheap at our scale.
 - No Iceberg. DuckDB writes to Iceberg are not yet first-class; DuckLake is the chosen format.
+- No per-file telemetry. Nextflow's weblog doesn't carry publishDir info and we don't add a side-channel to capture it; the spec layer is how we know what files exist.
 
 If a feature belongs in the analytical catalog, it doesn't belong in telemetry's Postgres schema. That's the line.

--- a/docs/temporal-design-seed.md
+++ b/docs/temporal-design-seed.md
@@ -1,0 +1,122 @@
+# Temporal-backed nextflow_telemetry — design seed
+
+> Status: **seed for a future session** — uncommitted draft. Refine then decide.
+
+## Why Temporal
+
+The current `nextflow_telemetry` server reinvents what Temporal already solves:
+
+- A job lifecycle state machine (`pending → claimed → submitted → running → completed/failed → dead_letter`) implemented as Postgres rows + ad-hoc reconcilers.
+- A `nf-client daemon` that polls and claims jobs (`SELECT … FOR UPDATE SKIP LOCKED`).
+- A `MARK_COMPLETE` sentinel process to detect completion via the unauthenticated `/telemetry` weblog endpoint.
+- `sweep_run_incomplete()` for retries with a `max_retries` budget.
+- A dead-letter table.
+
+Every one of these is a thing Temporal does, durably, with replay, with first-class retries, with a worker model that scales horizontally. The current `daemon` is essentially a hand-rolled Temporal worker without the durability guarantees.
+
+## What Temporal would replace
+
+| Current concept | Temporal concept |
+|---|---|
+| `jobs_tbl.status` lifecycle | Workflow state (durable, replayable) |
+| `nf-client daemon` polling loop | Temporal worker on the HPC node |
+| `SELECT … FOR UPDATE SKIP LOCKED` claim | Activity polling on a task queue |
+| `MARK_COMPLETE` sentinel | Signal to the running workflow |
+| `/telemetry` weblog catch-all | Signal handler in the workflow |
+| `sweep_run_incomplete()` | Activity retry policy + workflow timer |
+| `dead_letter_tbl` | Workflow failure → DLQ namespace or status field |
+| Manual reconcile (`reconcile_jobs`) | Per-sample workflow started by an admin signal/API |
+
+## Proposed workflow shape
+
+```python
+@workflow.defn
+class SampleProcessingWorkflow:
+    """One workflow per (sample × workflow_def) pair."""
+
+    @workflow.run
+    async def run(self, params: SampleJobParams) -> JobResult:
+        # 1. Wait for a worker to claim
+        await workflow.wait_condition(lambda: self._claimed)
+
+        # 2. Run the activity (submit to local/slurm/pbs/lsf)
+        run_id = await workflow.execute_activity(
+            submit_to_executor,
+            params,
+            start_to_close_timeout=timedelta(minutes=10),
+            retry_policy=RetryPolicy(maximum_attempts=3),
+        )
+
+        # 3. Wait for either MARK_COMPLETE signal or a heartbeat-based timeout
+        try:
+            await workflow.wait_condition(
+                lambda: self._completed,
+                timeout=timedelta(hours=24),
+            )
+        except asyncio.TimeoutError:
+            raise ApplicationError("nextflow run did not signal completion within SLA")
+
+        return JobResult(run_id=run_id, status=self._final_status)
+
+    @workflow.signal
+    def claim(self, claimer: str) -> None:
+        self._claimed = True
+        self._claimer = claimer
+
+    @workflow.signal
+    def mark_complete(self, status: str) -> None:
+        self._completed = True
+        self._final_status = status
+```
+
+Replaces the entire job-table state machine. The workflow IS the state.
+
+## Architecture
+
+```
+┌──────────────────┐       ┌──────────────────┐
+│  Admin / API     │       │  Nextflow weblog │
+│  (FastAPI thin)  │       │  → /signal       │
+└────────┬─────────┘       └────────┬─────────┘
+         │                          │
+         │  start_workflow          │  signal
+         │                          │
+         ▼                          ▼
+   ┌────────────────────────────────────┐
+   │      Temporal Server (OSS)         │
+   │  (or self-hosted; very lightweight)│
+   └────────────────┬───────────────────┘
+                    │ task queue
+                    ▼
+   ┌────────────────────────────────────┐
+   │    Workers (HPC nodes, anvil, etc) │
+   │    activities: submit_to_executor, │
+   │       check_status, cleanup        │
+   └────────────────────────────────────┘
+```
+
+- **FastAPI shrinks to a thin facade**: `POST /jobs` → `start_workflow`; `POST /telemetry` → look up workflow by run_id and `signal`. No more `dispatch`, `reconcile`, `sweep` services.
+- **Workers run on HPC nodes**, just like `nf-client daemon` does today, but with durable execution semantics: a worker dying doesn't lose state, the workflow just resumes elsewhere.
+- **Postgres** still holds telemetry events and process metrics (the observability data, not the orchestration state). Temporal manages its own state in its own DB.
+
+## Open questions for the next session
+
+1. **Self-hosted Temporal server vs. Temporal Cloud?** Self-hosted on the existing big server is probably right (consistent with monode's "ops on one box" pattern). Temporal Cloud is fine but a recurring cost.
+2. **Migration strategy.** Run the two systems side-by-side during cutover, or hard switch? Probably side-by-side: new jobs go through Temporal, existing pending jobs drain through the legacy state machine.
+3. **What to do with telemetry events.** Keep the existing `telemetry_tbl`, `process_metrics`, `task_logs` tables — those are observational data, not orchestration state. Wire from the workflow's signal handler.
+4. **`MARK_COMPLETE` sentinel: keep or drop?** Could replace with a Nextflow-native completion mechanism (workflow `onComplete` hook calling our signal endpoint directly). Cleaner.
+5. **Workflow id schema.** Probably `{workflow_def_name}:{sample_id}:{attempt}` — content-addressed where possible.
+6. **What about `dispatch/batch`?** With Temporal, the worker pulls from the task queue. The "claim a batch" semantics get replaced by worker-side concurrency tuning.
+7. **Authentication for signal endpoint.** Nextflow weblog can't send auth headers. Options: (a) keep `/telemetry` unauthenticated and have it map weblog → signal; (b) use a per-workflow URL token in the workflow id.
+
+## Migration phases (rough)
+
+1. **Phase 0** — stand up Temporal server on the big box (`temporalio/server` + Postgres + UI). Keep current FastAPI alongside.
+2. **Phase 1** — write the `SampleProcessingWorkflow` + activities. Run a single test job through it end-to-end.
+3. **Phase 2** — port one workflow profile (e.g. `anvil`) to Temporal-backed. Keep others on legacy.
+4. **Phase 3** — port all profiles. Legacy services (`dispatch`, `reconcile`, `sweep`) marked deprecated.
+5. **Phase 4** — drain legacy queue, drop tables, remove `nf-client daemon`.
+
+## Concrete first step
+
+Stand up Temporal server + UI in a `compose/temporal/` directory in `monode/infrastructure/`, on a new Docker network or the existing `pg_and_duckdb_default`. Verify a hello-world workflow runs from a Python worker on the same box. That's the smoke test before any real design work.


### PR DESCRIPTION
Tracking issue: #79.

## Summary

Production compose for the telemetry API and frontend on \`onclappc02\`,
served via the existing Traefik + Let's Encrypt on \`cancerdatasci.org\`
and backed by the existing \`pg_duckdb\` container. Pattern-matched on
the clickhouse stanza in \`monode/infrastructure/compose/clickhouse\`.

- \`deploy/onclappc02/docker-compose.yml\` — API + frontend on the
  \`proxy\` network with Traefik labels (websecure + cloudflare
  certresolver). API reaches the host's Postgres via
  \`host.docker.internal:host-gateway\` so the pg_duckdb compose
  doesn't need to be touched.
- \`deploy/onclappc02/Dockerfile.frontend\` — multi-stage
  node:20-alpine → nginx:alpine, with \`VITE_API_URL\` baked at
  build time.
- \`deploy/onclappc02/nginx.conf\` — SPA-routing fallback,
  content-hashed asset caching, no-cache on index.html, gzip +
  security headers. TLS stays at Traefik.
- \`deploy/onclappc02/.env.example\` — hostnames + SQLALCHEMY_URI
  template, with inline psql commands to bootstrap the DB and user.
- \`deploy/onclappc02/README.md\` — first-time setup + the three-phase
  cutover plan (CNAME stable → bootstrap fresh DB → flip DNS).
- \`.gitignore\` — un-ignore \`.env.example\` files so future templates
  stay tracked.

## Test plan

Nothing to run in CI — this is deploy infrastructure, validated by
hand on the server. The cutover plan in \`deploy/onclappc02/README.md\`
walks through:

- [ ] DB + user creation in the existing pg_duckdb container
- [ ] \`alembic upgrade head\` against the fresh DB
- [ ] \`docker compose build && docker compose up -d\` on onclappc02
- [ ] Health endpoint reachable at \`https://nf-telemetry.cancerdatasci.org\`
- [ ] One real end-to-end run

🤖 Generated with [Claude Code](https://claude.com/claude-code)