### PR TITLE
fix(telemetry): complete jobs from bare ${meta.sample} tags (all 2.0.6 jobs DLQ'd despite clean runs)

### DIFF
--- a/src/nextflow_telemetry/services/telemetry.py
+++ b/src/nextflow_telemetry/services/telemetry.py
@@ -17,14 +17,24 @@ from .reconcile import sweep_run_incomplete
 
 
 def _parse_tag(tag: str | None) -> str | None:
-    """Extract sample_id from a tag of the form 'sample_id:run_name'.
+    """Extract sample_id from a Nextflow process tag.
 
-    Returns None if the tag is absent or does not match the convention.
+    The pipeline tags every process with a bare ``"${meta.sample}"`` (the sample
+    id, no suffix), so the sample id is the whole tag. We also tolerate a
+    historical ``"sample_id:run_name"`` form and take the part before the first
+    colon — the run is already disambiguated by ``run_name`` everywhere we match
+    on the sample.
+
+    Returns None only if the tag is absent.
+
+    NOTE: requiring the colon form here was a latent bug — it returned None for
+    the bare tags the pipeline actually emits, so MARK_COMPLETE never set
+    sample_id and per-sample completion never fired (jobs swept to the DLQ
+    despite clean runs). Sample ids do not contain ':'.
     """
     if not tag:
         return None
-    parts = tag.split(":", 1)
-    return parts[0] if len(parts) == 2 else None
+    return tag.split(":", 1)[0]
 
 
 @dataclass

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,6 +4,23 @@ from __future__ import annotations
 import pytest
 from fastapi.testclient import TestClient
 
+from nextflow_telemetry.services.telemetry import _parse_tag
+
+
+@pytest.mark.parametrize(
+    "tag,expected",
+    [
+        ("SRR123", "SRR123"),            # bare ${meta.sample} — what Nextflow emits
+        ("SRR123:run-abc", "SRR123"),    # historical sample:run form still works
+        (None, None),
+        ("", None),
+    ],
+)
+def test_parse_tag_handles_bare_and_colon_forms(tag, expected):
+    # Regression: a bare sample tag must yield the sample id, not None — else
+    # MARK_COMPLETE never sets sample_id and jobs never reach `completed`.
+    assert _parse_tag(tag) == expected
+
 
 def test_health_returns_healthy_when_database_is_available(app_module, monkeypatch):
     class FakeConnection:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -33,7 +33,9 @@ def _weblog_payload(
     workflow_id: str = "curatedMetagenomics",
     workflow_version: str = "1.0.0",
 ) -> dict:
-    tag = f"{sample_id}:{run_name}" if sample_id else None
+    # Nextflow tags processes with a bare `${meta.sample}` (the sample id, no
+    # run suffix) — mirror that here so the suite exercises the real wire format.
+    tag = sample_id if sample_id else None
     return {
         "runId": run_id,
         "runName": run_name,


### PR DESCRIPTION
## Symptom

cmgd_nextflow **2.0.6** ran cleanly — every workflow run exited 0 with all tasks `COMPLETED` (e.g. one run: 361/361 COMPLETED, `wrapper_exit_code=0`) — yet **all 69 jobs ended in the dead-letter queue with 0 completed**.

```
2.0.6 job-summary: total 69 | completed 0 | failed 69 | dead_letter 69
```

## Root cause

A job only flips to `completed` when telemetry receives `process_completed` for the `MARK_COMPLETE` sentinel **with a resolved `sample_id`** (`services/telemetry.py` step 3). `sample_id` comes from `_parse_tag(trace["tag"])`, which required the tag to be `"sample_id:run_name"` (exactly one colon):

```python
parts = tag.split(":", 1)
return parts[0] if len(parts) == 2 else None   # bare tag -> None
```

But the pipeline tags **every** process — MARK_COMPLETE included — with a **bare** `tag "${meta.sample}"` (no run suffix). So `_parse_tag` returned `None`, the completion branch (`... and sample_id ...`) was skipped, jobs stayed non-terminal, and the run-end `sweep_run_incomplete()` retried them to exhaustion → DLQ.

### Why it surfaced only now
Earlier revisions never ran clean to MARK_COMPLETE (they died at GTDB). 2.0.6 is the first batch to reach the sentinel — exposing a completion handshake that had **never actually fired in production**. The GTDB fix in 2.0.6 worked; this is a separate, older orchestration bug it uncovered.

### Why tests were green
The integration helper `_weblog_payload` fabricated the colon tag `f"{sample_id}:{run_name}"` that real Nextflow never emits — so the lifecycle test validated a fiction.

## Fix

- `_parse_tag` now takes the part before the first `:` — a bare tag yields the whole tag; the historical colon form still works (run is already disambiguated by `run_name` everywhere we match on sample). Sample ids don't contain `:`.
- Test helper now emits the **bare** tag Nextflow actually sends, so the completion lifecycle test exercises the real wire format (this test would now fail without the parser fix).
- Added a `_parse_tag` unit test (bare / colon / None / empty).

## Verification
- `tests/test_api.py` — 7 passed (incl. new parser cases).
- `tests/test_integration.py -k "complete or lifecycle or mark"` — 8 passed (real bare-tag completion path).
- `mypy` clean.

## ⚠️ Post-merge (operator steps — not done here)
1. **Deploy** the telemetry server (Cloud Run) — server caches modules at startup.
2. **Requeue** the DLQ'd 2.0.6 jobs: `POST /api/admin/requeue-dead-letter`, then `POST /api/admin/reconcile-jobs` is not needed (jobs exist) — the daemon reclaims and reruns. (Outputs from the first clean runs are already published to GCS; reruns will re-publish/resume.)
3. Confirm a sample flips to `completed` on the next MARK_COMPLETE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)