### PR TITLE
feat(nf-client): run-wrapper as a subcommand (uv-tool friendly)

### DIFF
--- a/packages/nf_client/client-example.yaml
+++ b/packages/nf_client/client-example.yaml
@@ -63,8 +63,9 @@ submission:
     nxf_home: "/scratch/myuser/nxf_home"
     nextflow_bin: "nextflow"                          # or absolute path if not on PATH
     google_credentials: "/home/myuser/gcp-key.json"  # omit if not using GCS
-    # Shell snippet run inside the submit job to make nf_client importable on
-    # the compute node, so run_wrapper can emit lifecycle telemetry and upload
-    # .nextflow.log. Point it at the daemon's environment. Required for the
-    # run_wrapper-based templates (submit_alpine / submit_anvil / submit_example).
-    client_env_setup: "source /scratch/myuser/nf_client/venv/bin/activate"
+    # Shell snippet run inside the submit job to put the `nf-client` executable
+    # on PATH, so `nf-client run-wrapper` resolves on the compute node (it emits
+    # lifecycle telemetry and uploads .nextflow.log). With `uv tool install`,
+    # nf-client lives in ~/.local/bin. Required for the run_wrapper-based
+    # templates (submit_alpine / submit_anvil / submit_example).
+    client_env_setup: "export PATH=$HOME/.local/bin:$PATH"

--- a/packages/nf_client/src/nf_client/cli.py
+++ b/packages/nf_client/src/nf_client/cli.py
@@ -483,3 +483,36 @@ def upload_logs(
 
     asyncio.run(_upload_all())
     typer.echo(f"Done — uploaded: {uploaded}, skipped (too large): {skipped}, errors: {errors}")
+
+
+@app.command(
+    name="run-wrapper",
+    context_settings={"ignore_unknown_options": True, "allow_extra_args": True},
+    help=(
+        "Wrap a `nextflow run` command with run-lifecycle telemetry "
+        "(wrapper_started / heartbeat / wrapper_exited, and .nextflow.log upload). "
+        "Put the nextflow command after `--`, e.g.:\n\n"
+        "  nf-client run-wrapper --run-name R --telemetry-url URL -- nextflow run repo ..."
+    ),
+)
+def run_wrapper_cmd(
+    ctx: typer.Context,
+    run_name: str = typer.Option(..., "--run-name", help="Nextflow run name (-name)."),
+    telemetry_url: str = typer.Option(..., "--telemetry-url", help="Telemetry API base URL (same as ClientConfig.server_url)."),
+    heartbeat_seconds: float | None = typer.Option(None, "--heartbeat-seconds", help="Heartbeat interval in seconds; 0 disables. Omit for the default."),
+    nextflow_log: Path | None = typer.Option(None, "--nextflow-log", help="Path to .nextflow.log to upload on exit (default: cwd/.nextflow.log)."),
+) -> None:
+    """Thin front-end that delegates to run_wrapper.main, so the exec / signal-
+    forwarding / stream-capture machinery lives in exactly one place."""
+    from . import run_wrapper as _rw
+
+    argv: list[str] = ["--run-name", run_name, "--telemetry-url", telemetry_url]
+    if heartbeat_seconds is not None:
+        argv += ["--heartbeat-seconds", str(heartbeat_seconds)]
+    if nextflow_log is not None:
+        argv += ["--nextflow-log", str(nextflow_log)]
+    # Everything after the typer options (the nextflow command) lands in
+    # ctx.args. Re-insert `--` so argparse treats single-dash nextflow flags
+    # (-revision, -name, -profile, ...) as the positional command, not options.
+    argv += ["--", *ctx.args]
+    raise typer.Exit(_rw.main(argv))

--- a/packages/nf_client/tests/test_client.py
+++ b/packages/nf_client/tests/test_client.py
@@ -194,3 +194,20 @@ def test_daemon_survives_unreachable_api(tmp_path: Path):
         )
         # Must return cleanly after recovery, not raise.
         cli.daemon(config=cfg_file, batch_size=0, poll_interval=0.0, continuous=False)
+
+
+def test_run_wrapper_subcommand_propagates_exit_code():
+    """`nf-client run-wrapper -- <cmd>` execs the trailing command (single-dash
+    flags passed through) and returns its exit code; unreachable telemetry is
+    swallowed."""
+    from typer.testing import CliRunner
+    from nf_client.cli import app
+
+    runner = CliRunner()
+    U = "http://127.0.0.1:9/api"   # unreachable → telemetry no-op
+
+    ok = runner.invoke(app, ["run-wrapper", "--run-name", "t", "--telemetry-url", U, "--", "true"])
+    assert ok.exit_code == 0
+
+    fail = runner.invoke(app, ["run-wrapper", "--run-name", "t", "--telemetry-url", U, "--", "bash", "-c", "exit 3"])
+    assert fail.exit_code == 3

--- a/templates/submit_alpine.sh.j2
+++ b/templates/submit_alpine.sh.j2
@@ -36,11 +36,11 @@ cat << 'METATSV' > metadata.tsv
 {{ metadata_tsv_content }}
 METATSV
 
