### PR TITLE
docs(deploy): document onclappc02 as production; mark Cloud Run retired

### DIFF
--- a/.claude/skills/cmgd-config/SKILL.md
+++ b/.claude/skills/cmgd-config/SKILL.md
@@ -63,7 +63,8 @@ See `alpine-daemon` for the full field rundown.
 
 ## 3. Telemetry server (env vars → `config.py` `Settings`)
 
-Set in the deploy environment (Cloud Run), not a file in the repo:
+Set in the deploy environment — on onclappc02 via the compose `env_file:`/`environment:`
+(`deploy/onclappc02/.env` + `.env.secrets`), not committed to the repo:
 - `SQLALCHEMY_URI` — DB DSN. `postgresql://` is auto-upgraded to
   `postgresql+asyncpg://`. Default dev: local postgres `cmdg_dev`.
 - `CORS_ORIGINS`, `FRONTEND_URL`, `SESSION_COOKIE_DOMAIN`.

--- a/README.md
+++ b/README.md
@@ -229,102 +229,51 @@ with configurable probability (default 30%) to generate realistic retry telemetr
 
 ## Production Deployment
 
-The production stack runs on Google Cloud:
+Production runs **self-hosted on `onclappc02`** as a Docker Compose stack behind the
+shared Traefik reverse proxy on `cancerdatasci.org`, using the shared `pg_main` Postgres
+cluster (one database per app — this app owns `nf_telemetry`). The migration off Cloud Run
++ Cloud SQL completed in May 2026.
 
 | Component | Service |
 |-----------|---------|
-| API | Cloud Run (`nf-telemetry.cancerdatasci.org`) |
-| Frontend | Firebase Hosting (`curatedmetagenomicdata.web.app`) |
-| Database | Cloud SQL (PostgreSQL) |
+| API | `nf_telemetry_api` container, Traefik route `nf-telemetry.cancerdatasci.org` |
+| Frontend | `nf_telemetry_frontend` container (nginx), Traefik route `cmgd.cancerdatasci.org` (Cloudflare-proxied) |
+| Database | shared `pg_main` cluster, database `nf_telemetry` |
+| Host | `onclappc02` (`140.226.4.71`) |
 
-A self-hosted alternative is in flight — see `deploy/onclappc02/` for the Docker Compose
-stack that runs the same image behind Traefik on the existing
-`pg_main` / Postgres-18 instance. Cutover plan tracked in the project's GitHub issues
-(meta issue: self-host migration).
+**The canonical runbook is [`deploy/onclappc02/README.md`](deploy/onclappc02/README.md)** —
+first-time setup, secrets, DB topology, and the routine deploy. Read it before deploying.
 
-### Prerequisites
+### Routine deploy
 
