### PR TITLE
feat(diagnostics): stuck-pending / no-active-daemon check (Tier 1 #1)

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -16,6 +16,7 @@ import type {
   ReconcileResult,
   RequeueResult,
   RequeueDlqResult,
+  DispatchabilityResult,
   SampleResponse,
   SampleRegisterRequest,
   SubmittedRequest,
@@ -125,6 +126,7 @@ export const api = {
   admin: {
     reconcile: () => post<ReconcileResult>('/admin/reconcile-jobs'),
     requeueDeadLetter: () => post<RequeueDlqResult>('/admin/requeue-dead-letter'),
+    dispatchability: () => get<DispatchabilityResult>('/admin/dispatchability'),
   },
 
   daemons: {

--- a/frontend/src/pages/OverviewPage.tsx
+++ b/frontend/src/pages/OverviewPage.tsx
@@ -10,7 +10,32 @@ import MiniBar from '../components/MiniBar'
 import DonutChart from '../components/DonutChart'
 import Panel from '../components/Panel'
 import PageWrap from '../components/PageWrap'
-import type { ProcessSummaryResponse, RunningProcessesResponse, RunningProcessRow, TopFailureRow, TopRetryRow, TopFailureExitCodeRow } from '../types'
+import type { ProcessSummaryResponse, RunningProcessesResponse, RunningProcessRow, TopFailureRow, TopRetryRow, TopFailureExitCodeRow, DispatchabilityResult } from '../types'
+
+function StuckWorkBanner({ data }: { data: DispatchabilityResult }) {
+  if (!data.stuck.length) return null
+  return (
+    <div style={{
+      background: 'rgba(245,101,101,0.12)', border: `1px solid ${T.red}`,
+      borderRadius: 8, padding: '12px 16px', marginBottom: 16,
+    }}>
+      <div style={{ color: T.red, fontWeight: 700, fontSize: 14, marginBottom: 4 }}>
+        ⚠ {fmtNum(data.stuck_pending_total)} pending job{data.stuck_pending_total === 1 ? '' : 's'} with no active daemon to claim them
+      </div>
+      <div style={{ color: T.text, fontSize: 13, lineHeight: 1.6 }}>
+        {data.active_daemons} active daemon{data.active_daemons === 1 ? '' : 's'} heartbeating.
+        These active workflows have pending work that nothing will pick up — usually a stopped daemon
+        or a daemon whose <code style={{ fontFamily: 'DM Mono, monospace', color: T.accent }}>workflow_id</code> filter
+        doesn't match:
+      </div>
+      <ul style={{ margin: '6px 0 0', paddingLeft: 18, color: T.muted, fontSize: 12.5, fontFamily: 'DM Mono, monospace' }}>
+        {data.stuck.map(s => (
+          <li key={s.workflow_pk}>{s.workflow_id} — {fmtNum(s.pending)} pending</li>
+        ))}
+      </ul>
+    </div>
+  )
+}
 
 function ExitCodeChart({ rows }: { rows: TopFailureExitCodeRow[] }) {
   const exitLabels: Record<string, string> = {
@@ -75,11 +100,13 @@ function RunningPanel({ data }: { data: RunningProcessesResponse }) {
 export default function OverviewPage({ pollInterval = 30_000 }: { pollInterval?: number }) {
   const [summary, setSummary]   = useState<ProcessSummaryResponse | null>(null)
   const [running, setRunning]   = useState<RunningProcessesResponse | null>(null)
+  const [dispatchability, setDispatchability] = useState<DispatchabilityResult | null>(null)
   const { tick, refresh, lastUpdated } = usePoll(pollInterval)
 
   useEffect(() => {
     api.metrics.summary({ windowDays: 30 }).then(setSummary).catch(console.error)
     api.metrics.running().then(setRunning).catch(console.error)
+    api.admin.dispatchability().then(setDispatchability).catch(console.error)
   }, [tick])
 
   if (!summary || !running) {
@@ -100,6 +127,7 @@ export default function OverviewPage({ pollInterval = 30_000 }: { pollInterval?:
 
   return (
     <PageWrap>
+      {dispatchability && <StuckWorkBanner data={dispatchability} />}
       <div>
         <SectionHeader title="Process Execution"
           sub={`Last ${summary.window_days ?? 30} days · ${fmtNum(c.process_completed_rows)} task completions`}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -259,6 +259,20 @@ export interface RequeueDlqResult {
   requeued: number
 }
 
+export interface StuckWorkflow {
+  workflow_id: string
+  workflow_pk: number
+  pending: number
+  reason: string
+}
+
+export interface DispatchabilityResult {
+  checked_at: string
+  active_daemons: number
+  stuck: StuckWorkflow[]
+  stuck_pending_total: number
+}
+
 export interface TaskLogEntry {
   id: number
   run_name: string

--- a/src/nextflow_telemetry/routers/admin.py
+++ b/src/nextflow_telemetry/routers/admin.py
@@ -7,8 +7,12 @@ from fastapi import APIRouter, HTTPException
 from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncEngine
 
-from ..db import dead_letter_tbl, jobs_tbl, samples_tbl, workflow_runs_tbl, workflows_tbl
+from ..db import daemon_agents_tbl, dead_letter_tbl, jobs_tbl, samples_tbl, workflow_runs_tbl, workflows_tbl
 from ..services.reconcile import ReconcileService, sweep_run_incomplete
+
+# Keep in sync with routers/daemons.ACTIVE_THRESHOLD — a daemon is "active" if
+# its last heartbeat is within this window.
+_DAEMON_ACTIVE_THRESHOLD = datetime.timedelta(minutes=2)
 
 
 def create_admin_router(engine: AsyncEngine) -> APIRouter:
@@ -179,6 +183,68 @@ def create_admin_router(engine: AsyncEngine) -> APIRouter:
             )
 
         return {"requeued": len(job_ids)}
+
+    @router.get(
+        "/dispatchability",
+        summary="Find pending work that no active daemon will claim",
+        description=(
+            "Cross-checks pending jobs on `active` workflows against the set of currently "
+            "active daemons (heartbeat within the last 2 minutes) and their `workflow_id` "
+            "claim filters. Returns the workflows that have pending jobs but no active daemon "
+            "configured to claim them — i.e. work that will silently sit forever. This is the "
+            "fast answer to 'why isn't anything running?' when a daemon has died."
+        ),
+    )
+    async def dispatchability():
+        now = datetime.datetime.now(datetime.timezone.utc)
+        async with engine.begin() as conn:
+            pending_rows = (await conn.execute(
+                select(
+                    jobs_tbl.c.workflow_pk,
+                    jobs_tbl.c.workflow_id,
+                    func.count().label("pending"),
+                )
+                .select_from(jobs_tbl.join(workflows_tbl, jobs_tbl.c.workflow_pk == workflows_tbl.c.id))
+                .where(jobs_tbl.c.status == "pending", workflows_tbl.c.status == "active")
+                .group_by(jobs_tbl.c.workflow_pk, jobs_tbl.c.workflow_id)
+            )).all()
+
+            daemon_rows = (await conn.execute(
+                select(daemon_agents_tbl.c.workflow_id, daemon_agents_tbl.c.last_seen_at)
+            )).all()
+
+        # An active daemon claims a workflow if its filter is empty (claims any)
+        # or the workflow_id is in its comma-separated filter list.
+        active_filters: list[set[str] | None] = []
+        for d in daemon_rows:
+            last_seen = d.last_seen_at
+            if last_seen.tzinfo is None:
+                last_seen = last_seen.replace(tzinfo=datetime.timezone.utc)
+            if (now - last_seen) >= _DAEMON_ACTIVE_THRESHOLD:
+                continue
+            wf = (d.workflow_id or "").strip()
+            active_filters.append({x.strip() for x in wf.split(",") if x.strip()} if wf else None)
+
+        def claimed_by_active(workflow_id: str) -> bool:
+            return any(f is None or workflow_id in f for f in active_filters)
+
+        stuck = [
+            {
+                "workflow_id": r.workflow_id,
+                "workflow_pk": r.workflow_pk,
+                "pending": r.pending,
+                "reason": "no active daemon claims this workflow",
+            }
+            for r in pending_rows
+            if not claimed_by_active(r.workflow_id)
+        ]
+
+        return {
+            "checked_at": now,
+            "active_daemons": len(active_filters),
+            "stuck": stuck,
+            "stuck_pending_total": sum(s["pending"] for s in stuck),
+        }
 
     @router.get(
         "/stats",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -303,6 +303,55 @@ def test_reconcile_skips_paused_workflows(integration_client, db_url):
 
 
 # ---------------------------------------------------------------------------
+# Dispatchability (no-active-daemon detection)
+# ---------------------------------------------------------------------------
+
+def _heartbeat(client, *, agent_id: str, workflow_id: str | None) -> None:
+    client.put("/api/daemons/heartbeat", json={
+        "agent_id": agent_id,
+        "hostname": agent_id,
+        "workflow_id": workflow_id,   # None = claims any workflow
+        "mode": "slurm",
+        "batch_size": 10,
+        "status": "running",
+    })
+
+
+def test_dispatchability_flags_pending_with_no_active_daemon(integration_client):
+    client, _ = integration_client
+    _sample, wf_id, _pk = _seed_job(client, workflow_id=f"stuck-{uuid.uuid4().hex[:6]}")
+
+    resp = client.get("/api/admin/dispatchability")
+    assert resp.status_code == 200
+    stuck_ids = {s["workflow_id"] for s in resp.json()["stuck"]}
+    # No daemon heartbeated → our active workflow's pending jobs are unclaimed.
+    assert wf_id in stuck_ids
+
+
+def test_dispatchability_cleared_by_matching_daemon(integration_client):
+    client, _ = integration_client
+    _sample, wf_id, _pk = _seed_job(client, workflow_id=f"claimed-{uuid.uuid4().hex[:6]}")
+
+    # A daemon whose filter includes this workflow (plus an unrelated one).
+    _heartbeat(client, agent_id=f"agent-{uuid.uuid4().hex[:6]}",
+               workflow_id=f"{wf_id},some-other-wf")
+
+    stuck_ids = {s["workflow_id"] for s in client.get("/api/admin/dispatchability").json()["stuck"]}
+    assert wf_id not in stuck_ids
+
+
+def test_dispatchability_cleared_by_claim_any_daemon(integration_client):
+    client, _ = integration_client
+    _sample, wf_id, _pk = _seed_job(client, workflow_id=f"any-{uuid.uuid4().hex[:6]}")
+
+    # A daemon with no workflow filter claims any workflow.
+    _heartbeat(client, agent_id=f"agent-any-{uuid.uuid4().hex[:6]}", workflow_id=None)
+
+    stuck_ids = {s["workflow_id"] for s in client.get("/api/admin/dispatchability").json()["stuck"]}
+    assert wf_id not in stuck_ids
+
+
+# ---------------------------------------------------------------------------
 # Dispatch protocol (Phase 2)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Why
The hour lost to the dead Alpine daemon: 135 pending jobs sat unclaimed and it read like a reconcile bug. Nothing surfaced that **no active daemon was claiming the work**.

## What
**`GET /admin/dispatchability`** — joins pending jobs on `active` workflows against active daemons (heartbeat < 2 min) and their `workflow_id` claim filters (comma-list, or null = claims any). Returns the workflows with pending work no active daemon will claim:
```json
{ "checked_at": "...", "active_daemons": 1,
  "stuck": [{"workflow_id":"cmgd_nextflow","workflow_pk":4,"pending":69,"reason":"no active daemon claims this workflow"}],
  "stuck_pending_total": 69 }
```

**Overview banner** — red callout when `stuck` is non-empty, listing each workflow + pending count. The one-line answer to "why isn't anything running?"

## Tests
3 integration tests (real Postgres via testcontainers): flags unclaimed pending, cleared by a matching-filter daemon, cleared by a claim-any daemon. All pass. mypy clean; frontend builds clean.

## Deploy
Server: redeploy API on onclappc02. Frontend: rebuild container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)