### PR TITLE
docs(skills): operational runbook skills under .claude/skills/

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,19 @@
+# Skills
+
+Checked-in Claude Code skills for the cmgd Nextflow telemetry system. Each is a
+folder with a `SKILL.md` (model-triggered by its `description`) and optional
+`scripts/`. They encode the hard-won, non-obvious operational knowledge of this
+system — the stuff that isn't derivable from the code.
+
+| Skill | Use it when |
+|---|---|
+| `telemetry-api` | Querying the backend (job-summary, runs, dispatchability, reconcile). Shared base for the others. |
+| `cmgd-triage` | A run failed / is stuck / has no logs; DLQ; "lots of failures". Classification → root cause → right log. |
+| `cmgd-release` | Cutting + rolling out a new pipeline version (manifest/tag/registry lockstep, retire, reconcile). |
+| `alpine-daemon` | Deploy/restart/health-check the nf-client daemon on an HPC login node. |
+| `cmgd-config` | "Where is X configured / how do I change it?" — the config-location index. |
+| `gcs-verify` | Confirm + locate pipeline outputs in GCS (`rclone gs1:`). |
+| `adr-author` | Recording a behavior-affecting architecture decision (`docs/adr/`). |
+
+Skills reference each other by name (e.g. `cmgd-triage` builds on `telemetry-api`).
+Keep the **Gotchas** sections current — they are the highest-value part.