-- `gcloud` CLI authenticated to the target project
-- `firebase` CLI (`npm install -g firebase-tools`)
-- Docker (for local image builds)
-- [just](https://github.com/casey/just)
-
-### GCP setup (one-time)
-
-1. Enable APIs: Cloud Run, Artifact Registry, Cloud Build, Secret Manager.
-2. Create an Artifact Registry Docker repository named `nextflow-telemetry`.
-3. Create a service account for the Cloud Run service and grant it:
-   - `roles/secretmanager.secretAccessor`
-   - `roles/cloudsql.client` (if using Cloud SQL IAM auth later)
-4. Store the Cloud SQL connection string in Secret Manager:
-   ```bash
-   echo -n "postgresql://user:pass@HOST:5432/dbname" | \
-     gcloud secrets create nextflow-telemetry-db-uri --data-file=-
-   ```
-5. Update the placeholder values in `deploy/cloudrun.yaml` and `deploy/.firebaserc`:
-   - `YOUR_GCP_PROJECT` → your GCP project ID
-   - `YOUR_REGION` → e.g. `us-central1`
-   - `YOUR_FIREBASE_PROJECT` → your Firebase project ID
-   - Service account name in `cloudrun.yaml`
-
-### Database migration
-
-Run Alembic against Cloud SQL before the first deploy and after any schema change:
+From a checkout on `onclappc02`:
 
 ```bash
-SQLALCHEMY_URI=postgresql://user:pass@HOST:5432/dbname just migrate-prod
+git checkout main && git pull          # the build context is the working tree
+just deploy-onclappc02                  # fetch secrets → build API image → recycle container
 ```
 
-Cloud SQL uses a public IP, so this can be run directly from a machine with network
-access to the instance (no Cloud SQL Proxy required).
-
-### Deploying the API
+`just deploy-onclappc02` refreshes `.env.secrets` from GCP Secret Manager, rebuilds the API
+image from the working tree, and recreates the container (~30s of 503 while it restarts;
+clients retry). Verify:
 
 ```bash
-export GCP_PROJECT=your-project
-export REGION=us-central1
-
-just build-api       # build image and push to Artifact Registry
-just deploy-api      # update the Cloud Run service
+docker ps --filter name=nf_telemetry_api                # healthy?
+curl -sS https://nf-telemetry.cancerdatasci.org/health   # 200
 ```
 
-The `deploy/cloudrun.yaml` service definition pulls `SQLALCHEMY_URI` from Secret Manager
-and sets `CORS_ORIGINS` to the frontend's domain (see DNS section below).
+### Database migrations
 
-### Deploying the frontend
+Not run by the deploy target. If a change adds a migration, run it from the host first
+(`pg_main` only resolves inside Docker, so use `127.0.0.1` from the host) — see the
+runbook's migrations section.
 
-```bash
-just deploy-frontend   # vite build + firebase deploy
-```
+### Secrets
 
-Firebase Hosting serves the React SPA with a global CDN, automatic HTTPS, and a catch-all
-rewrite to `index.html` for client-side routing. Static assets under `/assets/` are cached
-with immutable headers; `index.html` itself is not cached so new deploys take effect
-immediately.
-
-### DNS
-
-The system uses two stable public hostnames, both custom domains rather than the default
-Cloud Run / Firebase subdomains so that HPC-submitted jobs always reach the right endpoint
-regardless of future infrastructure moves.
-
-| Hostname | Currently points to | Purpose |
-|----------|---------------------|---------|
-| `nf-telemetry.cancerdatasci.org` | Cloud Run (custom domain mapping) | All API traffic, including Nextflow weblog and wrapper-event POSTs from HPC |
-| `cmgd.cancerdatasci.org` | Firebase Hosting (custom domain) | React dashboard |
-
-**To add a custom domain to Cloud Run:**
-```bash
-gcloud run domain-mappings create \
-  --service nf-telemetry \
-  --domain nf-telemetry.cancerdatasci.org \
-  --region $REGION
-```
-Cloud Run will issue a managed TLS certificate automatically. Add the CNAME shown in the
-output to your DNS provider (Cloudflare, DNS-only on the campus network).
-
-**To add a custom domain to Firebase Hosting:** run `firebase hosting:channel:deploy` or
-use the Firebase console; Firebase provisions the cert and provides the DNS records.
+Source of truth is **GCP Secret Manager** (project `cdsci-infra`). Two derived, gitignored
+runtime files: `.env` (DB URI + hostnames) and `.env.secrets` (OAuth + session, generated
+by `deploy/onclappc02/fetch-secrets.sh`). Never hand-maintain a parallel copy. Full table
+and rotation steps are in the runbook.
 
 > **Important — weblog URL stability:** the weblog URL (`-with-weblog <url>`) is baked
 > into SLURM scripts at submission time. Changing the API hostname mid-batch will silently
@@ -335,7 +284,7 @@ use the Firebase console; Firebase provisions the cert and provides the DNS reco
 ### CORS
 
 The API reads allowed origins from the `CORS_ORIGINS` environment variable
-(comma-separated). Set this in `deploy/cloudrun.yaml` to the frontend's domain:
+(comma-separated), set via the compose `environment:` block to the frontend's domain:
 
 ```
 CORS_ORIGINS=https://cmgd.cancerdatasci.org
@@ -343,3 +292,11 @@ CORS_ORIGINS=https://cmgd.cancerdatasci.org
 
 Nextflow weblog POSTs and `nf_client.run_wrapper` events are server-to-server and are not
 subject to CORS, so the HPC endpoint does not need to be in the allowlist.
+
+### Legacy: Cloud Run + Cloud SQL (retired May 2026)
+
+The stack originally ran on Cloud Run (`nf-telemetry`, us-central1) with Cloud SQL and
+Firebase Hosting. That path is retired; the `just build-api` / `deploy-api` /
+`deploy-frontend` recipes, `deploy/cloudrun.yaml`, and `cloudbuild.yaml` remain only for
+historical reference and possible rollback while the GCP resources still exist (teardown
+status tracked in `deploy/onclappc02/README.md`).

--- a/deploy/DEPLOY.md
+++ b/deploy/DEPLOY.md
@@ -1,101 +1,56 @@
 # Deployment Guide
 
-## Architecture
+> **Production is self-hosted on `onclappc02` (Docker Compose + Traefik).**
+> The canonical, maintained runbook is **[`onclappc02/README.md`](onclappc02/README.md)** —
+> topology, secrets, first-time setup, routine deploy, migrations, rollback.
+> The Cloud Run / Cloud SQL / Firebase path below is **retired (May 2026)** and kept
+> only for historical reference.
+
+## Current production (summary)
 
 ```
-HPC (Anvil)          GCP
-──────────           ───────────────────────────────────────────
-nf-client daemon  →  Cloud Run (nf-telemetry)  →  Cloud SQL (main instance)
-                     Firebase Hosting (frontend)
+HPC (Alpine/Anvil)        onclappc02 (140.226.4.71)
+──────────────────        ─────────────────────────────────────────────
+nf-client daemon   →  Traefik  →  nf_telemetry_api (compose)  →  pg_main (shared cluster, db nf_telemetry)
+                                  nf_telemetry_frontend (nginx)
 ```
 
-| Component     | Resource                                                              |
-|---------------|-----------------------------------------------------------------------|
-| API           | Cloud Run service `nf-telemetry`, region `us-central1`               |
-| API URL       | https://nf-telemetry-819875667022.us-central1.run.app                |
-| Frontend      | Firebase Hosting, project `curatedmetagenomicdata`                   |
+Routine deploy, from a checkout on `onclappc02`:
+
+```bash
+git checkout main && git pull
+just deploy-onclappc02     # fetch secrets → docker compose build → up -d (recycle API)
+curl -sS https://nf-telemetry.cancerdatasci.org/health   # verify 200
+```
+
+Migrations are **not** run by that target — run them from the host first (use
+`@127.0.0.1` since `pg_main` only resolves inside Docker). See the runbook.
+
+Secrets live in **GCP Secret Manager** (`cdsci-infra`); `.env` and `.env.secrets` are
+derived/gitignored. See the runbook's Secrets section for the table and rotation steps.
+
+---
+
+## Historical: Cloud Run + Cloud SQL + Firebase (retired May 2026)
+
+The original GCP stack. Retained for rollback context only while the GCP resources may
+still exist (teardown status tracked in `onclappc02/README.md`). The `just build-api`,
+`deploy-api`, and `deploy-frontend` recipes, `cloudrun.yaml`, and `cloudbuild.yaml` belong
+to this path.
+
+| Component | Resource |
+|-----------|----------|
+| API | Cloud Run service `nf-telemetry`, region `us-central1` |
+| Frontend | Firebase Hosting, project `curatedmetagenomicdata` |
 | Container registry | Artifact Registry `us-central1-docker.pkg.dev/curatedmetagenomicdata/nextflow-telemetry/` |
-| Database      | Cloud SQL instance `main` (Postgres 17), database `cmgd_prod`        |
-| Service account | `nextflow-telemetry-api@curatedmetagenomicdata.iam.gserviceaccount.com` |
-
-## Secrets
-
-All secrets are stored in **GCP Secret Manager** under project `curatedmetagenomicdata`.
-
-| Secret name                  | What it contains              | Used by         |
-|------------------------------|-------------------------------|-----------------|
-| `nextflow-telemetry-db-uri`  | Full `SQLALCHEMY_URI` (asyncpg connection string to Cloud SQL `cmgd_prod`) | Cloud Run via `SQLALCHEMY_URI` env var |
-
-To update the DB URI (e.g. password rotation):
-```bash
-echo -n "postgresql+asyncpg://user:pass@host/cmgd_prod" | \
-  gcloud secrets versions add nextflow-telemetry-db-uri --data-file=- \
-  --project=curatedmetagenomicdata
-# Then redeploy Cloud Run to pick up the new version:
-just deploy-api
-```
-
-The local `.env.prod` file mirrors the secret for running migrations locally — keep them in sync.
-`.env.prod` is gitignored and must never be committed.
-
-## Deploy API
+| Database | Cloud SQL `main` (Postgres 17), database `cmgd_prod` |
+| DB secret | `nextflow-telemetry-db-uri` (GCP SM) → Cloud Run `SQLALCHEMY_URI` |
 
 ```bash
-just build-api    # builds via Cloud Build, tags image as api:<git-sha>
-just deploy-api   # deploys that git-sha-tagged image to Cloud Run
+just build-api    # Cloud Build → Artifact Registry, tag api:<git-sha>
+just deploy-api   # gcloud run deploy nf-telemetry with that image
+just deploy-frontend   # vite build + firebase deploy
 ```
 
-Images are tagged with the short git SHA (e.g. `api:7822a49`) rather than `latest`.
-This guarantees Cloud Run always creates a new revision on deploy, and makes it trivial
-to roll back: `gcloud run services update-traffic nf-telemetry --to-revisions=<rev>=100`.
-
-Cloud Build is used (not local Docker) to ensure the image is always `linux/amd64` — required by Cloud Run.
-
-## Run migrations
-
-Against production:
-```bash
-export $(grep SQLALCHEMY_URI .env.prod | xargs)
-uv run alembic upgrade head
-```
-
-Migrations must be run manually before deploying a new API version that adds schema changes.
-
-## Deploy frontend
-
-```bash
-cd frontend && npm run build
-cd deploy && firebase deploy --only hosting
-```
-
-## nf-client on Anvil
-
-The daemon runs on the Anvil HPC head node and talks to the Cloud Run API URL. Config at:
-`/anvil/scratch/x-seandavi/nf_worker/client-anvil.yaml`
-
-The `server_url` and `weblog_url` fields must point to the Cloud Run service URL above.
-
-## First-time GCP setup (already done — for reference)
-
-```bash
-# Enable APIs
-gcloud services enable secretmanager.googleapis.com artifactregistry.googleapis.com \
-  run.googleapis.com cloudbuild.googleapis.com --project=curatedmetagenomicdata
-
-# Create Artifact Registry repo
-gcloud artifacts repositories create nextflow-telemetry \
-  --repository-format=docker --location=us-central1 --project=curatedmetagenomicdata
-
-# Create service account
-gcloud iam service-accounts create nextflow-telemetry-api \
-  --display-name="Nextflow Telemetry API" --project=curatedmetagenomicdata
-
-# Grant service account access to the DB secret
-gcloud secrets add-iam-policy-binding nextflow-telemetry-db-uri \
-  --member="serviceAccount:nextflow-telemetry-api@curatedmetagenomicdata.iam.gserviceaccount.com" \
-  --role="roles/secretmanager.secretAccessor" --project=curatedmetagenomicdata
-
-# Create the secret (first time)
-echo -n "postgresql+asyncpg://..." | gcloud secrets create nextflow-telemetry-db-uri \
-  --data-file=- --project=curatedmetagenomicdata
-```
+Roll back a Cloud Run revision (while it exists):
+`gcloud run services update-traffic nf-telemetry --to-revisions=<rev>=100`.

--- a/justfile
+++ b/justfile
@@ -108,7 +108,11 @@ seed:
 daemon:
 	uv run nf-client daemon --config client-local.yaml --batch-size 10
 
-# ── Cloud deployment ──────────────────────────────────────────────────────────
+# ── LEGACY Cloud Run deployment (RETIRED May 2026) ─────────────────────────────
+# Production now runs on onclappc02 via `just deploy-onclappc02` (see
+# deploy/onclappc02/README.md). The build-api / deploy-api / deploy-frontend
+# recipes below target the retired Cloud Run + Firebase stack and are kept only
+# for historical reference / possible rollback while the GCP resources exist.
 # Set GCP_PROJECT and REGION env vars (or export them) before using these.
 
 GCP_PROJECT := env_var_or_default("GCP_PROJECT", "curatedmetagenomicdata")


### PR DESCRIPTION
## Why
The deploy docs still described **Cloud Run + Cloud SQL + Firebase** as production, with onclappc02 as an "in-flight alternative." Reality is the reverse: the self-hosted **onclappc02 Docker Compose** stack (Traefik + shared `pg_main`) has been production since the **May 2026 cutover**. The stale docs nearly caused a Cloud Run redeploy during tonight's hotfix.

## Changes (docs only)
- **README "Production Deployment"** — rewritten around onclappc02 (`just deploy-onclappc02`), with **[`deploy/onclappc02/README.md`](deploy/onclappc02/README.md)** as the canonical runbook. Cloud Run/Firebase demoted to a *Legacy (retired May 2026)* section. Kept the weblog-URL-stability warning and CORS notes.
- **deploy/DEPLOY.md** — now a pointer to the onclappc02 runbook; Cloud Run/Cloud SQL/Firebase content moved under *Historical (retired)*.
- **justfile** — `build-api` / `deploy-api` / `deploy-frontend` flagged as **LEGACY Cloud Run (retired)**; `deploy-onclappc02` is the live target.
- **skills/cmgd-config** — corrected server-env note from "(Cloud Run)" to the onclappc02 compose `env_file`/`.env.secrets` reality.

No functional changes. `cloudrun.yaml` and `cloudbuild.yaml` are retained for rollback reference while the GCP resources may still exist (teardown status tracked in the onclappc02 runbook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)