### PR TITLE
feat(wrapper): capture wrapper+nextflow output on wrapper_exited (#88)

### DIFF
--- a/packages/nf_client/src/nf_client/run_wrapper.py
+++ b/packages/nf_client/src/nf_client/run_wrapper.py
@@ -344,8 +344,11 @@ def main(argv: list[str] | None = None) -> int:
     # Tee sys.stdout / sys.stderr into a capture buffer so every ``print``
     # from this wrapper (and any library it calls) lands in both the
     # operator-visible slurm-log stream AND a bounded buffer we upload as
-    # ``wrapper_log`` on ``wrapper_exited``. The nextflow subprocess's
-    # output is captured separately via stdout=PIPE + reader thread below.
+    # the ``wrapper_output_log`` multipart attachment on ``wrapper_exited``.
+    # (Note: distinct from the ``wrapper_log`` *event type* in models.py,
+    # which carries per-line streaming via a different mechanism.) The
+    # nextflow subprocess's output is captured separately via stdout=PIPE
+    # + reader thread below.
     capture = _CaptureBuffer()
     orig_stdout, orig_stderr = sys.stdout, sys.stderr
     sys.stdout = _TeeWriter(orig_stdout, capture)
@@ -394,9 +397,9 @@ def main(argv: list[str] | None = None) -> int:
             # POSIX shell convention: 127 = command not found, 126 = found
             # but not executable (permission, wrong format). The wrapper's
             # diagnostic print below lands in *capture* via the tee, so it
-            # rides home on the wrapper_log attachment — exactly the
-            # pre-Nextflow failure surface this PR (#88) exists to make
-            # visible from the dashboard.
+            # rides home on the wrapper_output_log attachment — exactly
+            # the pre-Nextflow failure surface this PR (#88) exists to
+            # make visible from the dashboard.
             exec_exit_code = 126 if e.errno in (errno.EACCES, errno.ENOEXEC) else 127
             print(
                 f"[run_wrapper] could not start nextflow subprocess "
@@ -450,9 +453,9 @@ def main(argv: list[str] | None = None) -> int:
             signal.signal(signal.SIGTERM, prev_term)
             signal.signal(signal.SIGINT, prev_int)
             # Drain the capture reader before tearing down anything — once
-            # proc has exited the pipe will EOF promptly, so this is a tight
-            # join. Without it the wrapper_log we upload below could miss
-            # the final few lines that mattered most.
+            # proc has exited the pipe will EOF promptly, so this is a
+            # tight join. Without it the wrapper_output_log we upload
+            # below could miss the final few lines that mattered most.
             capture_reader.join(timeout=_EVENT_POST_TIMEOUT)
             # Stop the heartbeat thread AND wait for any in-flight POST to
             # return before the outer `finally` closes the httpx client.
@@ -491,9 +494,11 @@ def main(argv: list[str] | None = None) -> int:
 
 
 def _wrapper_log_files(capture: _CaptureBuffer) -> dict | None:
-    """Return the multipart files dict for the wrapper_log attachment.
+    """Return the multipart files dict for the wrapper_output_log attachment.
 
-    Returns None when the buffer is empty (don't attach an empty file).
+    Field name on the wire is ``wrapper_output_log`` (distinct from the
+    ``wrapper_log`` event *type* used for per-line streaming). Returns
+    None when the buffer is empty (don't attach an empty file).
     """
     if capture.is_empty():
         return None

--- a/packages/nf_client/src/nf_client/run_wrapper.py
+++ b/packages/nf_client/src/nf_client/run_wrapper.py
@@ -17,6 +17,7 @@ swallowed. The wrapper must never fail a run because of instrumentation.
 from __future__ import annotations
 
 import argparse
+import collections
 import errno
 import json
 import os
@@ -27,6 +28,7 @@ import threading
 import time
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import TextIO
 
 import httpx
 
@@ -34,6 +36,8 @@ import httpx
 _HEARTBEAT_SECONDS_DEFAULT = 60
 _LOG_UPLOAD_TIMEOUT = 60
 _EVENT_POST_TIMEOUT = 10
+# Server caps at 4 MB; keep some headroom for multipart overhead.
+_WRAPPER_LOG_MAX_CHARS = 3 * 1024 * 1024
 
 
 def _now_iso() -> str:
@@ -136,6 +140,107 @@ def _read_nextflow_log(log_path: Path, max_bytes: int = 16 * 1024 * 1024) -> byt
         return None
 
 
+class _CaptureBuffer:
+    """Bounded append-only string buffer for the wrapper's combined output.
+
+    Trims from the *front* when oversize: the failure context we care about
+    lives at the tail (the last things printed before nextflow died), so
+    keeping the tail is correct. Thread-safe; the reader thread and the
+    Python `print` callsites in the main thread share one buffer.
+    """
+
+    def __init__(self, max_chars: int = _WRAPPER_LOG_MAX_CHARS) -> None:
+        self._chunks: collections.deque[str] = collections.deque()
+        self._chars = 0
+        self._max = max_chars
+        self._lock = threading.Lock()
+
+    def append(self, data: str) -> None:
+        if not data:
+            return
+        with self._lock:
+            self._chunks.append(data)
+            self._chars += len(data)
+            while self._chars > self._max and self._chunks:
+                evicted = self._chunks.popleft()
+                self._chars -= len(evicted)
+
+    def encoded(self) -> bytes:
+        with self._lock:
+            return "".join(self._chunks).encode("utf-8", errors="replace")
+
+    def is_empty(self) -> bool:
+        with self._lock:
+            return not self._chunks
+
+
+class _TeeWriter:
+    """File-like wrapper that writes to *primary* and also appends to *buffer*.
+
+    Replaces ``sys.stdout`` / ``sys.stderr`` so every ``print()`` from the
+    wrapper or from libraries it calls accumulates in the capture buffer
+    in addition to reaching the slurm-job stdout/stderr file as before.
+
+    Subprocesses inherit the real underlying file descriptors (via
+    ``fileno()``), not this Python wrapper — so the nextflow subprocess's
+    output bypasses the tee. The reader thread set up around its
+    ``stdout=PIPE`` captures that stream separately and feeds it into
+    the same buffer.
+    """
+
+    def __init__(self, primary: TextIO, buffer: _CaptureBuffer) -> None:
+        self._primary = primary
+        self._buffer = buffer
+
+    def write(self, data: str) -> int:
+        self._buffer.append(data)
+        return self._primary.write(data)
+
+    def flush(self) -> None:
+        self._primary.flush()
+
+    def isatty(self) -> bool:
+        return False
+
+    def fileno(self) -> int:
+        return self._primary.fileno()
+
+    def __getattr__(self, name: str):
+        # encoding, errors, newlines, mode, name, … all delegate to primary
+        return getattr(self._primary, name)
+
+
+def _spawn_capture_reader(
+    proc: subprocess.Popen,
+    buffer: _CaptureBuffer,
+    echo_to: TextIO,
+) -> threading.Thread:
+    """Stream the subprocess's merged stdout/stderr to *echo_to* and *buffer*.
+
+    The subprocess must have been launched with ``stdout=PIPE``,
+    ``stderr=STDOUT``, ``bufsize=1``, ``text=True`` so we get one decoded
+    line per ``readline()`` call. ``echo_to`` should be the *underlying*
+    stdout (e.g. ``sys.__stdout__``), not the tee — otherwise lines would
+    end up in the capture buffer twice.
+    """
+    def _reader() -> None:
+        assert proc.stdout is not None
+        try:
+            for line in iter(proc.stdout.readline, ""):
+                buffer.append(line)
+                echo_to.write(line)
+                echo_to.flush()
+        finally:
+            try:
+                proc.stdout.close()
+            except Exception:
+                pass
+
+    thread = threading.Thread(target=_reader, daemon=True, name="nf-capture")
+    thread.start()
+    return thread
+
+
 class _Heartbeat:
     """Daemon thread that POSTs heartbeat events on a fixed interval.
 
@@ -236,6 +341,16 @@ def main(argv: list[str] | None = None) -> int:
         )
         client = None
 
+    # Tee sys.stdout / sys.stderr into a capture buffer so every ``print``
+    # from this wrapper (and any library it calls) lands in both the
+    # operator-visible slurm-log stream AND a bounded buffer we upload as
+    # ``wrapper_log`` on ``wrapper_exited``. The nextflow subprocess's
+    # output is captured separately via stdout=PIPE + reader thread below.
+    capture = _CaptureBuffer()
+    orig_stdout, orig_stderr = sys.stdout, sys.stderr
+    sys.stdout = _TeeWriter(orig_stdout, capture)
+    sys.stderr = _TeeWriter(orig_stderr, capture)
+
     try:
         host = _hostname()
         slurm_job_id = os.environ.get("SLURM_JOB_ID")
@@ -261,25 +376,47 @@ def main(argv: list[str] | None = None) -> int:
         # conventional shell-style exit code so the failure is observable
         # via telemetry — otherwise an OSError here would crash silently
         # before any "I tried to run nextflow" signal reached the server.
+        #
+        # stdout=PIPE + stderr=STDOUT + bufsize=1 + text=True gives us
+        # line-buffered, merged, decoded output that the capture reader
+        # thread can stream to both the buffer AND the operator's stdout
+        # in real time.
         start_ts = time.time()
         try:
-            proc = subprocess.Popen(args.nextflow_cmd)
+            proc = subprocess.Popen(
+                args.nextflow_cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                bufsize=1,
+                text=True,
+            )
         except OSError as e:
             # POSIX shell convention: 127 = command not found, 126 = found
-            # but not executable (permission, wrong format).
+            # but not executable (permission, wrong format). The wrapper's
+            # diagnostic print below lands in *capture* via the tee, so it
+            # rides home on the wrapper_log attachment — exactly the
+            # pre-Nextflow failure surface this PR (#88) exists to make
+            # visible from the dashboard.
             exec_exit_code = 126 if e.errno in (errno.EACCES, errno.ENOEXEC) else 127
             print(
                 f"[run_wrapper] could not start nextflow subprocess "
                 f"({args.nextflow_cmd[0]!r}): {e}",
                 file=sys.stderr, flush=True,
             )
-            _post_event(client, args.run_name, {
-                "type": "wrapper_exited",
-                "utc_time": _now_iso(),
-                "exit_code": exec_exit_code,
-                "duration_seconds": int(time.time() - start_ts),
-            })
+            _post_event(
+                client, args.run_name,
+                {
+                    "type": "wrapper_exited",
+                    "utc_time": _now_iso(),
+                    "exit_code": exec_exit_code,
+                    "duration_seconds": int(time.time() - start_ts),
+                },
+                files=_wrapper_log_files(capture),
+                timeout=_LOG_UPLOAD_TIMEOUT,
+            )
             return exec_exit_code
+
+        capture_reader = _spawn_capture_reader(proc, capture, orig_stdout)
 
         heartbeat = _Heartbeat(client, args.run_name, args.heartbeat_seconds)
         heartbeat.start()
@@ -312,6 +449,11 @@ def main(argv: list[str] | None = None) -> int:
             # Restore signal handlers so main() leaves no global side-effects.
             signal.signal(signal.SIGTERM, prev_term)
             signal.signal(signal.SIGINT, prev_int)
+            # Drain the capture reader before tearing down anything — once
+            # proc has exited the pipe will EOF promptly, so this is a tight
+            # join. Without it the wrapper_log we upload below could miss
+            # the final few lines that mattered most.
+            capture_reader.join(timeout=_EVENT_POST_TIMEOUT)
             # Stop the heartbeat thread AND wait for any in-flight POST to
             # return before the outer `finally` closes the httpx client.
             # Without the join, a heartbeat could try to use a closed client.
@@ -321,10 +463,10 @@ def main(argv: list[str] | None = None) -> int:
 
         # 5. read .nextflow.log and upload as the wrapper_exited attachment
         log_bytes = _read_nextflow_log(args.nextflow_log)
-        files = (
-            {"nextflow_log": (".nextflow.log", log_bytes, "text/plain")}
-            if log_bytes is not None else None
-        )
+        files = _wrapper_log_files(capture)
+        if log_bytes is not None:
+            files = files or {}
+            files["nextflow_log"] = (".nextflow.log", log_bytes, "text/plain")
 
         _post_event(
             client, args.run_name,
@@ -340,8 +482,22 @@ def main(argv: list[str] | None = None) -> int:
 
         return exit_code
     finally:
+        # Restore Python's standard streams so callers (tests, future
+        # in-process invokers) aren't left with a tee wrapper installed.
+        sys.stdout = orig_stdout
+        sys.stderr = orig_stderr
         if client is not None:
             client.close()
+
+
+def _wrapper_log_files(capture: _CaptureBuffer) -> dict | None:
+    """Return the multipart files dict for the wrapper_log attachment.
+
+    Returns None when the buffer is empty (don't attach an empty file).
+    """
+    if capture.is_empty():
+        return None
+    return {"wrapper_output_log": ("wrapper_output.log", capture.encoded(), "text/plain")}
 
 
 if __name__ == "__main__":

--- a/packages/nf_client/tests/test_run_wrapper.py
+++ b/packages/nf_client/tests/test_run_wrapper.py
@@ -131,7 +131,7 @@ def test_nextflow_log_attached_when_present(tmp_path, telemetry_base, monkeypatc
     assert 'name="nextflow_log"' in last_body
 
 
-def test_wrapper_log_attached_when_subprocess_produces_output(tmp_path, telemetry_base, monkeypatch, capfd):
+def test_wrapper_log_attached_when_subprocess_produces_output(tmp_path, telemetry_base, monkeypatch):
     """Output from the nextflow subprocess lands in the wrapper_log attachment (#88)."""
     monkeypatch.chdir(tmp_path)
 

--- a/packages/nf_client/tests/test_run_wrapper.py
+++ b/packages/nf_client/tests/test_run_wrapper.py
@@ -131,6 +131,116 @@ def test_nextflow_log_attached_when_present(tmp_path, telemetry_base, monkeypatc
     assert 'name="nextflow_log"' in last_body
 
 
+def test_wrapper_log_attached_when_subprocess_produces_output(tmp_path, telemetry_base, monkeypatch, capfd):
+    """Output from the nextflow subprocess lands in the wrapper_log attachment (#88)."""
+    monkeypatch.chdir(tmp_path)
+
+    with respx.mock(base_url=telemetry_base) as rx:
+        route = rx.post("/runs/r-cap/event").mock(
+            return_value=httpx.Response(201, json={
+                "run_name": "r-cap", "type": "x",
+                "nextflow_log_uploaded": False, "wrapper_output_log_uploaded": True,
+            })
+        )
+
+        rc = run_wrapper.main([
+            "--run-name", "r-cap",
+            "--telemetry-url", telemetry_base,
+            "--", "sh", "-c", "echo nextflow-says-hello; echo a-second-line",
+        ])
+
+    assert rc == 0
+    last_body = route.calls[-1].request.content.decode()
+    assert 'name="wrapper_output_log"' in last_body
+    # Both lines from the subprocess should be present in the multipart body
+    assert "nextflow-says-hello" in last_body
+    assert "a-second-line" in last_body
+
+
+def test_wrapper_log_captures_pre_nextflow_failure(tmp_path, telemetry_base, monkeypatch):
+    """If `nextflow` itself can't be exec'd, the wrapper's own stderr diagnostic
+    lands in the wrapper_log — exactly the gap #88 was filed for."""
+    monkeypatch.chdir(tmp_path)
+
+    with respx.mock(base_url=telemetry_base) as rx:
+        route = rx.post("/runs/r-noexec/event").mock(
+            return_value=httpx.Response(201, json={
+                "run_name": "r-noexec", "type": "x",
+                "nextflow_log_uploaded": False, "wrapper_output_log_uploaded": True,
+            })
+        )
+
+        rc = run_wrapper.main([
+            "--run-name", "r-noexec",
+            "--telemetry-url", telemetry_base,
+            "--", "/this/binary/definitely/does/not/exist",
+        ])
+
+    # 127 = command-not-found per POSIX shell convention (errno != EACCES/ENOEXEC)
+    assert rc == 127
+    last = _extract_event(route.calls[-1])
+    assert last["type"] == "wrapper_exited"
+    assert last["exit_code"] == 127
+    last_body = route.calls[-1].request.content.decode()
+    # The wrapper's diagnostic about Popen failure rode home in the buffer
+    assert 'name="wrapper_output_log"' in last_body
+    assert "could not start nextflow subprocess" in last_body
+
+
+def test_wrapper_log_omitted_when_capture_buffer_is_empty(tmp_path, telemetry_base, monkeypatch):
+    """No wrapper_log part when nothing was captured (e.g., silent `true`).
+
+    `true` writes nothing to stdout/stderr, and a happy-path run doesn't
+    print to sys.stderr either — so the buffer stays empty and we send no
+    attachment rather than an empty file.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    with respx.mock(base_url=telemetry_base) as rx:
+        route = rx.post("/runs/r-silent/event").mock(
+            return_value=httpx.Response(201, json={
+                "run_name": "r-silent", "type": "x", "nextflow_log_uploaded": False,
+            })
+        )
+
+        rc = run_wrapper.main([
+            "--run-name", "r-silent",
+            "--telemetry-url", telemetry_base,
+            "--", "true",
+        ])
+
+    assert rc == 0
+    last_body = route.calls[-1].request.content.decode()
+    assert 'name="wrapper_output_log"' not in last_body
+
+
+def test_capture_buffer_trims_front_when_oversized() -> None:
+    """The bounded buffer keeps the tail (where failure context lives)."""
+    buf = run_wrapper._CaptureBuffer(max_chars=20)
+    buf.append("aaaaa\n")        # 6 chars
+    buf.append("bbbbb\n")        # 6 → 12
+    buf.append("ccccc\n")        # 6 → 18
+    buf.append("ddddd\n")        # 6 → 24 → trim oldest (6 → 18)
+    captured = buf.encoded().decode()
+    assert "aaaaa" not in captured     # evicted
+    assert "bbbbb" in captured
+    assert "ccccc" in captured
+    assert "ddddd" in captured
+
+
+def test_tee_writer_writes_to_both_primary_and_buffer() -> None:
+    """The TeeWriter sends data to the real stream AND the capture buffer."""
+    import io
+    primary = io.StringIO()
+    buf = run_wrapper._CaptureBuffer()
+    tee = run_wrapper._TeeWriter(primary, buf)
+    tee.write("hello ")
+    tee.write("world\n")
+    tee.flush()
+    assert primary.getvalue() == "hello world\n"
+    assert buf.encoded() == b"hello world\n"
+
+
 def test_missing_nextflow_log_omits_attachment(tmp_path, telemetry_base, monkeypatch):
     monkeypatch.chdir(tmp_path)
     no_log = tmp_path / "does-not-exist.log"

--- a/src/nextflow_telemetry/models.py
+++ b/src/nextflow_telemetry/models.py
@@ -462,6 +462,7 @@ class RunEventResponse(BaseModel):
     run_name: str
     type: str
     nextflow_log_uploaded: bool = Field(description="True if a .nextflow.log file was attached and stored.")
+    wrapper_output_log_uploaded: bool = Field(default=False, description="True if a captured wrapper-output log was attached and stored (per #88). Distinct from the `wrapper_log` event type, which is per-line streaming.")
 
 
 class DaemonHeartbeat(BaseModel):

--- a/src/nextflow_telemetry/routers/runs.py
+++ b/src/nextflow_telemetry/routers/runs.py
@@ -49,8 +49,13 @@ _NEXTFLOW_LOG_TYPE = "nextflow_log"
 # the last N lines (failure context is at the end), so the upload is
 # already bounded.
 _MAX_WRAPPER_LOG_BYTES = 4 * 1024 * 1024  # 4 MB
-# Distinct from the WrapperLogEvent *event* type (which carries per-line
-# log lines as telemetry rows) — this is the captured-on-exit attachment.
+# The wrapper teez sys.stdout/sys.stderr AND drains the nextflow
+# subprocess's pipe into a single capture buffer, so this attachment
+# is the wrapper's *combined* output (its own diagnostic prints + the
+# nextflow subprocess's merged stdout/stderr), not just the subprocess
+# stream. Distinct from the WrapperLogEvent *event* type (which carries
+# per-line log lines as telemetry rows) — this is the
+# captured-on-exit attachment.
 _WRAPPER_LOG_SENTINEL_HASH = "wrapper_output_log"
 _WRAPPER_LOG_TYPE = "wrapper_output_log"
 
@@ -168,12 +173,17 @@ def create_runs_router(engine: AsyncEngine) -> APIRouter:
             # falsely claim the upload succeeded against a known run. Same
             # rule applies to both .nextflow.log and the captured wrapper log.
             if (log_content_str is not None or wrapper_log_content_str is not None) and existing is None:
-                missing = "nextflow_log" if log_content_str is not None else "wrapper_output_log"
+                provided = []
+                if log_content_str is not None:
+                    provided.append("nextflow_log")
+                if wrapper_log_content_str is not None:
+                    provided.append("wrapper_output_log")
+                attachments = " + ".join(provided)
                 raise HTTPException(
                     status_code=404,
                     detail=(
                         f"No workflow_runs row for '{run_name}'; refusing to store "
-                        f"{missing} attachment as an orphan."
+                        f"{attachments} attachment{'s' if len(provided) > 1 else ''} as orphan."
                     ),
                 )
 

--- a/src/nextflow_telemetry/routers/runs.py
+++ b/src/nextflow_telemetry/routers/runs.py
@@ -44,6 +44,15 @@ from ..db import telemetry_tbl, workflow_runs_tbl
 _MAX_NEXTFLOW_LOG_BYTES = 16 * 1024 * 1024  # 16 MB
 _NEXTFLOW_LOG_SENTINEL_HASH = "nextflow_log"
 _NEXTFLOW_LOG_TYPE = "nextflow_log"
+# Wrapper log: captured stdout+stderr of the wrapper's nextflow subprocess.
+# Smaller cap than nextflow_log because we tail-truncate at the wrapper to
+# the last N lines (failure context is at the end), so the upload is
+# already bounded.
+_MAX_WRAPPER_LOG_BYTES = 4 * 1024 * 1024  # 4 MB
+# Distinct from the WrapperLogEvent *event* type (which carries per-line
+# log lines as telemetry rows) — this is the captured-on-exit attachment.
+_WRAPPER_LOG_SENTINEL_HASH = "wrapper_output_log"
+_WRAPPER_LOG_TYPE = "wrapper_output_log"
 
 _run_event_adapter: TypeAdapter[RunEvent] = TypeAdapter(RunEvent)
 
@@ -75,6 +84,7 @@ def create_runs_router(engine: AsyncEngine) -> APIRouter:
         run_name: Annotated[str, Path(description="Nextflow run name (matches workflow_runs.run_name).")],
         event: Annotated[str, Form(description="JSON-encoded run event; `type` selects the variant.")],
         nextflow_log: Annotated[UploadFile | None, File(description="Optional .nextflow.log; honoured on `wrapper_exited`.")] = None,
+        wrapper_output_log: Annotated[UploadFile | None, File(description="Optional captured stdout+stderr of the wrapper's nextflow subprocess; honoured on `wrapper_exited`. Captures the pre-Nextflow failure surface (`.nextflow.log` may be empty or missing if Nextflow never started). Named distinctly from the `wrapper_log` *event type* (per-line telemetry rows) to avoid confusion.")] = None,
     ) -> RunEventResponse:
         try:
             payload = json.loads(event)
@@ -108,7 +118,26 @@ def create_runs_router(engine: AsyncEngine) -> APIRouter:
                 )
             log_content_str = raw.decode("utf-8", errors="replace")
 
+        wrapper_log_content_str: str | None = None
+        if wrapper_output_log is not None:
+            if not isinstance(parsed, WrapperExitedEvent):
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        "wrapper_output_log attachment is only valid on wrapper_exited events; "
+                        f"received it with type={parsed.type}."
+                    ),
+                )
+            raw = await wrapper_output_log.read()
+            if len(raw) > _MAX_WRAPPER_LOG_BYTES:
+                raise HTTPException(
+                    status_code=413,
+                    detail=f"wrapper_output_log exceeds {_MAX_WRAPPER_LOG_BYTES} byte limit.",
+                )
+            wrapper_log_content_str = raw.decode("utf-8", errors="replace")
+
         log_uploaded = False
+        wrapper_output_log_uploaded = False
         now = datetime.now(timezone.utc)
 
         async with engine.begin() as conn:
@@ -134,15 +163,17 @@ def create_runs_router(engine: AsyncEngine) -> APIRouter:
             workflow_id = existing["workflow_id"] if existing else None
             workflow_version = existing["workflow_version"] if existing else None
 
-            # If a .nextflow.log was attached but no workflow_runs row exists,
+            # If any log attachment was provided but no workflow_runs row exists,
             # 404 — storing it would orphan the row and the response would
-            # falsely claim the upload succeeded against a known run.
-            if log_content_str is not None and existing is None:
+            # falsely claim the upload succeeded against a known run. Same
+            # rule applies to both .nextflow.log and the captured wrapper log.
+            if (log_content_str is not None or wrapper_log_content_str is not None) and existing is None:
+                missing = "nextflow_log" if log_content_str is not None else "wrapper_output_log"
                 raise HTTPException(
                     status_code=404,
                     detail=(
                         f"No workflow_runs row for '{run_name}'; refusing to store "
-                        "nextflow_log attachment as an orphan."
+                        f"{missing} attachment as an orphan."
                     ),
                 )
 
@@ -191,10 +222,36 @@ def create_runs_router(engine: AsyncEngine) -> APIRouter:
                 )
                 log_uploaded = True
 
+            # 5. Optional wrapper_output_log attachment. Same upsert pattern as
+            # the nextflow_log block above, but with the wrapper-output-log
+            # sentinel hash so the two coexist in task_logs without conflict.
+            # No summary column on workflow_runs — operators query task_logs
+            # directly (the existing log viewer renders it the same way).
+            if wrapper_log_content_str is not None:
+                await conn.execute(
+                    text(
+                        """
+                        INSERT INTO task_logs (run_name, task_hash, log_type, content, uploaded_at)
+                        VALUES (:run_name, :task_hash, :log_type, :content, :uploaded_at)
+                        ON CONFLICT ON CONSTRAINT uq_task_log
+                        DO UPDATE SET content = EXCLUDED.content, uploaded_at = EXCLUDED.uploaded_at
+                        """
+                    ),
+                    {
+                        "run_name": run_name,
+                        "task_hash": _WRAPPER_LOG_SENTINEL_HASH,
+                        "log_type": _WRAPPER_LOG_TYPE,
+                        "content": wrapper_log_content_str,
+                        "uploaded_at": now,
+                    },
+                )
+                wrapper_output_log_uploaded = True
+
         return RunEventResponse(
             run_name=run_name,
             type=parsed.type,
             nextflow_log_uploaded=log_uploaded,
+            wrapper_output_log_uploaded=wrapper_output_log_uploaded,
         )
 
     return router

--- a/tests/test_runs_router.py
+++ b/tests/test_runs_router.py
@@ -59,10 +59,22 @@ def _seed_run(db_url: str, run_name: str, *, status: str = "claimed") -> None:
     ))
 
 
-def _post_event(client, run_name: str, body: dict, *, file: tuple | None = None):
+def _post_event(
+    client,
+    run_name: str,
+    body: dict,
+    *,
+    file: tuple | None = None,
+    wrapper_output_log: tuple | None = None,
+):
     payload: dict = {"data": {"event": json.dumps(body)}}
+    files: dict = {}
     if file is not None:
-        payload["files"] = {"nextflow_log": file}
+        files["nextflow_log"] = file
+    if wrapper_output_log is not None:
+        files["wrapper_output_log"] = wrapper_output_log
+    if files:
+        payload["files"] = files
     return client.post(f"/api/runs/{run_name}/event", **payload)
 
 
@@ -234,6 +246,70 @@ def test_wrapper_exited_with_attached_log_stores_in_task_logs(integration_client
         workflow_runs_tbl.c.run_name == run_name
     )))
     assert run_rows[0]["nextflow_log_uploaded_at"] is not None
+
+
+def test_wrapper_exited_with_wrapper_output_log_stores_separately(integration_client, db_url):
+    """wrapper_output_log lands in task_logs under its own sentinel hash, alongside
+    any nextflow_log attached to the same wrapper_exited event (#88)."""
+    from nextflow_telemetry.db import task_logs_tbl
+
+    client, _ = integration_client
+    run_name = _make_run_name()
+    _seed_run(db_url, run_name)
+
+    nf_log = "Nextflow log content\n"
+    wrapper_log = "[run_wrapper] could not start nextflow subprocess: No such file\n"
+
+    resp = _post_event(
+        client,
+        run_name,
+        {"type": "wrapper_exited", "utc_time": _ts(), "exit_code": 127},
+        file=("nextflow.log", nf_log.encode(), "text/plain"),
+        wrapper_output_log=("wrapper_output.log", wrapper_log.encode(), "text/plain"),
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["nextflow_log_uploaded"] is True
+    assert resp.json()["wrapper_output_log_uploaded"] is True
+
+    log_rows = _run(_query(db_url, select(task_logs_tbl).where(
+        task_logs_tbl.c.run_name == run_name
+    ).order_by(task_logs_tbl.c.task_hash)))
+    assert len(log_rows) == 2
+    by_hash = {r["task_hash"]: r for r in log_rows}
+    assert by_hash["nextflow_log"]["content"] == nf_log
+    assert by_hash["wrapper_output_log"]["content"] == wrapper_log
+    assert by_hash["wrapper_output_log"]["log_type"] == "wrapper_output_log"
+
+
+def test_wrapper_output_log_on_non_wrapper_exited_returns_422(integration_client, db_url):
+    """The wrapper_output_log attachment is only valid on wrapper_exited (same as nextflow_log)."""
+    client, _ = integration_client
+    run_name = _make_run_name()
+    _seed_run(db_url, run_name)
+
+    resp = _post_event(
+        client,
+        run_name,
+        {"type": "heartbeat", "utc_time": _ts()},
+        wrapper_output_log=("wrapper_output.log", b"stray output", "text/plain"),
+    )
+    assert resp.status_code == 422
+    assert "wrapper_output_log attachment is only valid on wrapper_exited" in resp.json()["detail"]
+
+
+def test_wrapper_output_log_on_unknown_run_returns_404(integration_client, db_url):
+    """Same orphan-prevention rule as nextflow_log — no row, no upload."""
+    client, _ = integration_client
+    # Deliberately do NOT seed the run
+
+    resp = _post_event(
+        client,
+        "r-nonexistent",
+        {"type": "wrapper_exited", "utc_time": _ts(), "exit_code": 0},
+        wrapper_output_log=("wrapper_output.log", b"orphan", "text/plain"),
+    )
+    assert resp.status_code == 404
+    assert "wrapper_output_log" in resp.json()["detail"]
 
 
 def test_re_uploading_nextflow_log_is_idempotent(integration_client, db_url):


### PR DESCRIPTION
## Summary

- **Wrapper-side**: capture both the wrapper's own stdout/stderr AND the nextflow subprocess's merged stdout/stderr into a bounded in-memory buffer, attach as multipart field `wrapper_output_log` on the `wrapper_exited` POST.
- **Server-side**: new optional `wrapper_output_log` UploadFile param on `POST /api/runs/{run_name}/event`, stored in `task_logs` under its own sentinel hash. Same validation as `nextflow_log` (only on wrapper_exited, only with a known run, 4 MB cap).
- **Response model**: `RunEventResponse` gains `wrapper_output_log_uploaded: bool` (default False — backward-compatible).
- Closes #88.

## Why

Pre-Nextflow failures — `module load`, container pull, JVM init, conda activation, wrapper-code exceptions — leave no trace in `.nextflow.log` because Nextflow never gets far enough to write one. The actionable stderr sits in `slurm-<jobid>.out` on the cluster filesystem, invisible to the dashboard. Today the only way to diagnose is to SSH in and read the file. Post-migration, with pull-mode the chosen architecture (#87 comment), cluster-side observability *is* observability — gaps here are operational gaps.

## How the capture works

Three pieces compose to capture *all* output the wrapper sees:

1. `_TeeWriter` replaces `sys.stdout` and `sys.stderr` at wrapper entry. Every `print()` from the wrapper or any library it calls writes to the original stream AND appends to the capture buffer. The OSError-before-Popen diagnostic at line 271 of `run_wrapper.py` now lands in the buffer too — exactly the gap this issue exists for.
2. `_CaptureBuffer` is the shared bounded buffer. Trims from the front on overflow because failure context lives at the tail. Thread-safe (the reader thread and the Python `print` callsites both write).
3. `_spawn_capture_reader` runs in a thread on `Popen(stdout=PIPE, stderr=STDOUT, bufsize=1, text=True)`, streaming each line to both the original stdout (so operators still see live progress in `slurm-<jobid>.out`) and the same buffer.

Subprocesses inherit FDs, not Python wrappers — so the nextflow subprocess's output bypasses the tee. The reader thread captures it explicitly. Everything else (wrapper's own Python output, library output) goes through the tee.

## Naming note

The attachment is called `wrapper_output_log`, not `wrapper_log`, because there's a pre-existing `WrapperLogEvent` event type with `type=wrapper_log` for per-line streaming. Two unrelated mechanisms sharing one name would be a footgun. The README comment in `runs.py` calls this out for the next maintainer.

## Test plan
- [x] **Wrapper tests** (5 new + 17 existing = 22 total, all passing):
  - subprocess stdout captured into attachment
  - **pre-Nextflow OSError captures the wrapper's own diagnostic into the same attachment** (the #88 gap)
  - empty buffer omits attachment entirely (silent run = no empty file)
  - buffer trims front when oversized (keeps tail = failure context)
  - TeeWriter writes to both primary and buffer
- [x] **Server tests** (3 new + 21 existing = 24 total, all passing):
  - `wrapper_output_log` lands in task_logs under correct sentinel, coexists with `nextflow_log` on same wrapper_exited event
  - Rejected on non-wrapper_exited events → 422
  - Orphan-log 404 rule extends to `wrapper_output_log` (no run row → no upload)
- [x] **Full suite**: 98 server-side + 31 client-side passing; the one pre-existing client-side failure (`test_config_from_dict`) is unchanged from `main` and already documented in #89.

## Scope notes

- **Doesn't cover failures BEFORE the Python wrapper starts.** If `module load python` fails in the SLURM submit script, the wrapper never runs and nothing captures that. That's a separate concern that lives in the `submit_*.sh.j2` templates; could be addressed by piping the submit script's own output through `tee` to a known path the wrapper picks up. Out of scope here.
- **4 MB cap on the upload.** The wrapper tail-trims at 3 MB chars (with margin for multipart overhead). For typical failures this is plenty — the relevant stderr is the last few dozen lines, not megabytes of progress output.
- **No new dependencies.** Uses stdlib `collections.deque`, `threading`, `subprocess`. Same toolbox as the existing wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)