### PR TITLE
fix(nf-client): keep daemon alive when the API is unreachable

### DIFF
--- a/packages/nf_client/src/nf_client/cli.py
+++ b/packages/nf_client/src/nf_client/cli.py
@@ -224,6 +224,13 @@ def daemon(
     hostname = socket.gethostname()
     agent_id = hostname
 
+    def _safe_heartbeat(cfg: ClientConfig, active: int, status: str) -> None:
+        """Heartbeat is observability only — never let it crash or stall the loop."""
+        try:
+            asyncio.run(_heartbeat(cfg, agent_id, active, status))
+        except Exception as e:
+            typer.echo(f"  WARN: heartbeat failed (API unreachable?): {e}", err=True)
+
     typer.echo(
         f"Daemon started — mode={cfg.submission.mode} batch_size={batch_size if batch_size > 0 else cfg.dispatch.batch_size}"
         + (f" max_concurrent_runs={cfg.submission.max_concurrent_runs}" if cfg.submission.max_concurrent_runs else "")
@@ -248,15 +255,22 @@ def daemon(
             active = _count_active_slurm_jobs()
             if active >= max_concurrent:
                 typer.echo(f"  {active} SLURM jobs active (limit {max_concurrent}) — waiting {poll_interval}s")
-                asyncio.run(_heartbeat(cfg, agent_id, active, "running"))
+                _safe_heartbeat(cfg, active, "running")
                 time.sleep(poll_interval)
                 continue
         else:
             active = 0
 
-        asyncio.run(_heartbeat(cfg, agent_id, active, "running" if active > 0 else "idle"))
+        _safe_heartbeat(cfg, active, "running" if active > 0 else "idle")
 
-        batch = asyncio.run(_fetch(cfg, effective_batch_size))
+        # The API being unreachable (server restart, network blip) must not kill
+        # the daemon — warn, back off, and retry on the next poll.
+        try:
+            batch = asyncio.run(_fetch(cfg, effective_batch_size))
+        except Exception as e:
+            typer.echo(f"  WARN: failed to reach API for next batch, retrying in {poll_interval}s: {e}", err=True)
+            time.sleep(poll_interval)
+            continue
 
         if batch is None:
             if run_continuous:

--- a/packages/nf_client/tests/test_client.py
+++ b/packages/nf_client/tests/test_client.py
@@ -50,7 +50,7 @@ def config() -> ClientConfig:
 
 def test_config_from_dict(config: ClientConfig):
     assert config.server_url == "http://test.local"
-    assert config.dispatch.workflow_id == "curatedMetagenomics"
+    assert config.dispatch.workflow_id == ["curatedMetagenomics"]  # coerced str → list
     assert config.dispatch.batch_size == 50
 
 
@@ -162,3 +162,35 @@ def test_render_submission_script_raises_on_missing_var(tmp_path: Path):
     template.write_text("{{ missing_var }}")
     with pytest.raises(UndefinedError):
         render_submission_script(template, {})
+
+
+# ---------------------------------------------------------------------------
+# Daemon resilience: an unreachable API must not crash the loop
+# ---------------------------------------------------------------------------
+
+def test_daemon_survives_unreachable_api(tmp_path: Path):
+    """A failed batch fetch (server restart / network blip) must be caught and
+    retried on the next poll, not propagate and kill the daemon."""
+    from nf_client import cli
+
+    cfg_file = tmp_path / "client.yaml"
+    cfg_file.write_text(textwrap.dedent("""\
+        server_url: http://test.local
+        weblog_url: http://test.local/telemetry
+        continuous: false
+        dispatch:
+          batch_size: 2
+          workflow_id: wf
+        submission:
+          mode: local
+    """))
+
+    with respx.mock(assert_all_called=False) as mock:
+        # Heartbeat unreachable — must be swallowed.
+        mock.put("http://test.local/daemons/heartbeat").mock(side_effect=httpx.ConnectError("down"))
+        # First fetch errors (API down), second returns 204 (no pending work).
+        mock.post("http://test.local/dispatch/batch").mock(
+            side_effect=[httpx.ConnectError("down"), httpx.Response(204)]
+        )
+        # Must return cleanly after recovery, not raise.
+        cli.daemon(config=cfg_file, batch_size=0, poll_interval=0.0, continuous=False)


### PR DESCRIPTION
## Why
If the telemetry API was down during a batch fetch (server restart, network blip), `fetch_next_batch`'s error propagated out of the daemon loop and **killed the process** — leaving pending jobs unclaimed until someone noticed and restarted the daemon. (Exactly the failure mode behind the stuck-pending incident.)

## Fix
- **Wrap the batch fetch**: on failure → warn, sleep one poll interval, retry next iteration. The loop's existing poll cadence *is* the retry.
- **Best-effort heartbeat** via `_safe_heartbeat` at the call site. (`post_heartbeat` already swallows at the client layer; this also guards payload-build/`asyncio.run` errors.)

Net: the daemon rides through restarts and intermittent network problems instead of dying.

## Tests
- `test_daemon_survives_unreachable_api` — `dispatch/batch` errors once then returns 204; the daemon recovers and exits cleanly instead of raising (respx-mocked).
- Drive-by: fixed a pre-existing stale assertion in `test_config_from_dict` (`workflow_id` is now a coerced `list`). Full client suite green (11 passed).

## Scope
nf-client only. No server change. Deploy = update nf-client on the cluster daemons (the resilience helps most exactly when the *server* is restarting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)