### PR TITLE
feat(scripts): UI-observability evaluator + job-seeding tooling

### DIFF
--- a/.claude/agents/ui-observability-evaluator.md
+++ b/.claude/agents/ui-observability-evaluator.md
@@ -1,0 +1,84 @@
+---
+name: ui-observability-evaluator
+description: >
+  Evaluates the Nextflow telemetry dashboard (https://cmgd.cancerdatasci.org) for
+  UI/UX and observability quality through the eyes of an operator monitoring
+  ~100k samples across many studies. Use when the UI changes, before a release,
+  or whenever you want a fresh, prioritized list of UI/observability improvements.
+  Produces severity-ranked findings tied to specific pages, each with a concrete
+  fix. Trigger words: evaluate the UI, UX review, dashboard review, observability
+  audit, is the dashboard usable at scale.
+tools: Bash, Read, Grep, Glob, Write
+---
+
+# UI / Observability Evaluator
+
+You judge the telemetry dashboard the way its actual operator does: **someone
+responsible for the completion of ~100k samples spread across many studies**, who
+cares about *relative completeness*, *progress/throughput over time*, *failure
+observability*, and *not drowning at scale*. You are not a generic "make it
+pretty" reviewer — every finding must matter to that operator.
+
+## Capabilities & constraints of the tooling
+
+- **Screenshots + real layout + interaction:** playwright's bundled headless
+  chromium. `uv run --with playwright python scripts/ui_eval_capture.py` walks
+  every nav page (the SPA is state-based — no per-page URLs, so pages are reached
+  by *clicking* nav items) and writes screenshots + `manifest.json` (structured
+  probes: table/row counts, pagination signals, loading/empty/error states,
+  heading outline, ARIA landmarks, %/ETA/study mentions, console errors) to
+  `/tmp/ui_eval/`.
+- **Fast headless DOM/data scraping (no pixels):** `obscura` (`~/.local/bin/obscura`)
+  — `obscura fetch <url> --dump text|markdown|html -e '<js>'`, or `obscura serve`
+  for CDP. Obscura has **no paint engine** (cannot screenshot) — use chromium for
+  visuals, obscura for quick DOM/text pulls.
+- The dashboard reads live data from `https://nf-telemetry.cancerdatasci.org/api`
+  (public, unauthenticated today). Cross-check what the UI *shows* against what
+  the API *has* (e.g. `/api/admin/stats`, `/api/workflows`, `/api/runs`).
+- Ground every visual claim in an actual screenshot (`Read` the PNGs). Ground
+  behavioral claims (pagination, virtualization, empty/error/loading states) in
+  the page source under `frontend/src/pages/*.tsx`.
+
+## How to run
+
+1. Capture: `uv run --with playwright python scripts/ui_eval_capture.py --url <url> --out /tmp/ui_eval`
+2. Read every screenshot in `/tmp/ui_eval/*.png` and `/tmp/ui_eval/manifest.json`.
+3. Read the corresponding `frontend/src/pages/*.tsx` for behavior at scale.
+4. Evaluate every page through **all six operator lenses** below.
+5. Emit findings.
+
+## The six operator lenses (apply each to every page)
+
+1. **Study / relative completeness (the PI):** Can I see "study X: 8.2k/10k = 82%
+   done", rank studies by completeness, spot the laggards? Is a *sample* ever shown
+   in the context of the *study* it belongs to?
+2. **Progress / throughput over time:** completion rate, trend, ETA to finish the
+   backlog, stalls. Is there any time axis at all, or only instantaneous counts?
+3. **Failure observability / triage:** can I find *what* failed and *why* in ≤2
+   clicks — DLQ, stuck/no-daemon, per-host, down to the log? Is the signal
+   actionable or just a count?
+4. **Scale to 100k:** does each table paginate / virtualize / server-side filter,
+   or try to render everything? Row caps that silently truncate? Load time? Does
+   "50 rows" mean "50 of 100k with no way to the rest"?
+5. **Cognitive load / first-run:** in 5 seconds, what question does this page
+   answer? Jargon (run_name UUIDs, workflow_pk) without explanation? Information
+   hierarchy and glanceability.
+6. **Accessibility & robustness:** color-contrast (dark theme), keyboard/focus,
+   heading structure, empty/loading/error states, and honest handling of the
+   unauthenticated/partial-data case.
+
+## Output format
+
+Return **only** a prioritized findings list (no preamble). Each finding:
+
+```
+[SEV] <page> — <one-line problem>
+  lens: <which of the six>
+  why it matters at 100k/study scale: <1 sentence>
+  fix: <concrete, buildable change>
+  evidence: <screenshot / manifest field / source file:line / API fact>
+```
+
+`SEV` ∈ {BLOCKER, HIGH, MED, LOW}. Sort BLOCKER→LOW. Prefer 8–15 findings that
+would genuinely change the operator's day over an exhaustive nitpick list. End
+with a 3-line **"Top 3 to build next"** synthesis.

--- a/.gitignore
+++ b/.gitignore
@@ -193,6 +193,14 @@ results/
 .playwright-mcp/
 .firebase/
 # Ignore agent-local .claude state (worktrees, settings) but DO check in
-# shared, version-controlled skills under .claude/skills/.
+# shared, version-controlled skills under .claude/skills/ and reusable
+# subagents under .claude/agents/.
 .claude/*
 !.claude/skills/
+!.claude/agents/
+
+# obscura headless-browser binaries (dropped into the repo dir by the installer;
+# used by scripts/ui_eval_capture.py's tooling — not project source)
+/obscura
+/obscura-worker
+/obscura-*.tar.gz

--- a/scripts/seed_collection_from_cohort.py
+++ b/scripts/seed_collection_from_cohort.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Create a collection (cohort) and map every sample tagged with that cohort.
+
+Samples seeded from a curation TSV carry the cohort name as a plain JSONB field
+(`metadata.cohort`). This is not the same as a first-class `collections` row, so
+the cohort dashboards have nothing to render. This one-off backfills a
+`collections` row plus `collection_samples` membership for every sample whose
+`metadata.cohort` matches.
+
+Idempotent: re-running upserts the collection and skips existing memberships.
+
+Usage (from the onclappc02 host; pg_main only resolves inside Docker, so use the
+127.0.0.1 override):
+
+    set -a; source deploy/onclappc02/.env; set +a
+    SQLALCHEMY_URI="${SQLALCHEMY_URI/@pg_main:/@127.0.0.1:}" \
+      uv run python scripts/seed_collection_from_cohort.py --cohort ArtachoA_2021
+
+    # add --commit to actually write (default is a dry run)
+"""
+from __future__ import annotations
+
+import asyncio
+import datetime
+import os
+import sys
+from pathlib import Path
+
+import click
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import create_async_engine
+
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from nextflow_telemetry.db import (  # noqa: E402
+    collection_samples_tbl,
+    collections_tbl,
+    samples_tbl,
+)
+
+
+async def _run(cohort: str, source: str, label: str | None, commit: bool) -> int:
+    uri = os.environ.get("SQLALCHEMY_URI")
+    if not uri:
+        raise click.ClickException("SQLALCHEMY_URI not set")
+    if uri.startswith("postgresql://"):
+        uri = uri.replace("postgresql://", "postgresql+asyncpg://", 1)
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    engine = create_async_engine(uri)
+    try:
+        async with engine.begin() as conn:
+            # Samples whose metadata.cohort matches the requested cohort.
+            sample_ids = [
+                r[0]
+                for r in (
+                    await conn.execute(
+                        select(samples_tbl.c.sample_id).where(
+                            samples_tbl.c.metadata_["cohort"].astext == cohort
+                        )
+                    )
+                ).all()
+            ]
+            if not sample_ids:
+                click.echo(f"No samples found with metadata.cohort == {cohort!r}. Nothing to do.")
+                return 0
+
+            click.echo(f"Cohort {cohort!r}: {len(sample_ids)} matching samples.")
+
+            if not commit:
+                click.echo("DRY RUN — pass --commit to write the collection + memberships.")
+                return 0
+
+            # 1. Upsert the collection row.
+            await conn.execute(
+                pg_insert(collections_tbl)
+                .values(
+                    collection_id=cohort,
+                    source=source,
+                    label=label or cohort,
+                    metadata_={"origin": "seed_collection_from_cohort", "cohort_field": cohort},
+                    created_at=now,
+                    updated_at=now,
+                )
+                .on_conflict_do_update(
+                    index_elements=[collections_tbl.c.collection_id],
+                    set_={"label": label or cohort, "updated_at": now},
+                )
+            )
+
+            # 2. Insert memberships, skipping any that already exist.
+            result = await conn.execute(
+                pg_insert(collection_samples_tbl)
+                .values([{"collection_id": cohort, "sample_id": sid} for sid in sample_ids])
+                .on_conflict_do_nothing(constraint="uq_collection_sample")
+            )
+            click.echo(f"Collection {cohort!r} upserted; {result.rowcount} new memberships added "
+                       f"({len(sample_ids)} total in cohort).")
+        return 0
+    finally:
+        await engine.dispose()
+
+
+@click.command()
+@click.option("--cohort", required=True, help="Value of samples.metadata.cohort to collect.")
+@click.option("--source", default="manual", show_default=True, help="collections.source value.")
+@click.option("--label", default=None, help="Human label (defaults to the cohort name).")
+@click.option("--commit", is_flag=True, default=False, help="Actually write (default: dry run).")
+def main(cohort: str, source: str, label: str | None, commit: bool) -> None:
+    raise SystemExit(asyncio.run(_run(cohort, source, label, commit)))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/seed_test_jobs.py
+++ b/scripts/seed_test_jobs.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Seed a small, controlled batch of pending jobs for one active workflow.
+
+Used to drive an end-to-end telemetry test: insert (or requeue) a handful of
+`pending` jobs so an idle daemon claims them and runs them through the full
+lifecycle. Targets cmgd_nextflow 2.0.6 (workflow pk 12) by default.
+
+Each sample can hold only one job per (workflow_id, version) — uq_job_composite —
+so seeding is an UPSERT: insert pending if absent, else reset the existing job
+(any status, including completed/failed) back to pending with a clean slate.
+
+Dry run by default — prints the chosen samples and their current job status.
+Pass --commit to actually write.
+
+Usage (from the onclappc02 host; pg_main only resolves inside Docker, so use the
+127.0.0.1 override):
+
+    set -a; source deploy/onclappc02/.env; set +a
+    SQLALCHEMY_URI="${SQLALCHEMY_URI/@pg_main:/@127.0.0.1:}" \
+      uv run python scripts/seed_test_jobs.py --limit 3            # dry run
+    SQLALCHEMY_URI="${SQLALCHEMY_URI/@pg_main:/@127.0.0.1:}" \
+      uv run python scripts/seed_test_jobs.py --limit 3 --commit   # write
+"""
+from __future__ import annotations
+
+import asyncio
+import datetime
+import os
+import sys
+from pathlib import Path
+
+import click
+from sqlalchemy import select, text
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import create_async_engine
+
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from nextflow_telemetry.db import jobs_tbl, workflows_tbl  # noqa: E402
+
+
+async def _run(workflow_pk: int, limit: int, samples: tuple[str, ...], commit: bool) -> int:
+    uri = os.environ.get("SQLALCHEMY_URI")
+    if not uri:
+        raise click.ClickException("SQLALCHEMY_URI not set")
+    if uri.startswith("postgresql://"):
+        uri = uri.replace("postgresql://", "postgresql+asyncpg://", 1)
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    engine = create_async_engine(uri)
+    try:
+        async with engine.begin() as conn:
+            wf = (await conn.execute(
+                select(
+                    workflows_tbl.c.workflow_id,
+                    workflows_tbl.c.version,
+                    workflows_tbl.c.status,
+                ).where(workflows_tbl.c.id == workflow_pk)
+            )).first()
+            if not wf:
+                raise click.ClickException(f"No workflow with pk={workflow_pk}")
+            workflow_id, version, wf_status = wf
+            click.echo(f"Target workflow: pk={workflow_pk} {workflow_id} {version} (status={wf_status})")
+            if wf_status != "active":
+                raise click.ClickException(
+                    f"Workflow pk={workflow_pk} is {wf_status!r}, not active — refusing to seed."
+                )
+
+            # Choose samples. Explicit --sample wins; otherwise pick samples whose
+            # existing job for this workflow (if any) is in a terminal/absent state,
+            # so we never disturb work that is currently in flight.
+            if samples:
+                chosen = list(samples)
+            else:
+                rows = (await conn.execute(
+                    text(
+                        """
+                        SELECT s.sample_id, j.status AS job_status
+                        FROM samples s
+                        LEFT JOIN jobs j
+                          ON j.sample_id = s.sample_id
+                         AND j.workflow_id = :wid
+                         AND j.workflow_version = :ver
+                        WHERE j.status IS NULL
+                           OR j.status IN ('completed', 'failed')
+                        ORDER BY (j.status IS NULL) DESC, s.sample_id
+                        LIMIT :lim
+                        """
+                    ),
+                    {"wid": workflow_id, "ver": version, "lim": limit},
+                )).all()
+                chosen = [r[0] for r in rows]
+
+            if not chosen:
+                click.echo("No eligible samples found (all have in-flight jobs?). Nothing to do.")
+                return 0
+
+            # Report current state of the chosen samples' jobs.
+            existing = {
+                r[0]: r[1]
+                for r in (await conn.execute(
+                    text(
+                        """
+                        SELECT sample_id, status FROM jobs
+                        WHERE workflow_id = :wid AND workflow_version = :ver
+                          AND sample_id = ANY(:ids)
+                        """
+                    ),
+                    {"wid": workflow_id, "ver": version, "ids": chosen},
+                )).all()
+            }
+            click.echo(f"\n{len(chosen)} sample(s) selected:")
+            for sid in chosen:
+                cur = existing.get(sid, "(no job — will insert)")
+                click.echo(f"  {sid:<40} current: {cur} -> pending")
+
+            if not commit:
+                click.echo("\nDRY RUN — pass --commit to write.")
+                return 0
+
+            stmt = (
+                pg_insert(jobs_tbl)
+                .values([
+                    {
+                        "sample_id": sid,
+                        "workflow_pk": workflow_pk,
+                        "workflow_id": workflow_id,
+                        "workflow_version": version,
+                        "status": "pending",
+                        "retry_count": 0,
+                        "created_at": now,
+                    }
+                    for sid in chosen
+                ])
+                .on_conflict_do_update(
+                    constraint="uq_job_composite",
+                    set_={
+                        "status": "pending",
+                        "run_name": None,
+                        "retry_count": 0,
+                        "completed_at": None,
+                        "failed_at": None,
+                        "failure_reason": None,
+                    },
+                )
+            )
+            result = await conn.execute(stmt)
+            click.echo(f"\nSeeded {result.rowcount} job(s) to pending for {workflow_id} {version}.")
+        return 0
+    finally:
+        await engine.dispose()
+
+
+@click.command()
+@click.option("--workflow-pk", default=12, show_default=True, help="workflows.id of the target (active) workflow.")
+@click.option("--limit", default=3, show_default=True, help="How many samples to seed when --sample not given.")
+@click.option("--sample", "samples", multiple=True, help="Explicit sample_id(s) to seed (repeatable).")
+@click.option("--commit", is_flag=True, default=False, help="Actually write (default: dry run).")
+def main(workflow_pk: int, limit: int, samples: tuple[str, ...], commit: bool) -> None:
+    raise SystemExit(asyncio.run(_run(workflow_pk, limit, samples, commit)))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ui_eval_capture.py
+++ b/scripts/ui_eval_capture.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Capture the telemetry dashboard for UI/UX + observability evaluation.
+
+Walks every nav page (state-based SPA, so we click nav items — there are no
+per-page URLs), and for each page saves:
+  - a full-page screenshot (real headless chromium; obscura has no paint engine)
+  - the rendered innerText
+  - a structured probe: tables/rows, pagination controls, loading/empty/error
+    signals, heading outline, ARIA landmarks, and any console errors.
+
+Output goes to an --out dir (default /tmp/ui_eval). Re-runnable as the UI evolves.
+
+Usage:
+    uv run --with playwright python scripts/ui_eval_capture.py \
+        --url https://cmgd.cancerdatasci.org --out /tmp/ui_eval
+"""
+from __future__ import annotations
+import argparse, json, os, sys
+from playwright.sync_api import sync_playwright
+
+NAV = ["Overview", "Process Metrics", "Workflows", "Samples",
+       "Cohorts", "Dispatch", "Runs", "Infrastructure"]
+
+PROBE = r"""
+() => {
+  const q = s => [...document.querySelectorAll(s)];
+  const txt = document.body.innerText || "";
+  const has = re => re.test(txt);
+  return {
+    tables: q("table").length,
+    rows: q("tbody tr").length,
+    buttons: q("button").length,
+    links: q("a[href]").length,
+    inputs: q("input,select").length,
+    // scale signals
+    pagination: q("*").some(e => /next|prev|page\s*\d|rows per page|load more|show more/i.test(e.textContent||"") && e.children.length===0),
+    scrollHeight: document.documentElement.scrollHeight,
+    // state signals
+    loading: has(/loading|skeleton|please wait/i),
+    empty: has(/no (data|results|samples|runs|rows)|nothing to show|empty/i),
+    error: has(/error|failed to (load|fetch)|something went wrong|4\d\d|5\d\d/i),
+    // structure / a11y
+    headings: q("h1,h2,h3").map(h => h.tagName + ":" + (h.textContent||"").trim()).slice(0,25),
+    landmarks: q("[role],nav,main,aside,header,footer").map(e=>e.getAttribute("role")||e.tagName.toLowerCase())
+                 .reduce((a,r)=>{a[r]=(a[r]||0)+1;return a;},{}),
+    ariaLabels: q("[aria-label]").length,
+    imgNoAlt: q("img:not([alt])").length,
+    // completeness-oriented content signals (persona: study monitor)
+    mentionsPercent: (txt.match(/\d+(\.\d+)?%/g)||[]).slice(0,20),
+    mentionsStudyCohort: /stud(y|ies)|cohort|collection|project/i.test(txt),
+    mentionsETA: /eta|estimat|time remaining|projected|throughput|per hour|\/hr|rate/i.test(txt),
+    textLen: txt.length,
+    textHead: txt.replace(/\n{2,}/g,"\n").slice(0,1200),
+  };
+}
+"""
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--url", default="https://cmgd.cancerdatasci.org")
+    ap.add_argument("--out", default="/tmp/ui_eval")
+    ap.add_argument("--viewport", default="1440x900")
+    args = ap.parse_args()
+    w, h = (int(x) for x in args.viewport.split("x"))
+    os.makedirs(args.out, exist_ok=True)
+
+    manifest = {"url": args.url, "viewport": args.viewport, "pages": []}
+    with sync_playwright() as p:
+        b = p.chromium.launch(headless=True)
+        pg = b.new_page(viewport={"width": w, "height": h})
+        console = []
+        pg.on("console", lambda m: console.append(f"{m.type}: {m.text[:200]}") if m.type in ("error","warning") else None)
+        pg.on("pageerror", lambda e: console.append(f"pageerror: {str(e)[:200]}"))
+        pg.goto(args.url, wait_until="networkidle", timeout=60000)
+        pg.wait_for_timeout(4000)
+
+        for label in NAV:
+            slug = label.lower().split()[0]
+            console.clear()
+            try:
+                if label != "Overview":
+                    pg.get_by_text(label, exact=False).first.click(timeout=8000)
+                    pg.wait_for_timeout(3500)
+                    try: pg.wait_for_load_state("networkidle", timeout=8000)
+                    except Exception: pass
+                shot = os.path.join(args.out, f"{slug}.png")
+                pg.screenshot(path=shot, full_page=True)
+                probe = pg.evaluate(PROBE)
+                probe["console"] = list(console)
+                probe["label"] = label
+                probe["screenshot"] = shot
+                manifest["pages"].append(probe)
+                print(f"[ok] {label:16} tables={probe['tables']} rows={probe['rows']} "
+                      f"%={len(probe['mentionsPercent'])} eta={probe['mentionsETA']} "
+                      f"empty={probe['empty']} err={probe['error']} console={len(probe['console'])}")
+            except Exception as e:
+                manifest["pages"].append({"label": label, "capture_error": str(e)[:300]})
+                print(f"[ERR] {label}: {str(e)[:160]}")
+        b.close()
+
+    with open(os.path.join(args.out, "manifest.json"), "w") as f:
+        json.dump(manifest, f, indent=1)
+    print(f"\nWrote {args.out}/manifest.json and {len([p for p in manifest['pages'] if 'screenshot' in p])} screenshots.")
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds reusable operational tooling produced while hardening telemetry and evaluating the dashboard at ~100k-sample scale.

## What's included
- **`.claude/agents/ui-observability-evaluator.md`** — reusable subagent that evaluates the dashboard through six operator lenses (study-completeness, throughput, failure-triage, scale-100k, cognitive-load, accessibility). Its first run produced #116–#122.
- **`scripts/ui_eval_capture.py`** — capture engine: chromium screenshots + DOM probes for every nav page. (Obscura has no paint engine, so chromium does the visual leg.)
- **`scripts/seed_test_jobs.py`** — upsert a controlled set of jobs to `pending` for an active workflow (dry-run by default) to drive end-to-end telemetry tests.
- **`scripts/seed_collection_from_cohort.py`** — backfill a `collections` row + membership from `samples.metadata.cohort`.
- **`.gitignore`** — version-control `.claude/agents/` (mirroring the existing `.claude/skills/` policy); ignore stray obscura binaries.

## Notes
- Scripts are one-off/operational utilities; no changes to server or nf-client packages.
- No new runtime deps (playwright is invoked via `uv run --with playwright`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)