### PR TITLE
feat(templates): run cluster nextflow under run_wrapper

### DIFF
--- a/packages/nf_client/client-example.yaml
+++ b/packages/nf_client/client-example.yaml
@@ -63,3 +63,8 @@ submission:
     nxf_home: "/scratch/myuser/nxf_home"
     nextflow_bin: "nextflow"                          # or absolute path if not on PATH
     google_credentials: "/home/myuser/gcp-key.json"  # omit if not using GCS
+    # Shell snippet run inside the submit job to make nf_client importable on
+    # the compute node, so run_wrapper can emit lifecycle telemetry and upload
+    # .nextflow.log. Point it at the daemon's environment. Required for the
+    # run_wrapper-based templates (submit_alpine / submit_anvil / submit_example).
+    client_env_setup: "source /scratch/myuser/nf_client/venv/bin/activate"

--- a/templates/submit_alpine.sh.j2
+++ b/templates/submit_alpine.sh.j2
@@ -36,14 +36,30 @@ cat << 'METATSV' > metadata.tsv
 {{ metadata_tsv_content }}
 METATSV
 
-nextflow run {{ workflow_repository }} \
-  -name {{ run_name }} \
-  -revision {{ workflow_revision }} \
-  -profile {{ profile }} \
-  -c nextflow_alpine_override.config \
-  --metadata_tsv metadata.tsv \
-  --run_name {{ run_name }} \
-  -with-weblog {{ weblog_url }}
+# Make nf_client importable on this compute node so run_wrapper can run.
+# Set submission.defaults.client_env_setup in the client config to whatever
+# activates the daemon's environment here (e.g. "source /projects/.../venv/bin/activate"
+# or a module load). Without it, `python -m nf_client.run_wrapper` will not be
+# found and the run will fail before nextflow starts.
+{{ client_env_setup | default('') }}
+
+# Wrap nextflow in run_wrapper: it emits run-lifecycle telemetry
+# (wrapper_started / heartbeat / wrapper_exited) and uploads .nextflow.log to
+# the server on exit, so driver-level deaths are visible server-side instead of
+# only in a log file on this node. Telemetry failures are swallowed; the wrapper
+# propagates nextflow's exit code.
+python -m nf_client.run_wrapper \
+  --run-name {{ run_name }} \
+  --telemetry-url {{ server_url }} \
+  -- \
+  nextflow run {{ workflow_repository }} \
+    -name {{ run_name }} \
+    -revision {{ workflow_revision }} \
+    -profile {{ profile }} \
+    -c nextflow_alpine_override.config \
+    --metadata_tsv metadata.tsv \
+    --run_name {{ run_name }} \
+    -with-weblog {{ weblog_url }}
 
 NF_EXIT=$?
 echo "Nextflow exited with code $NF_EXIT"

--- a/templates/submit_anvil.sh.j2
+++ b/templates/submit_anvil.sh.j2
@@ -37,14 +37,30 @@ cat << 'METATSV' > metadata.tsv
 {{ metadata_tsv_content }}
 METATSV
 
-$NEXTFLOW run {{ workflow_repository }} \
-  -name {{ run_name }} \
-  -revision {{ workflow_revision }} \
-  -profile anvil \
-  -c nextflow_anvil_override.config \
-  --metadata_tsv metadata.tsv \
-  --run_name {{ run_name }} \
-  -with-weblog {{ weblog_url }}
+# Make nf_client importable on this compute node so run_wrapper can run.
+# Set submission.defaults.client_env_setup in the client config to whatever
+# activates the daemon's environment here (e.g. "source /anvil/.../venv/bin/activate"
+# or a module load). Without it, `python -m nf_client.run_wrapper` will not be
+# found and the run will fail before nextflow starts.
+{{ client_env_setup | default('') }}
+
+# Wrap nextflow in run_wrapper: it emits run-lifecycle telemetry
+# (wrapper_started / heartbeat / wrapper_exited) and uploads .nextflow.log to
+# the server on exit, so driver-level deaths are visible server-side instead of
+# only in a log file on this node. Telemetry failures are swallowed; the wrapper
+# propagates nextflow's exit code.
+python -m nf_client.run_wrapper \
+  --run-name {{ run_name }} \
+  --telemetry-url {{ server_url }} \
+  -- \
+  $NEXTFLOW run {{ workflow_repository }} \
+    -name {{ run_name }} \
+    -revision {{ workflow_revision }} \
+    -profile anvil \
+    -c nextflow_anvil_override.config \
+    --metadata_tsv metadata.tsv \
+    --run_name {{ run_name }} \
+    -with-weblog {{ weblog_url }}
 
 NF_EXIT=$?
 echo "Nextflow exited with code $NF_EXIT"


### PR DESCRIPTION
## Summary
`submit_alpine` / `submit_anvil` ran nextflow directly → no `.nextflow.log` upload, no heartbeats, no `wrapper_exit_code`. That's the blindness behind the recent debugging: every Alpine run classifies `ended-no-log`, and root-causing needs SSH + `sacct`.

This wraps nextflow in `python -m nf_client.run_wrapper` in **both** cluster templates, keeping all cluster-specific setup (module loads, scratch workdir, SLURM executor override, `--metadata_tsv`, the close-run sweep). The wrapper emits lifecycle telemetry, uploads `.nextflow.log` on exit, and propagates nextflow's exit code.

Verified: both templates parse + render under StrictUndefined; nextflow is correctly nested under the wrapper; the env hook renders (and is blank-safe when omitted).

## ⚠ Deploy prerequisite — do not deploy without this
`run_wrapper` must be **importable on the compute node** where the driver sbatch job runs. The current templates only `module load nextflow` — no python env. Added a templated hook:
```
{{ client_env_setup | default('') }}
```
Set `submission.defaults.client_env_setup` in each cluster's client config to activate the daemon's environment, e.g. `source /projects/seda0001_amc/nf_client/venv/bin/activate`, **on a filesystem the compute nodes can read**. If unset, `python -m nf_client.run_wrapper` won't be found and runs will fail before nextflow starts.

So the rollout is: set `client_env_setup` in `client-alpine.yaml` / `client-anvil.yaml` → pull the template on the cluster → next runs report lifecycle + upload logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)