### PR TITLE
feat(task-logs): collect .command.out (stdout) for task logs

### DIFF
--- a/packages/nf_client/src/nf_client/cli.py
+++ b/packages/nf_client/src/nf_client/cli.py
@@ -381,25 +381,29 @@ def upload_logs(
     config: Path = config_option,
     run_name: str = typer.Option(..., "--run-name", "-r", help="Nextflow run name (value passed to -name)."),
     work_dir: Path = typer.Option(..., "--work-dir", "-w", help="Nextflow work directory (contains task subdirs)."),
-    max_size_kb: int = typer.Option(512, "--max-size-kb", help="Skip files larger than this many KB (default 512)."),
+    max_size_kb: int = typer.Option(5120, "--max-size-kb", help="Skip files larger than this many KB (default 5120 = 5 MB, matching the server cap). Lower it to trim noisy kraken2 stdout."),
     dry_run: bool = dry_run_option,
 ) -> None:
-    """Walk a Nextflow work directory and upload .command.sh and .command.err for each task.
+    """Walk a Nextflow work directory and upload .command.sh, .command.out and .command.err for each task.
 
     The Nextflow work directory structure is:
 
         work/<2-char-prefix>/<rest-of-hash>/
             .command.sh
+            .command.out
             .command.err
 
-    This command reconstructs the task_hash as "<prefix>/<rest>" and uploads both
-    files to the server as log_type "command_sh" and "command_err" respectively.
+    This command reconstructs the task_hash as "<prefix>/<rest>" and uploads each
+    file to the server as log_type "command_sh", "command_out" and "command_err"
+    respectively. Processes that log to stdout (e.g. kraken2's report) land in
+    .command.out — without it those tasks appear to have no logs at all.
 
     Intended to be called after a Nextflow run completes, typically from the SLURM
     job script or a Nextflow afterScript hook. Idempotent — safe to re-run.
     """
     _LOG_FILES = {
         ".command.sh":  "command_sh",
+        ".command.out": "command_out",
         ".command.err": "command_err",
     }
     max_bytes = max_size_kb * 1024

--- a/src/nextflow_telemetry/db.py
+++ b/src/nextflow_telemetry/db.py
@@ -177,7 +177,7 @@ task_logs_tbl = Table(
     Column("id", Integer, primary_key=True),
     Column("run_name", String, nullable=False),
     Column("task_hash", String, nullable=False),   # e.g. "ab/1234ef5678..."
-    Column("log_type", String, nullable=False),    # "command_sh" or "command_err"
+    Column("log_type", String, nullable=False),    # "command_sh", "command_out" or "command_err"
     Column("content", Text, nullable=False),
     Column("uploaded_at", DateTime(timezone=True), nullable=False),
     UniqueConstraint("run_name", "task_hash", "log_type", name="uq_task_log"),

--- a/src/nextflow_telemetry/routers/task_logs.py
+++ b/src/nextflow_telemetry/routers/task_logs.py
@@ -1,4 +1,4 @@
-"""Task log upload and retrieval — .command.sh and .command.err from Nextflow work dirs."""
+"""Task log upload and retrieval — .command.sh, .command.out and .command.err from Nextflow work dirs."""
 from __future__ import annotations
 
 import datetime
@@ -11,8 +11,11 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 from .. import models
 from ..db import task_logs_tbl
 
-_MAX_CONTENT_BYTES = 1 * 1024 * 1024  # 1 MB per log file
-_VALID_LOG_TYPES = {"command_sh", "command_err"}
+# Matches the client's default --max-size-kb (5 MB) so the two gates agree.
+# Anything bigger is almost certainly a kraken2 .command.out streaming per-read
+# classifications to stdout — that's data, not a log, so we drop it.
+_MAX_CONTENT_BYTES = 5 * 1024 * 1024  # 5 MB per log file
+_VALID_LOG_TYPES = {"command_sh", "command_out", "command_err"}
 
 
 def create_task_logs_router(engine: AsyncEngine) -> APIRouter:
@@ -24,7 +27,7 @@ def create_task_logs_router(engine: AsyncEngine) -> APIRouter:
         status_code=201,
         summary="Upload a task log file",
         description=(
-            "Upload the content of a .command.sh or .command.err file for a specific "
+            "Upload the content of a .command.sh, .command.out or .command.err file for a specific "
             "Nextflow task via multipart form data. Identified by (run_name, task_hash, log_type). "
             "Idempotent: re-uploading the same (run_name, task_hash, log_type) "
             "replaces the previous content."
@@ -80,7 +83,7 @@ def create_task_logs_router(engine: AsyncEngine) -> APIRouter:
         response_model=models.TaskLogsResponse,
         summary="Retrieve task logs",
         description=(
-            "Returns all uploaded log files (command_sh and command_err) for a specific "
+            "Returns all uploaded log files (command_sh, command_out and command_err) for a specific "
             "task, identified by run_name and the Nextflow work dir hash (e.g. 'ab/1234ef')."
         ),
     )

--- a/tests/test_task_logs_router.py
+++ b/tests/test_task_logs_router.py
@@ -65,6 +65,16 @@ def test_upload_task_log_returns_201():
     assert body["task_hash"] == "ab/1234ef"
 
 
+def test_upload_command_out_is_accepted():
+    row = {**_FAKE_ROW, "log_type": "command_out", "content": "kraken2 report on stdout"}
+    client = _client_with_mock_row(row)
+    r = client.post("/task-logs", **_multipart(
+        "happy-goldfish", "ab/1234ef", "command_out", "kraken2 report on stdout",
+    ))
+    assert r.status_code == 201
+    assert r.json()["log_type"] == "command_out"
+
+
 def test_invalid_log_type_is_rejected():
     engine, _ = _make_mock_engine()
     app = FastAPI()
@@ -79,7 +89,7 @@ def test_content_too_large_is_rejected():
     app = FastAPI()
     app.include_router(create_task_logs_router(engine))
     client = TestClient(app)
-    r = client.post("/task-logs", **_multipart("x", "ab/cd", "command_sh", "x" * (1024 * 1024 + 1)))
+    r = client.post("/task-logs", **_multipart("x", "ab/cd", "command_sh", "x" * (5 * 1024 * 1024 + 1)))
     assert r.status_code == 413
 
 


### PR DESCRIPTION
## Summary
Processes that report on **stdout** (e.g. kraken2's report) leave `.command.err` empty, so those tasks appeared to produce no logs at all. This adds `command_out` as a valid task-log type end to end.

## Changes
- **server** (`routers/task_logs.py`): accept `log_type=command_out`; raise per-file cap 1 MB → 5 MB (kraken2 stdout can be large)
- **nf-client** (`upload-logs`): collect `.command.out`; align `--max-size-kb` default (512 → 5120) with the server cap
- **db.py**: comment only
- **tests**: `command_out` accepted; bump too-large threshold to 5 MB

`log_type` is a plain `String` column → **no migration required**.

## Note
The production cmgd pipeline collects task logs via a per-task `afterScript` curl, *not* `nf-client upload-logs`. The matching `.command.out` curl is added in a separate PR on `curatedMetagenomicsNextflow`. This server change is the prerequisite (must deploy first, else the new curl 422s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)