### PR TITLE
fix(frontend): render .command.out tab in task log viewer

### DIFF
--- a/frontend/src/pages/MetricsPage.tsx
+++ b/frontend/src/pages/MetricsPage.tsx
@@ -447,7 +447,7 @@ function fmtDuration(ms: number | null): string {
 
 function TaskLogViewer({ runName, taskHash }: { runName: string; taskHash: string }) {
   const [logs, setLogs] = useState<TaskLogsResponse | null>(null)
-  const [activeLog, setActiveLog] = useState<'command_sh' | 'command_err'>('command_err')
+  const [activeLog, setActiveLog] = useState<'command_sh' | 'command_out' | 'command_err'>('command_err')
 
   useEffect(() => {
     api.metrics.taskLogs(runName, taskHash).then(setLogs).catch(console.error)
@@ -468,7 +468,7 @@ function TaskLogViewer({ runName, taskHash }: { runName: string; taskHash: strin
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
       <div style={{ display: 'flex', gap: 4 }}>
-        {(['command_err', 'command_sh'] as const).map(lt => (
+        {(['command_err', 'command_out', 'command_sh'] as const).map(lt => (
           logTypes.includes(lt) && (
             <button key={lt} onClick={() => setActiveLog(lt)} style={{
               background: activeLog === lt ? T.accentDim : T.elevated,
@@ -476,7 +476,7 @@ function TaskLogViewer({ runName, taskHash }: { runName: string; taskHash: strin
               color: activeLog === lt ? T.accent : T.muted,
               borderRadius: 4, padding: '2px 10px', fontSize: 11,
               fontWeight: 600, cursor: 'pointer', fontFamily: 'DM Mono, monospace',
-            }}>{lt === 'command_err' ? '.command.err' : '.command.sh'}</button>
+            }}>{lt === 'command_err' ? '.command.err' : lt === 'command_out' ? '.command.out' : '.command.sh'}</button>
           )
         ))}
       </div>


### PR DESCRIPTION
## Summary
The task-log viewer (`MetricsPage.tsx` → `TaskLogViewer`) hardcoded only `.command.err` / `.command.sh` tabs. After the recent change to collect `.command.out` per task (kraken2 reports to stdout), those logs are stored server-side but **never rendered** in the UI.

## Fix
- add `command_out` to the tab list `['command_err', 'command_out', 'command_sh']`
- add it to the `activeLog` state union type
- add its `.command.out` label

Tabs still only render for log types actually present on the task (`logTypes.includes(lt)`), so tasks without stdout simply won't show the tab.

## Verification
- `npm run build` (tsc -b + vite) passes clean.
- Backend already returns `command_out` rows (confirmed via `/api/task-logs`); this was purely a render gap.
- Couldn't drive Playwright on this Rocky host (browser install needs root / Ubuntu-Debian; MCP pinned to a missing `chrome` channel). Diagnosis is from source + API, not a screenshot.

Frontend is baked at build time — needs a frontend rebuild/deploy to go live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)