--- a/.claude/skills/adr-author/SKILL.md
+++ b/.claude/skills/adr-author/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: adr-author
+description: >
+  Write a new Architecture Decision Record in the cmgd / telemetry repos,
+  following the established Nygard format and conventions. Use when a non-trivial,
+  behavior-affecting decision is made (retry policy, storage layout, profile
+  semantics, framework choice) and should be recorded, or the user says "write an
+  ADR" / "record this decision". Trigger words: ADR, architecture decision,
+  record decision, document the decision, why did we choose, design rationale.
+---
+
+# Authoring an ADR
+
+Both repos keep ADRs in `docs/adr/` with a `template.md` and a `README.md` index.
+Match the existing convention exactly — read the latest few ADRs first.
+
+## Conventions
+
+- **Filename:** `NNNN-kebab-title.md`, zero-padded sequential number. Next number
+  = highest existing + 1 (`ls docs/adr/`). cmgd is at 0011; telemetry at 0003.
+- **Format (Nygard):** sections `Context` → `Decision` → `Alternatives considered`
+  → `Consequences`, preceded by a metadata block:
+  ```markdown
+  # NNNN. <Title in sentence case>
+
+  - **Status:** Accepted   (or: Proposed | Superseded by [NNNN](...))
+  - **Date:** YYYY-MM-DD
+  - **Deciders:** Sean Davis
+  ```
+- **Immutable.** Never rewrite an accepted ADR to reflect a new decision. Instead
+  write a NEW ADR and mark the old one `Superseded by [NNNN](...)`, and have the
+  new one say `supersedes [MMMM](...)` in its Status line. (See cmgd 0010
+  superseding the error-action choice in 0009.)
+- **Index:** add a line to `docs/adr/README.md`.
+
+## When an ADR is warranted
+
+Record decisions that change runtime behavior or are expensive to reverse and
+non-obvious from the code: retry/error policy, storage/publish layout, profile
+semantics, container strategy, choosing/declining a framework. Do NOT ADR routine
+bug fixes, version bumps, or anything self-evident from the diff.
+
+## Content guidance
+
+- **Context** = the forces and the triggering experience, concretely (e.g. "the
+  RGI image that failed to pull made Nextflow terminate the whole run → a wave of
+  ABORTED siblings"). Real incidents beat abstractions.
+- **Decision** = what we will do, with the actual config/code snippet.
+- **Alternatives considered** = each rejected option AND why — this is the part
+  future-you actually rereads.
+- **Consequences** = what gets better, what new cost we accept.
+
+## Procedure
+
+1. `ls docs/adr/` → pick next number; read the 2-3 latest for tone.
+2. Copy `docs/adr/template.md` → `docs/adr/NNNN-<title>.md`, fill it in.
+3. If it supersedes one, edit the old ADR's Status to `Superseded by [NNNN](...)`.
+4. Add the index line to `docs/adr/README.md`.
+5. Commit with the related code change (or alone if purely a decision).
+
+For pipeline behavior ADRs that ship in a release, cross-reference: the CHANGELOG
+entry cites the ADR number (see `cmgd-release`).

--- a/.claude/skills/alpine-daemon/SKILL.md
+++ b/.claude/skills/alpine-daemon/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: alpine-daemon
+description: >
+  Deploy, restart, or check the nf-client dispatch daemon on an HPC login node
+  (CU Alpine, Anvil). Pull-mode orchestration: the daemon runs ON the cluster and
+  reaches OUT to the telemetry API over HTTPS. Use when the daemon is down, needs
+  restarting after a code update, isn't claiming jobs, or you're standing up a new
+  cluster. Trigger words: daemon, nf-client, restart daemon, daemon down,
+  redeploy, alpine, anvil, login node, not claiming, heartbeat.
+---
+
+# nf-client daemon on HPC
+
+The daemon is the pull-mode worker: it runs on a cluster login node, polls the
+telemetry API, claims jobs, renders a submit script, and `sbatch`es a Nextflow
+driver per batch. See `telemetry-api` for the endpoints it calls.
+
+## Why pull-mode (don't fight it)
+
+The campus firewall **blocks outbound TCP/22 from onclappc02**, so the API host
+can't SSH into clusters to push work. Instead daemons live on the clusters and
+make **outbound HTTPS** to the API. Anything that assumes "the server connects to
+the cluster" is wrong for this deployment.
+
+## Restart on Alpine
+
+```bash
+# On the Alpine login node (ssh alpine):
+module load <whatever the job env needs>          # bare cluster python is 2.7 — see Gotchas
+export PATH=$HOME/.local/bin:$PATH                # uv-tool-installed nf-client lives here
+nf-client --version                               # sanity
+
+# Start the daemon (continuous = keep polling when queue empty):
+nf-client daemon --config client-alpine.yaml --batch-size 10
+```
+The daemon **reloads its YAML every poll cycle**, so config edits take effect
+within one interval without a restart. For a code update (new nf-client), you DO
+restart (and reinstall — below).
+
+## Update nf-client (uv tool)
+
+```bash
+uv tool install --python 3.13 --from <path-or-git> nf-client    # or `uv tool upgrade`
+which nf-client    # -> ~/.local/bin/nf-client
+```
+`uv tool install` brings its own managed Python 3.13 — it does not depend on the
+cluster module python.
+
+## Health check (from anywhere)
+
+```bash
+API=https://nf-telemetry.cancerdatasci.org
+curl -s "$API/api/daemons/" | python3 -m json.tool        # last_heartbeat fresh?
+curl -s "$API/api/admin/dispatchability" | python3 -m json.tool   # is cmgd stuck?
+```
+Fresh heartbeat + cmgd not in `stuck` = healthy. If cmgd is stuck with the daemon
+up, check the daemon's `dispatch.workflow_id` filter.
+
+## Client config surface (`client-alpine.yaml`)
+
+Lives **on the cluster, outside the repo** (holds site paths/creds). Key fields:
+- `server_url` (…/api), `weblog_url` (…/telemetry)
+- `profile` — Nextflow `-profile` for this cluster, e.g. `alpine,gcs`
+- `continuous: true` — keep polling when idle
+- `dispatch.batch_size`, `dispatch.workflow_id` (restrict to `cmgd_nextflow`)
+- `submission.mode: slurm`, `submission.template_path` (→ repo `templates/`)
+- `submission.slurm_export_none: true` on Alpine (login env leaks to compute)
+- `submission.defaults.*` — `mem`, `cpus`, `time`, `account`, `partition`,
+  `store_dir`-adjacent paths, `google_credentials`, and `client_env_setup`
+  (PATH snippet so `nf-client run-wrapper` resolves on the compute node).
+
+Note: `params.store_dir` for the *pipeline* is set in the pipeline's
+`conf/profiles/alpine.config` (`/projects/seda0001_amc/cmgd/store`), NOT in the
+client yaml. See `cmgd-config`.
+
+## Gotchas
+
+- **Bare cluster `python` is 2.7.** Anything needing `nf_client` importable on a
+  compute node (the `run-wrapper` driver) must use the uv-tool Python via the
+  `client_env_setup` PATH hook, not the system python.
+- **`--export=NONE` matters on Alpine** (`slurm_export_none: true`): the login
+  environment otherwise leaks into compute jobs and breaks them. Anvil is clean —
+  set false there.
+- **GCS on Alpine: use `rclone` (`gs1:` remote). There is no `gsutil`/`gcloud`.**
+  e.g. `rclone ls gs1:cmgd-data/results/cMDv4/cmgd_nextflow/<ver>`.
+- **`store_dir` must be on a persistent project path, not `/scratch`** (purged).
+  Alpine uses `/projects/seda0001_amc/cmgd/store` with a matching singularity bind.
+- The daemon now **survives API outages** (retry loop + heartbeat guard) — a 5xx
+  or network blip no longer kills it. After any restart, still confirm a fresh
+  heartbeat landed.
+- onclappc02's old `nf_testing` daemon is dead; it shows perpetually in
+  `dispatchability.stuck`. Ignore it.

--- a/.claude/skills/cmgd-config/SKILL.md
+++ b/.claude/skills/cmgd-config/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: cmgd-config
+description: >
+  Map of where configuration lives across the cmgd system (pipeline + telemetry
+  server + nf-client) and how to change each setting safely. Use when you need to
+  change a path, profile, resource, database URL, credential, store_dir,
+  publish location, or any "where do I set X?" question. Config is deliberately
+  spread across several files — this skill is the index. Trigger words: config,
+  where is X configured, store_dir, publish_dir, profile, env var, SQLALCHEMY,
+  credentials, settings, change a setting, which file.
+---
+
+# cmgd configuration map
+
+Config is spread across three components and several files (a known wart). This
+is the authoritative index of what lives where and how to change it.
+
+## 1. Pipeline (`curatedMetagenomicsNextflow`)
+
+### `nextflow.config` (top level — params + manifest)
+- `params.store_dir = 'databases'` — default reference-DB cache (overridden per
+  profile; Alpine points it at a project path).
+- `params.sgb2gtdb_url` — SGB→GTDB table URL; **must match the active
+  metaphlan_index**. Downloaded once into `store_dir`.
+- `params.publish_base_dir` — stable site prefix. The workflow derives the real
+  output dir at runtime as `<publish_base_dir>/<workflow-name>/<workflow-version>`.
+- `params.publish_dir = null` — escape-hatch full override of the derived path.
+- `params.publish_mode = 'copy'` — copy (not symlink); required for GCS.
+- `params.cmgd_version = '4'` — the cMD data-release major (in the GCS path).
+- `manifest { version }` — **the release version; keep == git tag == registry
+  revision** (see `cmgd-release`).
+- Bottom: `includeConfig` lines pull in every `conf/profiles/*.config`.
+
+### `conf/base.config` — process resources & error handling
+- `errorStrategy` (`finish` since 2.0.4), retries, per-`withName` cpu/mem/time.
+- Change resource escalation here (`memory = { N.GB * task.attempt }`).
+- **No `time > 24h`** on Alpine — escalate memory, not wall-time.
+
+### `conf/profiles/*.config` — per-environment overrides
+Selected via `-profile`, composable (`alpine,gcs`):
+- `alpine.config` — SLURM executor, `process.time='24h'` (Alpine requires it),
+  `workDir='work'`, `params.store_dir='/projects/seda0001_amc/cmgd/store'`,
+  singularity bind mount.
+- `anvil.config` — sibling SLURM profile for Anvil.
+- `gcs.config` — **split (ADR-0011)**: `gcs` publishes OUTPUTS to GCS only
+  (`publish_base_dir=gs://cmgd-data/results/cMDv${cmgd_version}`,
+  `google.project='curatedmetagenomicdata'`); `gcswork` *additionally* routes
+  workDir to `gs://cmgd-data/work` (cloud compute only — never on SLURM).
+- `local`, `dev`, `google`, `unitn`, `rollback` — other targets.
+
+## 2. nf-client (`client-<cluster>.yaml`, on the cluster, NOT in repo)
+
+Schema = `packages/nf_client/src/nf_client/config.py`; annotated example =
+`packages/nf_client/client-example.yaml`. Reloaded every poll cycle.
+- `server_url`, `weblog_url` — API + weblog endpoints.
+- `profile` — the Nextflow `-profile` passed to every run on this cluster.
+- `continuous`, `dispatch.{batch_size,workflow_id,workflow_version}`.
+- `submission.{mode,template_path,max_concurrent_runs,slurm_export_none,defaults}`.
+- `submission.defaults` — template variables (mem, cpus, time, account, partition,
+  credentials, `client_env_setup`). May hold credential paths → stripped from any
+  config echo.
+See `alpine-daemon` for the full field rundown.
+
+## 3. Telemetry server (env vars → `config.py` `Settings`)
+
+Set in the deploy environment (Cloud Run), not a file in the repo:
+- `SQLALCHEMY_URI` — DB DSN. `postgresql://` is auto-upgraded to
+  `postgresql+asyncpg://`. Default dev: local postgres `cmdg_dev`.
+- `CORS_ORIGINS`, `FRONTEND_URL`, `SESSION_COOKIE_DOMAIN`.
+- `OAUTH_CLIENT_ID/SECRET`, `OAUTH_REDIRECT_URI`, `SESSION_SECRET` — auth.
+- `DISPATCH_TOKEN` — dispatch auth.
+- `TELEMETRY_SKIP_DB_INIT` — skip schema init (used by unit tests).
+
+## "Where do I change…?" quick table
+
+| Want to change | File / place |
+|---|---|
+| Reference-DB cache location | `conf/profiles/<cluster>.config` → `params.store_dir` |
+| Where outputs are published | `params.publish_base_dir` (or `gcs` profile) |
+| GCS project | `conf/profiles/gcs.config` → `google.project` |
+| Per-process mem/cpu/time | `conf/base.config` (`withName:`) |
+| Retry / errorStrategy | `conf/base.config` |
+| Which profile a cluster uses | `client-<cluster>.yaml` → `profile` |
+| Batch size / workflow filter | `client-<cluster>.yaml` → `dispatch.*` |
+| SLURM account/partition/mem for the driver | `client-<cluster>.yaml` → `submission.defaults` |
+| Database connection | `SQLALCHEMY_URI` env var on the server |
+| Release version | `manifest.version` + git tag + registry revision (lockstep) |
+
+## Gotchas
+
+- **The same setting can exist in two layers.** Pipeline `params.store_dir` (for
+  Nextflow) is *not* the client yaml; the client yaml's `defaults` feed the submit
+  *template*. Know which layer you're editing.
+- **`publish_dir` vs `publish_base_dir`:** prefer `publish_base_dir` (keeps the
+  version in the path). `publish_dir` overrides the whole thing and breaks the
+  versioned layout — escape hatch only.
+- **`-profile` order matters and composes:** `alpine,gcs` = Alpine SLURM + GCS
+  publish, local workDir. Adding `gcswork` would (wrongly) push workDir to GCS on
+  SLURM. Don't.
+- **Secrets belong in GCP Secret Manager**, not static config files; `.env`/yaml
+  values are derived from SM. Rotate by versioning SM first.
+- **Server caches modules at startup** — restart uvicorn after changing anything
+  the server reads at import time.

--- a/.claude/skills/cmgd-release/SKILL.md
+++ b/.claude/skills/cmgd-release/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: cmgd-release
+description: >
+  Cut and roll out a new cmgd_nextflow pipeline version end-to-end — bump
+  manifest.version, update CHANGELOG, tag + GitHub release, register the revision
+  in the telemetry workflow registry, retire the prior revision, and reconcile to
+  dispatch. Use when the user says "cut a release", "ship 2.0.x", "bump the
+  version", "register the new workflow version", or "roll out" a pipeline change.
+  Trigger words: release, cut, bump version, manifest version, tag, gh release,
+  register workflow, retire, reconcile, roll out, ship.
+---
+
+# cmgd release & rollout
+
+End-to-end procedure to ship a new `cmgd_nextflow` version. Two repos are
+involved: the pipeline (`curatedMetagenomicsNextflow`) and the telemetry backend
+(this repo, via the API in `telemetry-api`).
+
+## The lockstep invariant
+
+**`manifest.version` (in `nextflow.config`) == the git tag == the workflow
+`revision` the orchestrator dispatches.** All three move together. If they drift,
+published GCS paths (`.../cmgd_nextflow/<version>/...`) and the telemetry join
+break silently. This is the single most important rule.
+
+## Procedure
+
+### 1. Pipeline repo (`curatedMetagenomicsNextflow`)
+1. Land the code change on `main` (or a release branch merged to main).
+2. Bump `manifest { version = 'X.Y.Z' }` in `nextflow.config`.
+3. Add a `CHANGELOG.md` entry under `## [X.Y.Z] - YYYY-MM-DD` (Keep a Changelog
+   format: `Added` / `Changed` / `Fixed` / `Documentation`). Append the compare
+   link at the bottom:
+   `[X.Y.Z]: https://github.com/seandavi/curatedMetagenomicsNextflow/compare/<prev>...X.Y.Z`
+4. If the change alters runtime behavior (retry policy, errorStrategy, profile
+   semantics, storage layout), record an ADR in `docs/adr/` — use the
+   `adr-author` skill.
+5. Commit, then tag and release:
+   ```bash
+   git tag X.Y.Z && git push origin X.Y.Z
+   gh release create X.Y.Z --title X.Y.Z --notes-from-tag   # or --notes "<changelog body>"
+   ```
+
+### 2. Telemetry registry (the API)
+The workflow row's `revision` is what daemons check out. Update it and flip
+lifecycle status so only the new version dispatches.
+```bash
+API=https://nf-telemetry.cancerdatasci.org
+curl -s "$API/api/workflows" | python3 -m json.tool        # find pks + current revisions
+
+# Point the live row at the new tag (if reusing a row) ...
+curl -s -X PATCH "$API/api/workflows/<pk>/revision" -H 'content-type: application/json' \
+  -d '{"revision":"X.Y.Z"}'
+
+# ... or, if a fresh row was registered for X.Y.Z, RETIRE every older revision:
+curl -s -X PATCH "$API/api/workflows/<old_pk>/status" -H 'content-type: application/json' \
+  -d '{"status":"retired"}'
+```
+Goal state: exactly one `active` `cmgd_nextflow` row, at revision X.Y.Z.
+
+### 3. Dispatch
+```bash
+curl -s -X POST "$API/api/admin/reconcile-jobs"            # -> {"jobs_created":N}
+curl -s "$API/api/workflows/<pk>/job-summary"              # N pending
+curl -s "$API/api/admin/dispatchability"                   # cmgd NOT in stuck list
+```
+Then poll job-summary: `pending → claimed → submitted → running`. Daemon claims on
+its next poll cycle.
+
+## Pre-flight checklist (before reconcile)
+- [ ] Exactly one active cmgd_nextflow row, revision == new tag.
+- [ ] Old revisions retired (else cross-product double-dispatches every sample).
+- [ ] Daemon up, fresh heartbeat, `dispatch.workflow_id` includes `cmgd_nextflow`
+      (`GET /api/daemons/`).
+- [ ] Cluster client yaml `profile` correct for this revision (see Gotchas).
+- [ ] Reference DBs present in `store_dir` (e.g. SGB2GTDB table) if the new
+      version added a step.
+
+## Gotchas
+
+- **Retire-before-reconcile.** `reconcile-jobs` = samples × *active* workflows.
+  Two active revisions ⇒ every sample dispatched twice.
+- **Profile flips are revision-gated.** `-profile alpine,gcs` is only safe at
+  revision **2.0.4+** — earlier `gcs.config` forced a `gs://` workDir on SLURM.
+  Coordinate the registry revision bump before changing the client profile.
+- **Reconcile doesn't kill in-flight runs.** Bumping a revision mid-batch leaves
+  older runs running; they finish (or fail) on the old revision. Don't expect them
+  to "switch."
+- **Deployed telemetry server caches modules at startup.** If the release includes
+  *server* changes (not just pipeline), restart uvicorn after the deploy.
+- A job only reaches `completed` via the `MARK_COMPLETE` sentinel — verify the
+  pipeline still emits it if you touched the DAG tail.

--- a/.claude/skills/cmgd-triage/SKILL.md
+++ b/.claude/skills/cmgd-triage/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: cmgd-triage
+description: >
+  Diagnose failed, stuck, or log-less Nextflow runs in the cmgd telemetry
+  system. Use when runs are failing, jobs are stuck pending, there are dead-letter
+  jobs, a run shows wrapper-failed or ended-no-log, tasks ABORTED with no logs, or
+  the user says "lots of failures" / "no logs coming back" / "why isn't it
+  running". Walks classification → root cause → the right log to pull.
+  Trigger words: failed, failure, stuck, DLQ, dead letter, wrapper-failed,
+  ended-no-log, ABORTED, no logs, requeue, why did it die, triage, debug run.
+---
+
+# cmgd run triage
+
+Diagnose why cmgd_nextflow runs fail or stall. Uses `telemetry-api` for all
+queries. Start with `scripts/triage.py <run_name>` for a one-shot dump, or follow
+the decision tree below.
+
+## Step 0 — orient
+
+```bash
+API=https://nf-telemetry.cancerdatasci.org
+curl -s "$API/api/workflows?status=active" | python3 -m json.tool     # which pk is live
+curl -s "$API/api/workflows/<pk>/job-summary" | python3 -m json.tool  # counts
+curl -s "$API/api/admin/dispatchability" | python3 -m json.tool       # is it even being claimed
+curl -s "$API/api/runs/?limit=80" | python3 -c 'import sys,json;from collections import Counter;r=json.load(sys.stdin);print(Counter(x["classification"] for x in r))'
+```
+
+## Decision tree by classification
+
+### `wrapper-failed` (wrapper_exit_code ≠ 0)
+The Nextflow driver finished but exited non-zero — i.e. at least one task failed
+and `errorStrategy = finish` let siblings drain before exit.
+1. `GET /api/runs/{run_name}` → read `task_status_counts`. The signal is the small
+   `FAILED` count amid many `COMPLETED` (e.g. `{COMPLETED:130, FAILED:1}` = the
+   pipeline ran nearly to the end and died on one process).
+2. Find the failing process, pull its task logs:
+   `GET /api/task-logs/{run_name}/{task_hash}?log_type=command_err` (and
+   `command_out` — kraken2/metaphlan report on **stdout**, so `.command.err` may be
+   empty).
+3. The `.nextflow.log` is attached on the `wrapper_exited` event when present.
+
+### `ended-no-log` (terminal, but no `.nextflow.log` uploaded)
+The driver died before/without uploading its log — usually the driver job itself
+was killed, not a task.
+- **Tasks ABORTED + 0 FAILED + no logs ⇒ the driver (wrapper) SLURM job was
+  killed, classically OOM.** Do NOT look in telemetry for a failed task — there
+  isn't one. Check SLURM directly: `sacct -j <driver_jobid> --format=JobID,State,ExitCode,MaxRSS,ReqMem`. Exit `1:0` / `OUT_OF_MEMORY` → bump driver mem in the
+  client yaml (`submission.defaults.mem`) and resubmit.
+
+### `stalled` (non-terminal, heartbeat > 15 min old)
+Driver alive in SLURM but not heart-beating, or hung.
+- `squeue -j <jobid>` — if PENDING, it's queue wait (cluster busy), not a bug; the
+  gap between `submitted` and `running` IS the scheduler queue wait.
+- If RUNNING but silent, check the wrapper's captured stdout (`wrapper_output_log`).
+
+### stuck `pending` (dispatchability says so)
+No active daemon claims this workflow_id.
+- Is the daemon up + heart-beating? `GET /api/daemons/`.
+- Does the daemon's `dispatch.workflow_id` filter include this workflow?
+- Ignore `nf_testing` in the stuck list — that's the retired onclappc02 daemon.
+
+## Container / pipeline failure fingerprints (hard-won)
+
+- **`manifest unknown` at image pull** → a biocontainer tag that doesn't exist.
+  Verify the exact tag on quay.io before trusting it (RGI cost us this:
+  `6.0.5--pyha8f3691_0` didn't exist; `6.0.5--pyh05cac1d_0` did). One bad tag
+  fails the process at pull and (pre-`finish`) terminated the whole run.
+- **"no <X> mapping/db found" when the file was definitely downloaded** → a
+  `find <staged-symlink-dir>` that won't descend a symlink without `-L`. Nextflow
+  stages `path` inputs as symlinks. Reference the file by known name instead of
+  `find`-ing for it.
+- **`unrecognized arguments` from a vendored `bin/` script** → the container bakes
+  an OLDER copy of the same-named script into `/usr/local/bin`, which shadows the
+  pipeline's `bin/` on PATH. Confirm with
+  `docker run --rm <image> which <script>.py` and `--help`. Fix: rename the
+  vendored script to something unique (e.g. `cmgd_*`).
+
+## Recovery actions
+
+```bash
+API=https://nf-telemetry.cancerdatasci.org
+curl -s -X POST "$API/api/admin/requeue-dead-letter"             # DLQ → pending
+curl -s -X POST "$API/api/admin/expire-stale-runs?older_than_hours=2"  # close zombies, sweep
+curl -s -X POST "$API/api/admin/reset-running"                   # last resort: running → pending
+```
+After requeue/reset, run `reconcile-jobs` is NOT needed (jobs already exist); the
+daemon will reclaim on its next poll. Confirm via job-summary.
+
+## Gotchas
+
+- `errorStrategy` is `finish` (since 2.0.4): one bad task no longer aborts the
+  batch — so `wrapper-failed` with a high `COMPLETED` count is "almost worked,"
+  not "catastrophe."
+- Per-task `.command.out` (stdout) is uploaded since pipeline 2.0.1; before that,
+  stdout-only tools (kraken2) were log-less. If a run predates 2.0.1, missing
+  stdout is expected.
+- A job is only `completed` when the `MARK_COMPLETE` sentinel process emits
+  `status=COMPLETED`. All tasks green but no MARK_COMPLETE ⇒ job won't flip to
+  completed.

--- a/.claude/skills/cmgd-triage/scripts/triage.py
+++ b/.claude/skills/cmgd-triage/scripts/triage.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""One-shot triage dump for a cmgd run.
+
+Usage:
+    triage.py <run_name> [--api URL]
+
+Prints the run's classification, status, wrapper exit code, SLURM state, and
+task_status_counts — the four things you look at first. Highlights the failing
+process count so you know whether it "almost worked" (high COMPLETED, low FAILED)
+or died early.
+"""
+import argparse
+import json
+import sys
+import urllib.request
+
+DEFAULT_API = "https://nf-telemetry.cancerdatasci.org"
+
+
+def get(url: str):
+    with urllib.request.urlopen(url, timeout=30) as r:
+        return json.load(r)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("run_name")
+    ap.add_argument("--api", default=DEFAULT_API)
+    args = ap.parse_args()
+
+    url = f"{args.api}/api/runs/{args.run_name}"
+    try:
+        d = get(url)
+    except Exception as e:  # noqa: BLE001
+        print(f"ERROR fetching {url}: {e}", file=sys.stderr)
+        return 1
+
+    keys = [
+        "run_name", "revision", "status", "classification",
+        "wrapper_exit_code", "last_known_slurm_state", "slurm_reason",
+        "executor_job_id", "nextflow_log_uploaded_at", "last_heartbeat_at",
+    ]
+    for k in keys:
+        print(f"{k:28} {d.get(k)}")
+
+    counts = d.get("task_status_counts") or {}
+    print("\ntask_status_counts:")
+    for k, v in sorted(counts.items()):
+        print(f"  {k:12} {v}")
+
+    failed = counts.get("FAILED", 0)
+    completed = counts.get("COMPLETED", 0)
+    if failed and completed:
+        print(
+            f"\n=> {completed} COMPLETED, {failed} FAILED: pipeline ran far and "
+            f"died on {failed} task(s). Pull that process's command_err / "
+            f"command_out via /api/task-logs/{args.run_name}/<task_hash>."
+        )
+    elif d.get("classification") == "ended-no-log":
+        print(
+            "\n=> ended-no-log: driver likely killed (OOM?). Check SLURM: "
+            f"sacct -j {d.get('executor_job_id')} "
+            "--format=JobID,State,ExitCode,MaxRSS,ReqMem"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/gcs-verify/SKILL.md
+++ b/.claude/skills/gcs-verify/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: gcs-verify
+description: >
+  Confirm that cmgd pipeline outputs were actually published to Google Cloud
+  Storage, and locate them. Use after a run completes to verify GCS publish, when
+  checking "did the outputs land", or when listing/finding result objects for a
+  sample or version. Trigger words: GCS, did it publish, outputs in bucket,
+  check the bucket, rclone, gs://, where are the results, output directory.
+---
+
+# Verify cmgd GCS outputs
+
+cmgd publishes results to GCS when run with a `gcs`-bearing profile
+(`-profile alpine,gcs`). This skill confirms they landed and finds them.
+
+## Output path layout
+
+```
+gs://cmgd-data/results/cMDv<cmgd_version>/<workflow-name>/<workflow-version>/<sample>/<branch>/<step>/
+```
+- `cmgd_version` = `4` (the cMD data release) → `cMDv4`
+- `workflow-name` = `cmgd_nextflow`, `workflow-version` = e.g. `2.0.6`
+- `<branch>` = full-depth vs rarefied dual-profiling branch
+- per-step subdirs, e.g. `gtdb/`, plus `.command*` files alongside outputs
+
+Example: `gs://cmgd-data/results/cMDv4/cmgd_nextflow/2.0.6/<sample>/.../gtdb/`
+
+## Check (on Alpine — `rclone` only)
+
+```bash
+# There is NO gsutil/gcloud on Alpine. Use the rclone gs1: remote.
+rclone ls    gs1:cmgd-data/results/cMDv4/cmgd_nextflow/2.0.6
+rclone lsf   gs1:cmgd-data/results/cMDv4/cmgd_nextflow/2.0.6/        # dirs (samples)
+rclone size  gs1:cmgd-data/results/cMDv4/cmgd_nextflow/2.0.6
+# Did the GTDB step publish for any sample?
+rclone ls gs1:cmgd-data/results/cMDv4/cmgd_nextflow/2.0.6 | grep -i gtdb
+```
+
+## Gotchas
+
+- **`rclone gs1:` is the only GCS tool on Alpine** — neither `gsutil` nor
+  `gcloud` is installed. From a machine that has them, the equivalent is
+  `gsutil ls gs://cmgd-data/results/cMDv4/cmgd_nextflow/2.0.6`.
+- **Public access to these buckets/R2 is HTTPS GET only — no anonymous S3 LIST.**
+  You cannot "browse" the bucket unauthenticated; discovery is via the app-layer
+  artifacts catalog or an authenticated rclone/gsutil. Don't expect anonymous
+  listing to work.
+- **GCS project is `curatedmetagenomicdata`** (not `omicidx-338300`, an old
+  value). Wrong project = permission errors.
+- **The version in the path is `manifest.version`.** If outputs aren't where you
+  expect, the run's manifest.version may not match the tag you think it ran (see
+  the lockstep rule in `cmgd-release`).
+- Publish is `mode = copy` (not symlink) because symlinks aren't meaningful across
+  cloud storage. A run that completed locally but used a non-`gcs` profile will
+  have NO GCS objects — check the run's profile, not just its status.
+- Cross-check completion with telemetry: a run can be `completed` while a single
+  step (e.g. `gtdb`) failed under `errorStrategy=finish` — verify the specific
+  step's subdir exists, not just the sample dir.

--- a/.claude/skills/telemetry-api/SKILL.md
+++ b/.claude/skills/telemetry-api/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: telemetry-api
+description: >
+  Query the Nextflow telemetry/orchestration backend — job-summary, runs,
+  dispatchability, reconcile, requeue. Use when checking job/run status,
+  counting pending/running/failed jobs, diagnosing why work isn't dispatching,
+  or kicking off runs. Trigger words: telemetry, job summary, job-summary,
+  check runs, run status, dispatchability, reconcile, requeue, DLQ, dead letter,
+  how many running, is it stuck.
+---
+
+# Telemetry API
+
+The orchestration backend for the Nextflow telemetry system. This skill is the
+shared reference for talking to it; `cmgd-triage`, `cmgd-release`, and
+`alpine-daemon` build on it.
+
+## Base URL
+
+Production: `https://nf-telemetry.cancerdatasci.org`
+Local dev:  `http://localhost:8000`
+
+All app routes are under `/api`. The single exception is `/telemetry` (the
+Nextflow `-with-weblog` sink) which is **unauthenticated by design** — Nextflow's
+weblog cannot send auth headers.
+
+## Endpoint map
+
+Path = base + `/api` + router-prefix + route.
+
+### workflows (`/api/workflows`)
+- `POST /` — register/update a workflow (keyed on `workflow_id`+`version`)
+- `GET  /` — list; filter `?status=active|paused|retired`
+- `GET  /{pk}` — one workflow
+- `GET  /{pk}/job-summary` — **authoritative** job counts (see Gotchas)
+- `PATCH /{pk}/status` — body `{"status":"active|paused|retired"}`
+- `PATCH /{pk}/revision` — body `{"revision":"<git-tag>"}`
+
+### admin (`/api/admin`)
+- `POST /reconcile-jobs` — create pending jobs = samples × active workflows; returns `{"jobs_created":N}`
+- `GET  /dispatchability` — which workflows have pending jobs but no daemon to claim them
+- `GET  /stats` — global counts
+- `POST /requeue-dead-letter` — move DLQ jobs back to pending
+- `POST /reset-running` — force running→pending (recovery)
+- `POST /expire-stale-runs?older_than_hours=2.0` — close zombie runs, sweep their jobs
+- `POST /close-run` — close a single run by name
+
+### runs (`/api/runs`)
+- `GET  /` — list runs newest-first, each with derived `classification`
+- `GET  /{run_name}` — full row + `task_status_counts` + log availability
+- `POST /{run_name}/event` — lifecycle events (clients use this, not you)
+
+### task-logs (`/api/task-logs`)
+- `GET  /{run_name}/{task_hash}` — per-task logs; `?log_type=command_err|command_out|command_sh|command_log`
+
+### daemons (`/api/daemons`)
+- `GET  /` — registered daemons + last heartbeat
+- `DELETE /{agent_id}` — deregister
+
+### dispatch (`/api/dispatch`) — clients only
+- `POST /batch` `/submitted` `/requeue-expired`
+
+### process metrics (`/api/metrics/processes`) — per-process aggregates
+
+## Quick recipes
+
+```bash
+API=https://nf-telemetry.cancerdatasci.org
+
+# Active workflows + their pks (pk is the {workflow_pk} in PATCH/job-summary)
+curl -s "$API/api/workflows?status=active" | python3 -m json.tool
+
+# AUTHORITATIVE job counts for workflow pk 12
+curl -s "$API/api/workflows/12/job-summary" | python3 -m json.tool
+
+# Anything stuck? (pending jobs with no daemon to claim them)
+curl -s "$API/api/admin/dispatchability" | python3 -m json.tool
+
+# Kick off newly-created work
+curl -s -X POST "$API/api/admin/reconcile-jobs"
+```
+
+## Gotchas
+
+- **`/api/runs/` ignores `limit`, `workflow_pk`, and `revision` query params and
+  hard-caps at ~58 newest rows.** Do NOT use it to count runs for a workflow —
+  the count will silently be wrong. For counts, always use
+  `/api/workflows/{pk}/job-summary`. `/api/runs/` is only good for eyeballing the
+  most-recent runs' `classification`.
+- **Job-summary `running` ≠ number of run records returned by `/api/runs/`.**
+  These come from different tables; the runs-list cap above is why they disagree.
+  Trust job-summary for "how many are running."
+- **`{pk}` is the integer `id`, not the `workflow_id` string.** `cmgd_nextflow` is
+  the workflow_id; its active 2.0.6 row is pk 12. Get the pk from
+  `GET /api/workflows`.
+- **`reconcile-jobs` is a cross-product of samples × *active* workflows.** Retire
+  old revisions (`PATCH /{pk}/status {"status":"retired"}`) BEFORE reconciling or
+  you double-dispatch every sample across both versions.
+- **Dispatchability `stuck` often lists `nf_testing` (pk 1).** That's the dead
+  `onclappc02` daemon — pre-existing, irrelevant to cmgd. Only act on
+  `cmgd_nextflow` appearing there.
+- JSONB status lives at `trace->>'status'`; if writing server SQL, bind the
+  `.astext` expression once and reuse it (raw GROUP BY on the JSON path errors).
+
+## Run classification (from `runs.py`)
+
+`/api/runs/` annotates each run with one of:
+`active` · `stalled` · `completed` · `failed` · `expired` · `wrapper-failed` · `ended-no-log`
+
+Decision order: `wrapper_exit_code` non-zero → `wrapper-failed`; else non-terminal
++ heartbeat older than 15 min → `stalled`; else terminal but no `.nextflow.log`
+uploaded → `ended-no-log`. See `cmgd-triage` for what each means and what to do.

--- a/.gitignore
+++ b/.gitignore
@@ -192,4 +192,7 @@ trace.txt*
 results/
 .playwright-mcp/
 .firebase/
-.claude/
+# Ignore agent-local .claude state (worktrees, settings) but DO check in
+# shared, version-controlled skills under .claude/skills/.
+.claude/*
+!.claude/skills/


### PR DESCRIPTION
## What

Adds seven checked-in Claude Code **skills** under `.claude/skills/`, encoding the non-obvious operational knowledge of the cmgd Nextflow telemetry system — the hard-won detail that isn't derivable from the code and otherwise gets re-learned painfully each time.

| Skill | Use it when |
|---|---|
| `telemetry-api` | Querying the backend (job-summary, runs, dispatchability, reconcile). Shared base for the others. |
| `cmgd-triage` | A run failed / is stuck / has no logs; DLQ. Classification → root cause → right log. Bundles `scripts/triage.py`. |
| `cmgd-release` | Cutting + rolling out a new pipeline version (manifest==tag==revision lockstep, retire-before-reconcile). |
| `alpine-daemon` | Deploy/restart/health-check the nf-client daemon on an HPC login node. |
| `cmgd-config` | "Where is X configured / how do I change it?" config-location index. |
| `gcs-verify` | Confirm + locate pipeline outputs in GCS (`rclone gs1:`). |
| `adr-author` | Recording a behavior-affecting architecture decision. |

## Why this shape

Authored against Anthropic's skill-writing guidance — [Lessons from building Claude Code: how we use skills](https://claude.com/blog/lessons-from-building-claude-code-how-we-use-skills): model-focused `description`s with trigger words, heavy **Gotchas** sections instead of restating the obvious, bundled scripts for composition, and skills that reference other skills by name (`cmgd-triage`/`cmgd-release`/`alpine-daemon` all build on `telemetry-api`).

The Gotchas are real incidents from recent operations: the `/api/runs/` filter/limit cap, retire-before-reconcile double-dispatch, biocontainer `manifest unknown` tags, `find` not descending staged symlinks, container-baked scripts shadowing vendored `bin/` on PATH, driver-OOM showing as ABORTED-with-no-logs, and `rclone gs1:`-only on Alpine.

## Packaging

`.gitignore` now exempts `.claude/skills/` (`.claude/*` + `!.claude/skills/`) so skills are version-controlled while the rest of `.claude/` stays agent-local.

## ADR?

No ADR. This is developer tooling, not a behavior-affecting decision about the system's architecture — per the `adr-author` rubric added here, routine/self-evident additions don't warrant one. (The skills themselves document when an ADR *is* warranted.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)