### PR TITLE
docs(adr): establish ADR practice + seed 0000-0003

### DIFF
--- a/docs/adr/0000-record-architecture-decisions.md
+++ b/docs/adr/0000-record-architecture-decisions.md
@@ -1,0 +1,53 @@
+# 0000. Record architecture decisions
+
+- **Status:** Accepted
+- **Date:** 2026-06-04
+- **Deciders:** Sean Davis
+
+## Context
+
+The telemetry/orchestration backend has accumulated significant, non-obvious
+decisions — why orchestration is pull-mode, why the `/telemetry` weblog endpoint
+is unauthenticated, why SQLAlchemy Core is used instead of an ORM, how run
+death is classified. Until now these lived in `CLAUDE.md`, code comments, GitHub
+issues, and PR threads. That makes them hard to find, easy to lose when an issue
+is closed, and impossible to grep. Contributors (human or agent) repeatedly
+re-derive or unknowingly contradict earlier reasoning.
+
+The sibling pipeline repo (`curatedMetagenomicsNextflow`) already records
+decisions this way; aligning the two keeps a single mental model across the
+system.
+
+## Decision
+
+We will record architecturally significant decisions as **Architecture Decision
+Records (ADRs)** stored in `docs/adr/`, using a lightweight Nygard-style format
+(context / decision / alternatives / consequences). The process and index live
+in `docs/adr/README.md`. ADRs are immutable once accepted; a changed decision is
+captured by a new ADR that supersedes the old one.
+
+## Alternatives considered
+
+- **Keep decisions in `CLAUDE.md` / issues / PRs** — the status quo. Rejected:
+  `CLAUDE.md` is operational guidance, not a decision log; issues and PRs are not
+  discoverable or versioned with the code, and are lost when closed or moved.
+- **A single `DECISIONS.md` log** — simpler, but grows into an unsearchable wall
+  of text with no stable per-decision anchor to link to.
+- **A heavier ADR tool** — more structure than this project needs; the format
+  can grow later if warranted.
+
+## Consequences
+
+- Each substantive decision gets a durable, linkable home that travels with the
+  code and shows up in `git blame`/`grep`.
+- Small added ceremony, scoped to decisions that are hard to reverse or
+  non-obvious.
+- The initial set is seeded from recent decisions (0001–0003); other existing
+  decisions (unauthenticated weblog, Core-over-ORM, the job lifecycle) can be
+  backfilled as they are touched.
+
+## References
+
+- Michael Nygard, "Documenting Architecture Decisions" (2011).
+- `docs/adr/README.md` for the process and index.
+- The sibling practice in `curatedMetagenomicsNextflow/docs/adr/`.

