### PR TITLE
feat(runs): run detail + death classification (Tier 1 #2)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { LayoutDashboard, BarChart2, GitBranch, FlaskConical, SendHorizonal, Server, Users, LogIn, LogOut, type LucideIcon } from 'lucide-react'
+import { LayoutDashboard, BarChart2, GitBranch, FlaskConical, SendHorizonal, Server, Users, Activity, LogIn, LogOut, type LucideIcon } from 'lucide-react'
 import { T } from './tokens'
 import { MOCK_HEALTH } from './lib/mock-data'
 import { AuthProvider, useAuth } from './lib/auth'
@@ -9,9 +9,10 @@ import WorkflowsPage from './pages/WorkflowsPage'
 import SamplesPage from './pages/SamplesPage'
 import CohortsPage from './pages/CohortsPage'
 import DispatchPage from './pages/DispatchPage'
+import RunsPage from './pages/RunsPage'
 import InfraPage from './pages/InfraPage'
 
-type NavId = 'overview' | 'metrics' | 'workflows' | 'samples' | 'cohorts' | 'dispatch' | 'infra'
+type NavId = 'overview' | 'metrics' | 'workflows' | 'samples' | 'cohorts' | 'dispatch' | 'runs' | 'infra'
 
 const NAV: Array<{ id: NavId; label: string; icon: LucideIcon; sub: string }> = [
   { id: 'overview',  label: 'Overview',        icon: LayoutDashboard, sub: 'Pipeline health'      },
@@ -20,6 +21,7 @@ const NAV: Array<{ id: NavId; label: string; icon: LucideIcon; sub: string }> = 
   { id: 'samples',   label: 'Samples',          icon: FlaskConical,    sub: 'Catalog'              },
   { id: 'cohorts',   label: 'Cohorts',          icon: Users,           sub: 'Collection summary'   },
   { id: 'dispatch',  label: 'Dispatch',         icon: SendHorizonal,   sub: '& Admin'              },
+  { id: 'runs',      label: 'Runs',             icon: Activity,        sub: 'Run health & deaths'  },
   { id: 'infra',     label: 'Infrastructure',   icon: Server,          sub: 'Daemon fleet'         },
 ]
 
@@ -193,6 +195,7 @@ export default function App() {
     samples:   <SamplesPage   pollInterval={pollInterval} />,
     cohorts:   <CohortsPage   pollInterval={pollInterval} />,
     dispatch:  <DispatchPage />,
+    runs:      <RunsPage      pollInterval={pollInterval} />,
     infra:     <InfraPage     pollInterval={pollInterval} />,
   }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -20,6 +20,8 @@ import type {
   SampleRegisterRequest,
   SubmittedRequest,
   DaemonAgentResponse,
+  RunsListResponse,
+  RunDetail,
   CohortListItem,
   CohortSummaryResponse,
   CohortFailuresResponse,
@@ -130,6 +132,18 @@ export const api = {
   daemons: {
     list: (activeOnly = false) =>
       get<DaemonAgentResponse[]>(`/daemons/${activeOnly ? '?active_only=true' : ''}`),
+  },
+
+  runs: {
+    list: (opts: { status?: string; workflowId?: string; limit?: number } = {}) => {
+      const p = new URLSearchParams()
+      if (opts.status) p.set('status', opts.status)
+      if (opts.workflowId) p.set('workflow_id', opts.workflowId)
+      if (opts.limit) p.set('limit', String(opts.limit))
+      const qs = p.toString()
+      return get<RunsListResponse>(`/runs/${qs ? `?${qs}` : ''}`)
+    },
+    get: (runName: string) => get<RunDetail>(`/runs/${encodeURIComponent(runName)}`),
   },
 
   cohorts: {

--- a/frontend/src/pages/RunsPage.tsx
+++ b/frontend/src/pages/RunsPage.tsx
@@ -1,0 +1,169 @@
+import { useState, useEffect } from 'react'
+import { T } from '../tokens'
+import { usePoll, fmtUpdated } from '../lib/usePoll'
+import { fmtNum } from '../lib/format'
+import { api } from '../lib/api'
+import KPICard from '../components/KPICard'
+import SectionHeader from '../components/SectionHeader'
+import DataTable, { Column } from '../components/DataTable'
+import Badge, { BadgeVariant } from '../components/Badge'
+import Panel from '../components/Panel'
+import PageWrap from '../components/PageWrap'
+import type { RunListItem, RunDetail } from '../types'
+
+// Map the server-derived run classification to a badge colour.
+function classVariant(c: string): BadgeVariant {
+  switch (c) {
+    case 'completed': return 'success'
+    case 'active':    return 'active'
+    case 'stalled':   return 'paused'
+    case 'failed':
+    case 'wrapper-failed':
+    case 'ended-no-log': return 'error'
+    case 'expired':   return 'retired'
+    default:          return 'neutral'
+  }
+}
+
+const CLASS_HELP: Record<string, string> = {
+  'wrapper-failed': 'Driver exited non-zero — the Nextflow process itself failed.',
+  'ended-no-log': 'Reached a terminal state but never uploaded .nextflow.log — driver likely hard-killed (OOM / scancel / node failure). Check sacct.',
+  'stalled': 'Non-terminal but no heartbeat for >15 min — wrapper gone, run not closed.',
+}
+
+function ts(v: string | null): string {
+  return v ? v.replace('T', ' ').slice(0, 19) : '—'
+}
+
+function RunDrawer({ runName, onClose }: { runName: string; onClose: () => void }) {
+  const [detail, setDetail] = useState<RunDetail | null>(null)
+  useEffect(() => {
+    setDetail(null)
+    api.runs.get(runName).then(setDetail).catch(console.error)
+  }, [runName])
+
+  return (
+    <Panel>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <SectionHeader title={runName} sub="Run detail" />
+        <button onClick={onClose} style={{
+          background: 'transparent', border: `1px solid ${T.border}`, color: T.muted,
+          borderRadius: 4, padding: '2px 10px', fontSize: 12, cursor: 'pointer',
+        }}>Close</button>
+      </div>
+      {!detail ? (
+        <div style={{ color: T.muted, fontSize: 12, padding: 8 }}>Loading…</div>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+          <div style={{ display: 'flex', gap: 10, alignItems: 'center', flexWrap: 'wrap' }}>
+            <Badge label={detail.classification} variant={classVariant(detail.classification)} />
+            <span style={{ fontSize: 12, color: T.muted, fontFamily: 'DM Mono, monospace' }}>
+              status={detail.status} · {detail.workflow_id} {detail.workflow_version}
+            </span>
+          </div>
+          {CLASS_HELP[detail.classification] && (
+            <div style={{ fontSize: 12.5, color: T.amber, lineHeight: 1.6 }}>
+              {CLASS_HELP[detail.classification]}
+            </div>
+          )}
+
+          <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+            {Object.entries(detail.task_status_counts).length === 0 && (
+              <div style={{ fontSize: 12, color: T.muted }}>No process_completed events recorded.</div>
+            )}
+            {Object.entries(detail.task_status_counts).map(([status, n]) => (
+              <KPICard key={status} label={status} value={fmtNum(n)}
+                accent={status === 'COMPLETED' ? T.green : status === 'FAILED' ? T.red : status === 'ABORTED' ? T.amber : T.muted} />
+            ))}
+          </div>
+          {(detail.task_status_counts['ABORTED'] ?? 0) > 0 && (detail.task_status_counts['FAILED'] ?? 0) === 0 && (
+            <div style={{ fontSize: 12.5, color: T.amber, lineHeight: 1.6 }}>
+              All-ABORTED with zero FAILED tasks — the run died from outside (driver/allocation killed),
+              not a pipeline task error. The aborted tasks are collateral.
+            </div>
+          )}
+
+          <div style={{ fontSize: 12.5, color: T.text, fontFamily: 'DM Mono, monospace', lineHeight: 1.8 }}>
+            <div>claimed:   {ts(detail.claimed_at)}</div>
+            <div>submitted: {ts(detail.submitted_at)}</div>
+            <div>started:   {ts(detail.started_at)}</div>
+            <div>completed: {ts(detail.completed_at)}</div>
+            <div>heartbeat: {ts(detail.last_heartbeat_at)}</div>
+            <div>executor_job_id: {detail.executor_job_id ?? '—'}</div>
+            <div>wrapper_exit_code: {detail.wrapper_exit_code ?? '—'}</div>
+            <div>slurm_state: {detail.last_known_slurm_state ?? '—'}{detail.slurm_reason ? ` (${detail.slurm_reason})` : ''}</div>
+          </div>
+
+          <div style={{ display: 'flex', gap: 12, fontSize: 12.5 }}>
+            <span style={{ color: detail.nextflow_log_available ? T.green : T.muted }}>
+              {detail.nextflow_log_available ? '✓' : '✗'} .nextflow.log
+            </span>
+            <span style={{ color: detail.wrapper_output_log_available ? T.green : T.muted }}>
+              {detail.wrapper_output_log_available ? '✓' : '✗'} wrapper output log
+            </span>
+          </div>
+        </div>
+      )}
+    </Panel>
+  )
+}
+
+export default function RunsPage({ pollInterval = 30_000 }: { pollInterval?: number }) {
+  const [runs, setRuns] = useState<RunListItem[]>([])
+  const [selected, setSelected] = useState<string | null>(null)
+  const { tick, refresh, lastUpdated } = usePoll(pollInterval)
+
+  useEffect(() => {
+    api.runs.list({ limit: 100 }).then(r => setRuns(r.runs)).catch(console.error)
+  }, [tick])
+
+  const columns: Column<RunListItem>[] = [
+    { key: 'run_name', label: 'Run', mono: true,
+      render: (v, row) => (
+        <span onClick={() => setSelected(row.run_name)}
+          style={{ color: T.accent, cursor: 'pointer', textDecoration: 'underline' }}>
+          {String(v).slice(0, 20)}
+        </span>
+      ) },
+    { key: 'workflow_id', label: 'Workflow', mono: true },
+    { key: 'classification', label: 'State',
+      render: (v) => <Badge label={String(v)} variant={classVariant(String(v))} /> },
+    { key: 'status', label: 'Raw', mono: true },
+    { key: 'wrapper_exit_code', label: 'Exit', align: 'right',
+      render: (v) => <span style={{ fontFamily: 'DM Mono, monospace' }}>{v == null ? '—' : String(v)}</span> },
+    { key: 'claimed_at', label: 'Claimed', mono: true, render: (v) => ts(v as string | null) },
+  ]
+
+  const counts = runs.reduce<Record<string, number>>((acc, r) => {
+    acc[r.classification] = (acc[r.classification] ?? 0) + 1
+    return acc
+  }, {})
+  const attention = (counts['wrapper-failed'] ?? 0) + (counts['ended-no-log'] ?? 0) + (counts['stalled'] ?? 0)
+
+  return (
+    <PageWrap>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+        <SectionHeader title="Runs" sub="Workflow runs with derived state classification" />
+        <span style={{ fontSize: 11, color: T.muted }}>
+          {fmtUpdated(lastUpdated)} · <button onClick={refresh} style={{
+            background: 'transparent', border: 'none', color: T.accent, cursor: 'pointer', fontSize: 11,
+          }}>refresh</button>
+        </span>
+      </div>
+
+      <div style={{ display: 'flex', gap: 12, marginBottom: 16, flexWrap: 'wrap' }}>
+        <KPICard label="Runs" value={fmtNum(runs.length)} accent={T.blue} />
+        <KPICard label="Completed" value={fmtNum(counts['completed'] ?? 0)} accent={T.green} />
+        <KPICard label="Active" value={fmtNum(counts['active'] ?? 0)} accent={T.accent} />
+        <KPICard label="Needs attention" value={fmtNum(attention)}
+          sub="wrapper-failed / ended-no-log / stalled" accent={attention ? T.red : T.muted} />
+      </div>
+
+      {selected && <div style={{ marginBottom: 16 }}><RunDrawer runName={selected} onClose={() => setSelected(null)} /></div>}
+
+      <Panel>
+        <DataTable<RunListItem> columns={columns} rows={runs} emptyMsg="No runs yet" />
+      </Panel>
+    </PageWrap>
+  )
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -259,6 +259,40 @@ export interface RequeueDlqResult {
   requeued: number
 }
 
+export interface RunListItem {
+  run_name: string
+  workflow_id: string
+  workflow_version: string
+  status: string
+  classification: string
+  claimed_at: string | null
+  submitted_at: string | null
+  started_at: string | null
+  completed_at: string | null
+  wrapper_exit_code: number | null
+  last_known_slurm_state: string | null
+  slurm_reason: string | null
+}
+
+export interface RunsListResponse {
+  total: number
+  limit: number
+  offset: number
+  runs: RunListItem[]
+}
+
+export interface RunDetail extends RunListItem {
+  run_id: string | null
+  revision: string | null
+  executor_job_id: string | null
+  last_heartbeat_at: string | null
+  nextflow_log_uploaded_at: string | null
+  wait_seconds: number | null
+  task_status_counts: Record<string, number>
+  nextflow_log_available: boolean
+  wrapper_output_log_available: boolean
+}
+
 export interface TaskLogEntry {
   id: number
   run_name: string

--- a/src/nextflow_telemetry/routers/runs.py
+++ b/src/nextflow_telemetry/routers/runs.py
@@ -21,9 +21,11 @@ import json
 from datetime import datetime, timezone
 from typing import Annotated
 
-from fastapi import APIRouter, File, Form, HTTPException, Path, UploadFile
+from datetime import timedelta
+
+from fastapi import APIRouter, File, Form, HTTPException, Path, Query, UploadFile
 from pydantic import TypeAdapter, ValidationError
-from sqlalchemy import insert, select, text, update
+from sqlalchemy import func, insert, select, text, update
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from ..models import (
@@ -38,7 +40,51 @@ from ..models import (
     WrapperLogEvent,
     WrapperStartedEvent,
 )
-from ..db import telemetry_tbl, workflow_runs_tbl
+from ..db import task_logs_tbl, telemetry_tbl, workflow_runs_tbl
+
+
+# A non-terminal run with no heartbeat for longer than this is "stalled" —
+# the wrapper is gone but nothing closed the run. Heartbeats arrive far more
+# often than this in normal operation.
+_RUN_STALE_THRESHOLD = timedelta(minutes=15)
+
+
+def _classify_run(row: dict, now: datetime) -> str:
+    """Derive a human-meaningful run state from the workflow_runs columns.
+
+    Beyond raw status, this surfaces the two failure shapes that were painful
+    to diagnose by hand:
+      - 'wrapper-failed' : the driver exited non-zero (wrapper_exit_code).
+      - 'ended-no-log'   : the run reached a terminal state but the wrapper
+                           never uploaded its .nextflow.log — the signature of
+                           a driver/allocation that was hard-killed (OOM,
+                           scancel, node failure) before its exit handler ran.
+      - 'stalled'        : non-terminal but no recent heartbeat.
+    """
+    status = row.get("status")
+    wec = row.get("wrapper_exit_code")
+    log_at = row.get("nextflow_log_uploaded_at")
+
+    # A non-zero wrapper exit is authoritative regardless of the status column,
+    # which can lag (or never advance) when the driver dies.
+    if wec is not None and wec != 0:
+        return "wrapper-failed"
+
+    if status in ("claimed", "submitted", "running"):
+        hb = row.get("last_heartbeat_at") or row.get("submitted_at") or row.get("claimed_at")
+        if hb is not None:
+            if hb.tzinfo is None:
+                hb = hb.replace(tzinfo=timezone.utc)
+            if (now - hb) > _RUN_STALE_THRESHOLD:
+                return "stalled"
+        return "active"
+
+    # Terminal-ish: completed / failed / expired / anything else.
+    if log_at is None:
+        return "ended-no-log"
+    if status == "completed":
+        return "completed"
+    return status or "unknown"
 
 
 _MAX_NEXTFLOW_LOG_BYTES = 16 * 1024 * 1024  # 16 MB
@@ -263,6 +309,89 @@ def create_runs_router(engine: AsyncEngine) -> APIRouter:
             nextflow_log_uploaded=log_uploaded,
             wrapper_output_log_uploaded=wrapper_output_log_uploaded,
         )
+
+    @router.get(
+        "/",
+        summary="List workflow runs with a derived state classification",
+        description=(
+            "Returns workflow_runs newest-first, each annotated with a `classification` "
+            "(active / stalled / completed / failed / expired / wrapper-failed / ended-no-log) "
+            "derived from status, wrapper_exit_code, heartbeat age, and whether the .nextflow.log "
+            "was uploaded. `ended-no-log` and `wrapper-failed` flag runs whose driver died — the "
+            "cases that otherwise require sacct to diagnose."
+        ),
+    )
+    async def list_runs(
+        status: str | None = Query(default=None, description="Filter by raw run status."),
+        workflow_id: str | None = Query(default=None, description="Filter by workflow_id."),
+        limit: int = Query(default=50, ge=1, le=500),
+        offset: int = Query(default=0, ge=0),
+    ):
+        now = datetime.now(timezone.utc)
+        stmt = select(workflow_runs_tbl).order_by(workflow_runs_tbl.c.claimed_at.desc().nullslast())
+        if status:
+            stmt = stmt.where(workflow_runs_tbl.c.status == status)
+        if workflow_id:
+            stmt = stmt.where(workflow_runs_tbl.c.workflow_id == workflow_id)
+        count_stmt = select(func.count()).select_from(workflow_runs_tbl)
+        if status:
+            count_stmt = count_stmt.where(workflow_runs_tbl.c.status == status)
+        if workflow_id:
+            count_stmt = count_stmt.where(workflow_runs_tbl.c.workflow_id == workflow_id)
+
+        async with engine.connect() as conn:
+            rows = (await conn.execute(stmt.limit(limit).offset(offset))).mappings().all()
+            total = (await conn.execute(count_stmt)).scalar_one()
+
+        runs = []
+        for r in rows:
+            d = dict(r)
+            d["classification"] = _classify_run(d, now)
+            runs.append(d)
+        return {"total": total, "limit": limit, "offset": offset, "runs": runs}
+
+    @router.get(
+        "/{run_name}",
+        summary="Run detail: lifecycle fields, task-status counts, log availability",
+        description=(
+            "Full workflow_runs row plus the derived `classification`, a breakdown of "
+            "process task statuses for the run (COMPLETED/FAILED/ABORTED — an all-ABORTED, "
+            "zero-FAILED run points at a driver death, not a pipeline bug), and whether the "
+            "nextflow_log / wrapper_output_log attachments are available to view."
+        ),
+    )
+    async def get_run(run_name: Annotated[str, Path(description="Nextflow run name.")]):
+        now = datetime.now(timezone.utc)
+        async with engine.connect() as conn:
+            row = (await conn.execute(
+                select(workflow_runs_tbl).where(workflow_runs_tbl.c.run_name == run_name)
+            )).mappings().first()
+            if not row:
+                raise HTTPException(status_code=404, detail=f"No workflow run with name '{run_name}'")
+
+            status_expr = telemetry_tbl.c.trace["status"].astext
+            task_counts = (await conn.execute(
+                select(status_expr.label("task_status"), func.count())
+                .where(
+                    telemetry_tbl.c.run_name == run_name,
+                    telemetry_tbl.c.event == "process_completed",
+                )
+                .group_by(status_expr)
+            )).all()
+
+            log_types = (await conn.execute(
+                select(task_logs_tbl.c.log_type).where(
+                    task_logs_tbl.c.run_name == run_name,
+                    task_logs_tbl.c.log_type.in_([_NEXTFLOW_LOG_TYPE, _WRAPPER_LOG_TYPE]),
+                )
+            )).scalars().all()
+
+        d = dict(row)
+        d["classification"] = _classify_run(d, now)
+        d["task_status_counts"] = {(s or "unknown"): n for s, n in task_counts}
+        d["nextflow_log_available"] = _NEXTFLOW_LOG_TYPE in log_types
+        d["wrapper_output_log_available"] = _WRAPPER_LOG_TYPE in log_types
+        return d
 
     return router
 

--- a/tests/test_runs_router.py
+++ b/tests/test_runs_router.py
@@ -194,6 +194,57 @@ def test_slurm_state_records_state_and_reason(integration_client, db_url):
     assert rows[0]["slurm_reason"] == "WallTimeLimit"
 
 
+# ---------------------------------------------------------------------------
+# GET /runs/ list + /runs/{run_name} detail with classification
+# ---------------------------------------------------------------------------
+
+def test_list_runs_includes_classification(integration_client, db_url):
+    client, _ = integration_client
+    run_name = _make_run_name()
+    _seed_run(db_url, run_name, status="claimed")
+
+    resp = client.get("/api/runs/")
+    assert resp.status_code == 200
+    body = resp.json()
+    mine = next((r for r in body["runs"] if r["run_name"] == run_name), None)
+    assert mine is not None
+    # Just claimed, no heartbeat staleness → active.
+    assert mine["classification"] == "active"
+
+
+def test_get_run_classifies_wrapper_failed(integration_client, db_url):
+    client, _ = integration_client
+    run_name = _make_run_name()
+    _seed_run(db_url, run_name, status="running")
+
+    _post_event(client, run_name, {"type": "wrapper_exited", "utc_time": _ts(), "exit_code": 1})
+
+    resp = client.get(f"/api/runs/{run_name}")
+    assert resp.status_code == 200
+    body = resp.json()
+    # Non-zero wrapper exit is authoritative even though status never went terminal.
+    assert body["classification"] == "wrapper-failed"
+    assert body["wrapper_exit_code"] == 1
+    assert isinstance(body["task_status_counts"], dict)
+    assert body["nextflow_log_available"] is False
+
+
+def test_get_run_classifies_ended_no_log(integration_client, db_url):
+    client, _ = integration_client
+    run_name = _make_run_name()
+    # Terminal status but the wrapper never uploaded a .nextflow.log → driver
+    # hard-killed before its exit handler ran.
+    _seed_run(db_url, run_name, status="completed")
+
+    body = client.get(f"/api/runs/{run_name}").json()
+    assert body["classification"] == "ended-no-log"
+
+
+def test_get_run_404_for_unknown(integration_client):
+    client, _ = integration_client
+    assert client.get("/api/runs/does-not-exist").status_code == 404
+
+
 def test_wrapper_exited_records_exit_code(integration_client, db_url):
     from nextflow_telemetry.db import workflow_runs_tbl
 


### PR DESCRIPTION
## Why
The ABORTED rabbit hole: a driver crash showed up as ABORTED tasks + 0 FAILED + no log, with **no run-level view** in the app — diagnosing it meant SSHing to Alpine and running `sacct`.

## What
**`GET /runs/`** (list) and **`GET /runs/{run_name}`** (detail), each annotating `workflow_runs` with a derived **`classification`**:
`active / stalled / completed / failed / expired / wrapper-failed / ended-no-log`

The two new labels target what was hard to see:
- **`wrapper-failed`** — driver exited non-zero (`wrapper_exit_code`), authoritative even if the status column never advanced.
- **`ended-no-log`** — terminal but the wrapper never uploaded `.nextflow.log` → driver/allocation hard-killed (OOM / scancel / node failure) before its exit handler ran.

**Detail** also returns per-run **task-status counts** (an all-ABORTED, zero-FAILED run = driver death, not a pipeline bug) and `nextflow_log` / `wrapper_output_log` availability.

**Frontend** — new **Runs** page: table with classification badges + needs-attention KPI, and a per-run drawer (task-status counts, lifecycle timestamps, slurm state, exit code, log availability). Calls out the all-ABORTED/zero-FAILED case inline.

## Tests
6 integration tests (real Postgres): list includes classification; wrapper-failed; ended-no-log; 404. mypy clean; frontend builds clean.

## Notes
Independent of the dispatchability PR (#104); both append to `types.ts` so whichever merges second needs a trivial conflict resolve.

## Deploy
Server redeploy + frontend container rebuild on onclappc02.

🤖 Generated with [Claude Code](https://claude.com/claude-code)