-# Make nf_client importable on this compute node so run_wrapper can run.
-# Set submission.defaults.client_env_setup in the client config to whatever
-# activates the daemon's environment here (e.g. "source /projects/.../venv/bin/activate"
-# or a module load). Without it, `python -m nf_client.run_wrapper` will not be
-# found and the run will fail before nextflow starts.
+# Put the nf-client executable on PATH for this job so `nf-client run-wrapper`
+# resolves. With `uv tool install`, nf-client lands in ~/.local/bin — set
+# submission.defaults.client_env_setup to e.g. "export PATH=$HOME/.local/bin:$PATH".
+# Without it the run_wrapper call below is not found and the run fails before
+# nextflow starts.
 {{ client_env_setup | default('') }}
 
 # Wrap nextflow in run_wrapper: it emits run-lifecycle telemetry
@@ -48,7 +48,7 @@ METATSV
 # the server on exit, so driver-level deaths are visible server-side instead of
 # only in a log file on this node. Telemetry failures are swallowed; the wrapper
 # propagates nextflow's exit code.
-python -m nf_client.run_wrapper \
+nf-client run-wrapper \
   --run-name {{ run_name }} \
   --telemetry-url {{ server_url }} \
   -- \

--- a/templates/submit_anvil.sh.j2
+++ b/templates/submit_anvil.sh.j2
@@ -37,11 +37,11 @@ cat << 'METATSV' > metadata.tsv
 {{ metadata_tsv_content }}
 METATSV
 
-# Make nf_client importable on this compute node so run_wrapper can run.
-# Set submission.defaults.client_env_setup in the client config to whatever
-# activates the daemon's environment here (e.g. "source /anvil/.../venv/bin/activate"
-# or a module load). Without it, `python -m nf_client.run_wrapper` will not be
-# found and the run will fail before nextflow starts.
+# Put the nf-client executable on PATH for this job so `nf-client run-wrapper`
+# resolves. With `uv tool install`, nf-client lands in ~/.local/bin — set
+# submission.defaults.client_env_setup to e.g. "export PATH=$HOME/.local/bin:$PATH".
+# Without it the run_wrapper call below is not found and the run fails before
+# nextflow starts.
 {{ client_env_setup | default('') }}
 
 # Wrap nextflow in run_wrapper: it emits run-lifecycle telemetry
@@ -49,7 +49,7 @@ METATSV
 # the server on exit, so driver-level deaths are visible server-side instead of
 # only in a log file on this node. Telemetry failures are swallowed; the wrapper
 # propagates nextflow's exit code.
-python -m nf_client.run_wrapper \
+nf-client run-wrapper \
   --run-name {{ run_name }} \
   --telemetry-url {{ server_url }} \
   -- \

--- a/templates/submit_example.sh.j2
+++ b/templates/submit_example.sh.j2
@@ -11,13 +11,14 @@ set -euo pipefail
 echo "Starting Nextflow run {{ run_name }} at $(date -u)"
 echo "Samples: {{ sample_ids }}"
 
-# nf_client.run_wrapper instruments the nextflow run with run-lifecycle
+# `nf-client run-wrapper` instruments the nextflow run with run-lifecycle
 # events (wrapper_started, pre_nextflow, heartbeat, wrapper_exited) and
 # uploads .nextflow.log on exit. Telemetry failures are swallowed inside
 # the wrapper — they never fail the run. The wrapper exits with
 # nextflow's exit code, which we propagate below.
+# Requires nf-client on PATH (e.g. `uv tool install` → ~/.local/bin).
 set +e
-python -m nf_client.run_wrapper \
+nf-client run-wrapper \
   --run-name {{ run_name }} \
   --telemetry-url {{ server_url }} \
   -- \


### PR DESCRIPTION
## Why
`run_wrapper` was only callable as `python -m nf_client.run_wrapper`, which needs a matching python on PATH **inside the SLURM job** — but the cluster default is python 2.7, and `uv tool install` exposes the `nf-client` executable, not a python. So the wrapper couldn't run from a uv-tool install (the direction we're moving for portability).

## What
- **`nf-client run-wrapper`** — a thin typer subcommand that delegates to the existing `run_wrapper.main(argv)`. No change to the exec / signal-forwarding / stream-capture internals. Uses `ignore_unknown_options` + a re-inserted `--` so the trailing nextflow command (single-dash flags and all) passes through untouched; propagates the child exit code.
- **Templates** (alpine/anvil/example): `python -m nf_client.run_wrapper` → `nf-client run-wrapper`.
- **client-example.yaml**: `client_env_setup` is now just "put nf-client on PATH" (`export PATH=$HOME/.local/bin:$PATH` for a `uv tool install`) instead of activating a venv.
- **Test**: passthrough + exit-code propagation (`-- true` → 0, `-- bash -c 'exit 3'` → 3). Full client suite green (12).

Benefits: one executable, unified `nf-client --help`, works cleanly with `uv tool install` (no venv, no python-on-PATH), room for more subcommands.

## Deploy (Alpine/Anvil)
1. Pull repo on the cluster, then `uv tool install --reinstall <repo>/packages/nf_client` (picks up the new subcommand).
2. Set `submission.defaults.client_env_setup: "export PATH=$HOME/.local/bin:$PATH"` in `client-alpine.yaml` / `client-anvil.yaml` (replaces the venv-activate). The empty `.venv` is no longer needed.
3. Templates are pulled with the repo. Next runs call `nf-client run-wrapper`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)