--- a/docs/adr/0001-pull-mode-orchestration.md
+++ b/docs/adr/0001-pull-mode-orchestration.md
@@ -1,0 +1,61 @@
+# 0001. Pull-mode HPC orchestration
+
+- **Status:** Accepted
+- **Date:** 2026-06-04
+- **Deciders:** Sean Davis
+
+## Context
+
+The backend dispatches Nextflow work to multiple HPC clusters (Alpine, Anvil,
+and future sites) that we do not administer. Two integration shapes are
+possible:
+
+- **Push** — an orchestrator on our host (`onclappc02`) SSHes out to each
+  cluster's login node to submit and monitor jobs.
+- **Pull** — a long-running `nf-client` daemon on each cluster's login node
+  initiates outbound HTTPS to the API, claims batches, and reports status.
+
+Constraints in tension:
+
+- The campus firewall **blocks outbound TCP/22 from `onclappc02`** (SYNs are
+  silently dropped), so push-mode SSH does not work without a firewall
+  exception. ICMP and HTTPS egress are clean.
+- The available SSH workaround (ProxyJump through a PHI/HIPAA host) inverts the
+  trust boundary — using a more-sensitive host as an egress proxy for
+  less-sensitive research workloads is a security smell.
+- ACCESS clusters allow outbound HTTPS from login nodes and tolerate a small
+  long-lived poller there.
+
+## Decision
+
+We will use **pull-mode**: an `nf-client` daemon runs on each cluster's login
+node and initiates outbound HTTPS to the API (`/dispatch/batch`,
+`/dispatch/submitted`, `/runs/.../event`, `/daemons/heartbeat`). The server is
+never required to initiate a connection into a cluster. Push-mode remains
+documented in `docs/orchestrator-architecture.md` as a deferred option, gated on
+a firewall exception being granted.
+
+## Alternatives considered
+
+- **Push-mode (orchestrator SSHes out)** — rejected as the default: blocked by
+  the outbound-22 firewall rule, and the ProxyJump workaround is a trust-boundary
+  violation. Reconsider only if a scoped firewall exception is granted.
+- **A managed workflow service per site** — far more integration surface than a
+  single config-driven daemon; not justified for the current set of clusters.
+
+## Consequences
+
+- Works across heterogeneous network postures: the daemon only needs outbound
+  HTTPS, which every site already permits. Firewall-friendly by construction.
+- The cluster-side daemon is now a critical, mostly-invisible component. Its
+  health must be observable (heartbeats; see [0003](0003-dispatchability-detection.md))
+  and it must tolerate API outages without dying (nf-client #106).
+- Per-cluster credentials/config live on the cluster, not centrally.
+- Adding a cluster means standing up a daemon there, not opening inbound access.
+
+## References
+
+- `docs/orchestrator-architecture.md` (push-mode deferred design + prerequisites).
+- `packages/nf_client/` (the daemon).
+- Network constraint: outbound TCP/22 blocked from `onclappc02`
+  (same family as the UDP/53 block in monode `NETWORK_CONSTRAINTS.md`).

--- a/docs/adr/0002-run-death-classification.md
+++ b/docs/adr/0002-run-death-classification.md
@@ -1,0 +1,63 @@
+# 0002. Run death classification
+
+- **Status:** Accepted
+- **Date:** 2026-06-04
+- **Deciders:** Sean Davis
+
+## Context
+
+When a Nextflow run dies, the raw signals are ambiguous. A driver (the
+`nf-client` wrapper sbatch job running the Nextflow process) that is hard-killed
+— OOM, `scancel`, node failure, or its own wall-time — cancels all in-flight
+task jobs. Those tasks surface as `ABORTED` with **zero `FAILED`**, and the
+wrapper never gets to upload its `.nextflow.log`. From the telemetry alone this
+is indistinguishable from a healthy run at a glance, and diagnosing it meant
+SSHing to the cluster and running `sacct` by hand.
+
+The `workflow_runs` table already records the signals needed to disambiguate:
+`status`, `wrapper_exit_code`, `last_heartbeat_at`, and
+`nextflow_log_uploaded_at`. They were just not interpreted anywhere.
+
+## Decision
+
+We will derive a single **`classification`** for each run from its
+`workflow_runs` columns and expose it on `GET /runs/` and `GET /runs/{name}`.
+The values and their precedence:
+
+- **`wrapper-failed`** — `wrapper_exit_code` is non-zero (authoritative even if
+  `status` never advanced; the driver itself failed).
+- **`stalled`** — non-terminal status but no heartbeat for > 15 min.
+- **`active`** — non-terminal with a recent heartbeat.
+- **`ended-no-log`** — terminal but no `.nextflow.log` was ever uploaded: the
+  signature of a driver/allocation hard-kill before its exit handler ran.
+- **`completed` / `failed` / `expired`** — otherwise, mirroring `status`.
+
+The run detail endpoint also returns per-run task-status counts, so an
+all-`ABORTED`/zero-`FAILED` run is visibly a driver death, not a pipeline bug.
+
+## Alternatives considered
+
+- **Expose raw `status` only** — the status quo. Rejected: it cannot express
+  "terminal but the driver was killed", which is the case that actually cost
+  debugging time.
+- **Compute the classification client-side in the frontend** — rejected: the
+  rule should be one authoritative definition usable by any consumer (UI, alerts,
+  scripts), not duplicated per client.
+- **Infer death purely from task ABORTED/FAILED counts** — rejected as the
+  primary signal: it requires scanning telemetry events and misses runs that
+  died before emitting any, whereas `workflow_runs` columns are always present.
+
+## Consequences
+
+- The two driver-death shapes (`wrapper-failed`, `ended-no-log`) are now visible
+  in the app, pointing the operator at SLURM instead of leaving them to guess.
+- The classification is a derived view, not stored — it always reflects current
+  columns and needs no migration, but it is only as good as those columns
+  (a run that never reports a heartbeat or exit code leans on `ended-no-log`).
+- The 15-minute stall threshold is a heuristic that may need per-site tuning.
+
+## References
+
+- `src/nextflow_telemetry/routers/runs.py` (`_classify_run`, `GET /runs`).
+- seandavi/nextflow_telemetry#105 (implementation + Runs page).
+- Related pipeline-side policy: `curatedMetagenomicsNextflow` ADR-0009.

--- a/docs/adr/0003-dispatchability-detection.md
+++ b/docs/adr/0003-dispatchability-detection.md
@@ -1,0 +1,56 @@
+# 0003. Dispatchability detection (pending work with no active daemon)
+
+- **Status:** Accepted
+- **Date:** 2026-06-04
+- **Deciders:** Sean Davis
+
+## Context
+
+In pull-mode ([0001](0001-pull-mode-orchestration.md)), pending jobs are only
+worked if an active daemon claims them. A daemon can be absent for ordinary
+reasons — it was stopped, it crashed, or its `workflow_id` claim filter does not
+include the workflow that has pending work. When that happens, jobs sit in
+`pending` indefinitely while every individual subsystem looks healthy. This
+exact situation was misread as a reconciliation bug and cost an hour: reconcile
+correctly created the jobs, but nothing was claiming them because the cluster
+daemon had stopped heartbeating.
+
+The pieces to detect it already exist: pending counts per active workflow, and
+daemon heartbeats with their claim filters (a daemon is "active" if seen within
+the last 2 minutes; its `workflow_id` is a comma list, or empty = claims any).
+
+## Decision
+
+We will add `GET /admin/dispatchability`, which joins pending jobs on **active**
+workflows against **active** daemons and their claim filters, and returns the
+workflows that have pending work no active daemon will claim. The Overview page
+shows a banner when this set is non-empty. This is the first-class answer to
+"why isn't anything running?".
+
+## Alternatives considered
+
+- **Rely on the daemon list page** — the staleness was already shown there, yet
+  still missed because it required knowing to look and cross-referencing against
+  pending work. Rejected as insufficient: the signal must be pushed to the
+  Overview, pre-correlated with pending jobs.
+- **Alert purely on daemon staleness** — rejected: a stale daemon with no
+  pending work for it is not a problem; the actionable condition is pending work
+  *and* no claimant. Correlating the two removes false alarms.
+- **Block/winddown on the condition** — rejected: detection and surfacing is
+  enough; the operator decides whether to restart a daemon or adjust filters.
+
+## Consequences
+
+- Stuck-pending situations surface immediately and in plain language, instead of
+  presenting as a phantom reconcile/dispatch bug.
+- The check is computed on demand from current rows; no new state, no migration.
+- It depends on the 2-minute daemon-active threshold staying in sync with the
+  daemons router (a shared constant / documented coupling).
+- It only flags *active* workflows; pending jobs on retired/paused workflows are
+  intentionally ignored (they are not meant to run).
+
+## References
+
+- `src/nextflow_telemetry/routers/admin.py` (`GET /admin/dispatchability`).
+- seandavi/nextflow_telemetry#104 (implementation + Overview banner).
+- [0001](0001-pull-mode-orchestration.md) (why daemon liveness is load-bearing).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,54 @@
+# Architecture Decision Records
+
+This directory holds **Architecture Decision Records (ADRs)** — short documents
+that capture a single significant decision: the context that forced it, the
+choice we made, the alternatives we rejected, and the consequences we accept.
+
+We use ADRs because decisions were previously scattered across `CLAUDE.md`, code
+comments, GitHub issues, and PR threads, where they are hard to find and easy to
+lose. An ADR is the durable, greppable home for *why* the backend is shaped the
+way it is. The sibling pipeline repo (`curatedMetagenomicsNextflow`) uses the
+same practice.
+
+## When to write one
+
+Write an ADR when a decision:
+
+- is hard or expensive to reverse (e.g. orchestration model, auth posture, the
+  job lifecycle), or
+- has non-obvious rationale that a future maintainer would otherwise have to
+  reconstruct, or
+- was contested — there were real alternatives with real trade-offs.
+
+Do **not** write one for routine, easily-reversible changes (a bug fix, a
+dependency bump, a rename). Those belong in the commit message.
+
+## How to write one
+
+1. Copy [`template.md`](template.md) to `NNNN-short-title.md`, where `NNNN` is
+   the next zero-padded number in sequence.
+2. Fill it in. Keep it short — one decision, one page.
+3. Set the status (see below).
+4. Add a row to the index below.
+5. Commit it alongside the change it documents where possible.
+
+ADRs are immutable once `Accepted`. To change a decision, write a **new** ADR
+that supersedes the old one, and update both `Status` lines to point at each
+other. This preserves the historical record rather than rewriting it.
+
+## Status values
+
+- **Proposed** — under discussion, not yet acted on.
+- **Accepted** — the decision is in force.
+- **Accepted (not yet implemented)** — agreed, but the code does not exist yet.
+- **Superseded by [NNNN](NNNN-...md)** — replaced by a later decision.
+- **Deprecated** — no longer relevant, but kept for the record.
+
+## Index
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0000](0000-record-architecture-decisions.md) | Record architecture decisions | Accepted |
+| [0001](0001-pull-mode-orchestration.md) | Pull-mode HPC orchestration | Accepted |
+| [0002](0002-run-death-classification.md) | Run death classification | Accepted |
+| [0003](0003-dispatchability-detection.md) | Dispatchability detection (pending work with no active daemon) | Accepted |

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,29 @@
+# NNNN. Short title in the imperative
+
+- **Status:** Proposed | Accepted | Accepted (not yet implemented) | Superseded by [NNNN](NNNN-...md) | Deprecated
+- **Date:** YYYY-MM-DD
+- **Deciders:** names
+
+## Context
+
+What is the situation that forces a decision? Capture the constraints, the
+forces in tension, and any relevant history. State facts, not the choice.
+
+## Decision
+
+The choice we are making, stated plainly. "We will …".
+
+## Alternatives considered
+
+- **Option A** — why we rejected it.
+- **Option B** — why we rejected it.
+
+## Consequences
+
+What becomes easier, harder, or constrained as a result. Include the costs we
+are knowingly accepting and any follow-up work this creates.
+
+## References
+
+Links to the issue, PR, commit, or external docs that motivated or implement
+this decision.


### PR DESCRIPTION
## Summary
Establishes an ADR practice for the telemetry backend (the pipeline repo already has one) and seeds it with the foundational + recent decisions.

## Contents
- `docs/adr/README.md` — process + index
- `docs/adr/template.md`, `0000-record-architecture-decisions.md` — the practice itself
- **0001 Pull-mode HPC orchestration** — daemons pull via outbound HTTPS; push-mode blocked by the outbound-22 firewall (foundational)
- **0002 Run death classification** — `wrapper-failed` / `ended-no-log` / `stalled` derived from `workflow_runs` (PR #105)
- **0003 Dispatchability detection** — pending work with no active daemon (PR #104)

Docs only — no code change. Other existing decisions (unauthenticated weblog, Core-over-ORM, job lifecycle) can be backfilled as they're touched.
🤖 Generated with [Claude Code](https://claude.com/claude-code)