### PR TITLE
Epic A identity model + fix completion semantics (#116, #114)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -33,6 +33,12 @@ move in the whole backlog.
 ### Epic A — Data-model foundation  ⟵ START HERE
 Settle identity/semantics before adding columns. Deliverable: design doc(s), then a
 migration plan. Blocks B, D, E.
+- **Study/sample/version identity** settled in `docs/study-sample-version-identity.md`
+  (2026-07-02). Resolved: sample↔study is **many-to-many** (kills `metadata.cohort` as
+  source of truth; join table wins); **one unified study entity** (cMD study =
+  `collections` row with `source='cmd'`); **exactly one active version per
+  `workflow_id`**; completion measured in **distinct samples under the active version**.
+  Migration plan sketched there; not yet written.
 - **#55** sample metadata data model + agentic (LLM) harmonization — write
   `docs/sample-metadata-design.md` answering: annotation key `(sample_id)` vs
   `(sample_id, study)`; provenance (`source`/`evidence`/`confidence`); publications
@@ -43,8 +49,16 @@ migration plan. Blocks B, D, E.
 
 ### Epic B — Operational-state correctness  (cheap, high-value, unblocks the UI)
 - **#114** retiring a workflow reconciles its pending jobs; bucket pending by
-  active/retired in stats (fixes the "298 pending" illusion).
+  active/retired in stats (fixes the "298 pending" illusion). _Stats-bucketing half
+  DONE (branch `epic-b/completion-semantics`): `/admin/stats` now returns
+  `jobs_by_status_active` alongside the all-versions `jobs_by_status`. Still TODO: the
+  reconcile-on-retire behavior itself._
 - **#116** per-sample completion under the **active** workflow version (depends on A).
+  _DONE (branch `epic-b/completion-semantics`): cohort `summary()` now measures
+  completion as distinct samples with a completed job under the active version
+  (`completion_pct = samples_completed / sample_count`); `all_workflows=true` opts into
+  the old across-versions view. Read-path only; tested. TODO: frontend samples-based
+  labels + the #119 leaderboard on top of the corrected semantics._
 - **#115** server-side heartbeat-staleness watchdog — makes `running` honest; a
   walltime-killed run currently sits `running` forever (observed live 2026-07-01).
 

--- a/docs/study-sample-version-identity.md
+++ b/docs/study-sample-version-identity.md
@@ -1,0 +1,198 @@
+# Study / Sample / Version identity — design positions
+
+> Status: **draft v1** — Epic A of `docs/roadmap.md`. Settles the three identity
+> decisions that everything downstream (correct completeness #116, the study
+> leaderboard #119, sample metadata #55, the outputs catalog keying #57/#93)
+> inherits. Companion to `docs/sample-metadata-design.md`, which deliberately drew
+> its scope line at the harmonization boundary and left *study identity* unsettled —
+> this doc fills exactly that gap. No migrations are written until the forks in
+> "Open questions" are resolved.
+
+## Why this doc exists
+
+The orchestration layer works. The **identity layer underneath it is muddled**, and
+the correctness/UX complaints in the backlog are downstream symptoms. Three questions
+have never been answered in one place:
+
+1. What *is* a study, and where does study membership live?
+2. Is a sample in exactly one study, or many?
+3. What does "complete" mean when a pipeline has many versions?
+
+Today the code answers each of these inconsistently, in ways that silently disagree.
+
+## The problem, concretely
+
+There are **three independent representations of "what study a sample belongs to"**,
+and no server code path keeps them in sync (verified by a full read of `services/`,
+`routers/`, `scripts/`, and the frontend):
+
+| # | Representation | Cardinality | Written by | Read by |
+|---|---|---|---|---|
+| (a) | `collections` + `collection_samples` (`db.py:109-128`) | **many-to-many** (join table) | *only* `scripts/seed_collection_from_cohort.py` (manual backfill) | Cohorts dashboard: `services/cohort.py`, `CohortsPage.tsx` |
+| (b) | `curated_studies` + `curated_sample_annotations.study_name` (`db.py:249-274`) | **many-to-many** (`uq(sample_id, study_name)`) | `POST /api/curated/import` → `services/curated.py` | `/api/curated/*` only — **an island; nothing joins it to jobs/collections** |
+| (c) | `samples.metadata_.cohort` — free-text JSONB scalar (`db.py:99`) | **one-per-sample** (a scalar key) | every seeding script + the register form (`seed_from_tsv.py:73`, `load_bioproject.py:91`, `SamplesPage.tsx:211`) | Samples page grouping (`SamplesPage.tsx:85-146`) |
+
+Ways they silently disagree today:
+
+- **Samples page vs Cohorts dashboard show different truths for the same study.**
+  The Samples page groups by `metadata.cohort` (rep c); the Cohorts dashboard groups
+  by `collections` (rep a). A newly-registered sample appears under its cohort on the
+  Samples page *immediately* but is **invisible on the Cohorts dashboard until someone
+  manually runs `seed_collection_from_cohort.py --commit`.** Add samples to an existing
+  cohort later and the Cohorts dashboard silently undercounts.
+- **The same study lives under two different keys.** `seed_from_tsv.py:61` reads the
+  TSV's `study_name` column and stores it under `metadata.cohort`; the *same* TSV
+  imported through `/api/curated/import` keys everything by `study_name` in
+  `curated_sample_annotations` and never touches `metadata.cohort`. Same identity, two
+  spellings, no link.
+- **`load_bioproject.py` writes `cohort` *and* `sra_study` *and* `bioproject` into one
+  JSONB blob** (`load_bioproject.py:91-97`), any of which can disagree — and
+  `collections.source` adds a fourth notion (`bioproject|sra_study|manual`).
+
+## The three load-bearing decisions
+
+### Decision 1 — Study is first-class, and there is exactly ONE source of truth for membership
+
+Promote study to a real entity with a single membership table. **Rep (c)
+`metadata.cohort` is retired as a source of truth** (see Decision 2 for why it *must*
+be). Rep (a) `collections`/`collection_samples` is the survivor and becomes the
+canonical study entity. Rep (b) `curated_studies` is reconciled into it (fork below).
+
+### Decision 2 — Sample↔study is many-to-many (this is the decisive one)
+
+A `sample_id` is **content-addressed** — the md5 of its sorted, deduplicated SRR set
+(`db.py:88-91`). The identity is the *reads*, not the study context. The same physical
+SRR set legitimately recurs across contexts:
+
+- a BioProject, later re-analyzed as a curated cMD study;
+- the same run accessioned into two publications / meta-analyses;
+- a sample that is simultaneously in an `sra_study` collection and a hand-built
+  `manual` cohort.
+
+Therefore **sample↔study is many-to-many**, and this is not a corner case — it is the
+normal shape once curated overlays sit on top of a raw SRA substrate (the exact
+"minority overlay on a 10× raw substrate" framing of `sample-metadata-design.md`).
+
+This decision **kills rep (c) structurally, not just for tidiness**:
+`samples.metadata_.cohort` is a single scalar — it *cannot* express a sample in two
+studies. The join tables (a) and (b) already can. A scalar cohort field forces a lie
+whenever the true membership is >1. So membership **must** live in the join table, and
+`metadata.cohort` cannot be the source of truth.
+
+Consequence for completeness: "study X is N% complete" counts **distinct samples in
+X** (via the join table), and a sample completing counts toward *every* study it
+belongs to. That is correct and unambiguous under m2m; a scalar cohort would
+double-count or drop.
+
+### Decision 3 — Completion is measured in SAMPLES, under the ACTIVE version
+
+Two bugs in one (this is #116):
+
+1. **Counted in job rows across all versions.** `services/cohort.py::summary()` counts
+   `jobs` grouped by status with the workflow filter *optional and defaulted off*
+   (`cohort.py:75-104`) — so the denominator is `samples × all-ever-registered-versions`.
+   `ArtachoA_2021` reads **0.5% = 3/552** where 552 = 69 samples × 8 versions. Retiring
+   a workflow does **not** delete its `jobs` rows (`reconcile.py` only *creates* jobs
+   for `status='active'`; nothing removes them on retire), so completed work under old
+   versions pollutes both numerator and denominator forever.
+2. **Expressed in the wrong unit.** Operators think in *samples* ("8,200 / 10,000
+   done"), not job rows.
+
+**Position:** define per-study completion as
+
+```
+completion = (distinct samples in study with a COMPLETED job
+              under the workflow's ACTIVE version)
+             ÷ (distinct samples in study)
+```
+
+"All workflows" becomes an explicit opt-in, never the default denominator. This is a
+read-path fix (the *write* path is already version-correct: `MARK_COMPLETE` matches on
+`run_name`, which belongs to exactly one version — `telemetry.py:160-175`).
+
+## Proposed model
+
+Minimal schema change; mostly a consolidation plus one rule.
+
+### Samples — unchanged
+Content-addressed `sample_id` stays the identity and the universal join key. No study
+context on the sample row. (SRA-derivable columns from `sample-metadata-design.md` are
+orthogonal and can land independently.)
+
+### Study — one entity, one membership table
+Generalize `collections` into the canonical study entity (keep the table name to avoid
+churn, or rename to `studies` — cosmetic). `collection_samples` is the **single source
+of truth for membership** (many-to-many). `source` distinguishes origin
+(`bioproject|sra_study|cmd|manual`). Every path that today writes `metadata.cohort`
+instead upserts a `collections` row + `collection_samples` membership **server-side at
+registration** — closing the "invisible until backfill" gap by construction.
+
+**A curated cMD study is not a separate entity (resolved, was Fork 1).** It is a
+`collections` row with `source='cmd'`. `curated_sample_annotations` is reconceived as
+annotation *rows attached to that study* (FK to the study), not a parallel study table
+with its own `study_name` identity. There is exactly one study identity system-wide.
+The harmonization boundary of `sample-metadata-design.md` is preserved at the level
+that matters: study *identity* is operational and lives here; the *annotation content*
+(controlled-vocab facets, provenance, publications) remains harmonization's problem and
+does not move into the telemetry DB. `curated_studies.study_name` becomes the study's
+`label`/natural key on the unified row; annotation rows join to the study by its id.
+
+### `metadata.cohort` — demoted
+Retired as source of truth. Either dropped, or kept *only* as a denormalized display
+cache that is derived from membership (never written by clients). The Samples page
+grouping moves onto the membership join, matching the Cohorts dashboard.
+
+### Version / completion — one rule + version-scoped reads
+- **Rule (resolved, was Fork 2): exactly one `active` version per `workflow_id`**,
+  enforced by a partial unique index (`WHERE status='active'`). Promoting a new version
+  to active auto-retires the prior active version in the same transaction. This makes
+  "the active version" a single unambiguous row, so Decision 3's completion query is
+  well-defined by construction. `reconcile.py`'s cross-join over active workflows then
+  yields at most one active version per `workflow_id`, as intended.
+- Rewrite the aggregate read paths (`cohort.py::summary`, `admin.py::stats`) to join
+  `workflows` and scope to the active version, counting **distinct samples**. The
+  per-workflow path (`workflows.py::job_summary`) is already version-scoped via
+  `workflow_pk` and needs no change.
+
+## Migration plan (sketch — not yet written)
+
+Non-destructive, staged; each step independently shippable and reversible:
+
+1. **Server-side membership on registration.** `POST /api/samples` (and the seeding
+   scripts) upsert `collections` + `collection_samples` from the supplied study, in the
+   same transaction as the sample. `metadata.cohort` still written (dual-write) so
+   nothing breaks.
+2. **Backfill.** Fold `scripts/seed_collection_from_cohort.py` logic into a one-shot
+   admin endpoint; reconcile existing `metadata.cohort` and `curated_sample_annotations`
+   into `collections`/`collection_samples`.
+3. **Move reads to membership.** Samples page + Cohorts dashboard read the join;
+   completion queries scoped to active version, counted in distinct samples.
+4. **Enforce single-active-version:** add the partial unique index and the
+   promote-auto-retires-prior transaction (Decision resolved above).
+5. **Demote `metadata.cohort`** to derived-cache or drop, after all reads have moved.
+
+## Resolved decisions
+
+- **Fork 1 — study entity: UNIFIED.** One study entity; a cMD study is a `collections`
+  row with `source='cmd'`; `curated_sample_annotations` are annotation rows attached to
+  it. (Folded into "Proposed model → Study" above.)
+- **Fork 2 — active version: EXACTLY ONE per `workflow_id`**, partial-unique-index
+  enforced, promote-auto-retires-prior. (Folded into "Version / completion" above.)
+
+## Open questions (remaining)
+
+1. **Drop `metadata.cohort` entirely, or keep it as a read-only derived cache?**
+   Position: keep short-term as a derived display cache (less frontend churn), drop once
+   the Samples page reads membership directly. Low-stakes; decide at migration step 5.
+2. **Rename `collections` → `studies`?** Purely cosmetic; the table becomes *the* study
+   entity so the name `collections` is now slightly misleading. Defer to migration time.
+
+## What this design explicitly does NOT do
+
+- Does **not** change `sample_id` (content-addressing stays).
+- Does **not** pull publications, vocabularies, or provenance into the telemetry DB —
+  that boundary from `sample-metadata-design.md` is unchanged.
+- Does **not** couple dispatch/reconcile to study identity beyond what already exists.
+- Does **not** attempt subject-level identity (cMD `subject_id`) — sample-level only.
+- Does **not** touch the outputs catalog schema (#57) — but it *unblocks* it by giving
+  the catalog a stable study key to group outputs under.

--- a/src/nextflow_telemetry/routers/admin.py
+++ b/src/nextflow_telemetry/routers/admin.py
@@ -252,8 +252,12 @@ def create_admin_router(engine: AsyncEngine) -> APIRouter:
         description=(
             "Returns total sample/workflow counts, jobs grouped by status, "
             "workflow runs grouped by status, and the count of unresolved "
-            "dead-letter entries. Lightweight — used by `nf-client stats` "
-            "to give operators a one-shot system overview."
+            "dead-letter entries. `jobs_by_status` counts every job across all "
+            "workflow versions (including retired ones); `jobs_by_status_active` "
+            "counts only jobs under a currently-active workflow version — the "
+            "actionable numbers, undiluted by orphaned retired-version jobs "
+            "(#114/#116). Lightweight — used by `nf-client stats` to give "
+            "operators a one-shot system overview."
         ),
     )
     async def stats():
@@ -266,6 +270,17 @@ def create_admin_router(engine: AsyncEngine) -> APIRouter:
             )).scalar_one()
             jobs_rows = (await conn.execute(
                 select(jobs_tbl.c.status, func.count())
+                .group_by(jobs_tbl.c.status)
+            )).all()
+            # Same breakdown, but only jobs whose workflow version is active.
+            # workflow_pk identifies the exact (workflow_id, version) row, so the
+            # join is precise — retired-version jobs are excluded (#114/#116).
+            jobs_active_rows = (await conn.execute(
+                select(jobs_tbl.c.status, func.count())
+                .select_from(
+                    jobs_tbl.join(workflows_tbl, jobs_tbl.c.workflow_pk == workflows_tbl.c.id)
+                )
+                .where(workflows_tbl.c.status == "active")
                 .group_by(jobs_tbl.c.status)
             )).all()
             runs_rows = (await conn.execute(
@@ -281,6 +296,7 @@ def create_admin_router(engine: AsyncEngine) -> APIRouter:
             "samples": samples_total,
             "workflows": workflows_total,
             "jobs_by_status": {status: count for status, count in jobs_rows},
+            "jobs_by_status_active": {status: count for status, count in jobs_active_rows},
             "runs_by_status": {status: count for status, count in runs_rows},
             "dead_letter_unresolved": dlq_unresolved,
         }

--- a/src/nextflow_telemetry/routers/cohorts.py
+++ b/src/nextflow_telemetry/routers/cohorts.py
@@ -51,9 +51,19 @@ class CohortSummaryResponse(BaseModel):
     workflow_id: Optional[str] = None
     workflow_version: Optional[str] = None
     sample_count: int = Field(description="Total samples in the cohort.")
-    total_jobs: int = Field(description="Total jobs across all statuses, after the workflow filter is applied.")
+    samples_completed: int = Field(
+        default=0,
+        description="Distinct samples with a completed job in scope (numerator of completion_pct).",
+    )
+    total_jobs: int = Field(description="Total jobs across all statuses, after the workflow scope is applied.")
     job_status_counts: CohortJobStatusCounts
-    completion_pct: float = Field(description="completed / total_jobs × 100. Zero when total_jobs is 0.")
+    completion_pct: float = Field(
+        description=(
+            "samples_completed / sample_count × 100 — study completeness in "
+            "distinct samples under the active workflow version. Zero when the "
+            "cohort has no samples."
+        )
+    )
     failure_by_process: list[CohortFailureByProcessRow]
     generated_at_utc: datetime.datetime
 
@@ -96,17 +106,23 @@ def create_cohorts_router(engine: AsyncEngine) -> APIRouter:
         summary="Cohort summary: completion %, status counts, and failure-by-process",
         description=(
             "Aggregates job status across all samples in the cohort and identifies "
-            "which Nextflow processes are producing the most failures. Filter by "
-            "`workflow_id` and `workflow_version` to scope to a specific pipeline; "
-            "omit them for an all-workflows view."
+            "which Nextflow processes are producing the most failures. By default, "
+            "completion and counts are scoped to the **active** workflow version. "
+            "Filter by `workflow_id`/`workflow_version` to scope to a specific "
+            "pipeline (including retired versions), or pass `all_workflows=true` "
+            "for the across-all-versions view."
         ),
     )
     async def get_summary(
         collection_id: Annotated[str, Path(description="Collection identifier (e.g. PRJNA123456).")],
         workflow_id: Annotated[Optional[str], Query(description="Restrict to a single workflow.")] = None,
         workflow_version: Annotated[Optional[str], Query(description="Restrict to a specific workflow version.")] = None,
+        all_workflows: Annotated[bool, Query(description="Count across ALL workflow versions instead of just the active one.")] = False,
     ) -> CohortSummaryResponse:
-        summary = await svc.summary(collection_id, workflow_id, workflow_version)
+        summary = await svc.summary(
+            collection_id, workflow_id, workflow_version,
+            include_all_workflows=all_workflows,
+        )
         if summary is None:
             raise HTTPException(status_code=404, detail=f"Cohort '{collection_id}' not found.")
         return CohortSummaryResponse.model_validate(summary)
@@ -126,13 +142,15 @@ def create_cohorts_router(engine: AsyncEngine) -> APIRouter:
         process: Annotated[str, Query(description="Fully-qualified Nextflow process name (e.g. `FETCH_READS`).")],
         workflow_id: Annotated[Optional[str], Query()] = None,
         workflow_version: Annotated[Optional[str], Query()] = None,
+        all_workflows: Annotated[bool, Query(description="Include failures across ALL workflow versions instead of just the active one.")] = False,
         limit: Annotated[int, Query(ge=1, le=1000, description="Max rows.")] = 200,
     ) -> CohortFailuresResponse:
         # Match /summary's behaviour: 404 on unknown cohort, not 200 + empty rows.
         if not await svc.cohort_exists(collection_id):
             raise HTTPException(status_code=404, detail=f"Cohort '{collection_id}' not found.")
         rows = await svc.failures_for_process(
-            collection_id, process, workflow_id, workflow_version, limit=limit
+            collection_id, process, workflow_id, workflow_version,
+            limit=limit, include_all_workflows=all_workflows,
         )
         return CohortFailuresResponse(
             collection_id=collection_id,

--- a/src/nextflow_telemetry/services/cohort.py
+++ b/src/nextflow_telemetry/services/cohort.py
@@ -43,13 +43,59 @@ class CohortService:
         async with self.engine.connect() as conn:
             return [dict(r) for r in (await conn.execute(sql)).mappings()]
 
+    @staticmethod
+    def _workflow_scope(
+        alias: str,
+        workflow_id: str | None,
+        workflow_version: str | None,
+        include_all_workflows: bool,
+    ) -> str:
+        """Build the workflow-scoping SQL fragment for a job/telemetry alias.
+
+        Three modes, matching the study/sample/version identity design
+        (docs/study-sample-version-identity.md, Decision 3):
+
+        - **explicit**: caller passed workflow_id and/or workflow_version — scope
+          to exactly that, including retired versions (opt into a specific view).
+        - **all**: include_all_workflows=True — no version scoping (the old
+          behaviour, now an explicit opt-in, never the default denominator).
+        - **active (default)**: only jobs/events whose (workflow_id, version) is a
+          currently-active workflow. Retired-version rows left in `jobs` after a
+          workflow is retired no longer pollute the counts (fixes #116).
+
+        Uses a correlated EXISTS rather than a JOIN so the aggregate row counts
+        are unaffected by the workflows table's cardinality.
+        """
+        if workflow_id or workflow_version:
+            frag = ""
+            if workflow_id:
+                frag += f" AND {alias}.workflow_id = :workflow_id"
+            if workflow_version:
+                frag += f" AND {alias}.workflow_version = :workflow_version"
+            return frag
+        if include_all_workflows:
+            return ""
+        return (
+            f" AND EXISTS (SELECT 1 FROM workflows w "
+            f"WHERE w.workflow_id = {alias}.workflow_id "
+            f"AND w.version = {alias}.workflow_version "
+            f"AND w.status = 'active')"
+        )
+
     async def summary(
         self,
         collection_id: str,
         workflow_id: str | None,
         workflow_version: str | None,
+        include_all_workflows: bool = False,
     ) -> dict | None:
-        """Return cohort summary or None if the collection does not exist."""
+        """Return cohort summary or None if the collection does not exist.
+
+        Completion is measured in **distinct samples** under the **active**
+        workflow version by default: ``completion_pct`` is the fraction of the
+        cohort's samples that have a completed job in scope, not completed job
+        rows over total job rows. See docs/study-sample-version-identity.md.
+        """
         async with self.engine.connect() as conn:
             exists = (
                 await conn.execute(
@@ -73,23 +119,28 @@ class CohortService:
             ).scalar() or 0
 
             params: dict = {"cid": collection_id}
-            wf_filter = ""
             if workflow_id:
-                wf_filter += " AND j.workflow_id = :workflow_id"
                 params["workflow_id"] = workflow_id
             if workflow_version:
-                wf_filter += " AND j.workflow_version = :workflow_version"
                 params["workflow_version"] = workflow_version
+            job_scope = self._workflow_scope(
+                "j", workflow_id, workflow_version, include_all_workflows
+            )
+            tel_scope = self._workflow_scope(
+                "t", workflow_id, workflow_version, include_all_workflows
+            )
 
             status_rows = (
                 await conn.execute(
                     text(
                         f"""
-                        SELECT j.status, COUNT(*) AS n
+                        SELECT j.status,
+                               COUNT(*) AS n,
+                               COUNT(DISTINCT j.sample_id) AS n_samples
                         FROM jobs j
                         JOIN collection_samples cs ON cs.sample_id = j.sample_id
                         WHERE cs.collection_id = :cid
-                          {wf_filter}
+                          {job_scope}
                         GROUP BY j.status
                         """
                     ),
@@ -97,11 +148,19 @@ class CohortService:
                 )
             ).mappings().all()
             counts = {s: 0 for s in _JOB_STATUSES}
+            samples_completed = 0
             for r in status_rows:
                 if r["status"] in counts:
                     counts[r["status"]] = r["n"]
+                if r["status"] == "completed":
+                    samples_completed = r["n_samples"]
             total = sum(counts.values())
-            completion_pct = (counts["completed"] / total * 100.0) if total > 0 else 0.0
+            # Completeness of the STUDY: distinct completed samples over all
+            # samples in the cohort — a sample with no job yet counts as
+            # incomplete. Denominator is sample_count, not total_jobs (#116).
+            completion_pct = (
+                (samples_completed / sample_count * 100.0) if sample_count > 0 else 0.0
+            )
 
             failure_rows = (
                 await conn.execute(
@@ -115,8 +174,7 @@ class CohortService:
                         WHERE cs.collection_id = :cid
                           AND t.event = 'process_completed'
                           AND t.trace->>'status' IN ('FAILED', 'ABORTED')
-                          {("AND t.workflow_id = :workflow_id" if workflow_id else "")}
-                          {("AND t.workflow_version = :workflow_version" if workflow_version else "")}
+                          {tel_scope}
                           AND t.trace->>'process' IS NOT NULL
                         GROUP BY t.trace->>'process'
                         ORDER BY failed_count DESC, process
@@ -133,6 +191,7 @@ class CohortService:
             "workflow_id": workflow_id,
             "workflow_version": workflow_version,
             "sample_count": sample_count,
+            "samples_completed": samples_completed,
             "job_status_counts": counts,
             "total_jobs": total,
             "completion_pct": round(completion_pct, 2),
@@ -157,6 +216,7 @@ class CohortService:
         workflow_id: str | None,
         workflow_version: str | None,
         limit: int = 200,
+        include_all_workflows: bool = False,
     ) -> list[dict]:
         """Return failed task occurrences for a given (cohort, process).
 
@@ -164,15 +224,17 @@ class CohortService:
         so the UI can link straight to the existing log viewer. Caller is
         responsible for checking that the cohort exists (use cohort_exists)
         — this method returns an empty list for unknown cohorts.
+
+        Scoped to the active workflow version by default, matching summary().
         """
         params: dict = {"cid": collection_id, "process": process, "limit": limit}
-        wf_filter = ""
         if workflow_id:
-            wf_filter += " AND t.workflow_id = :workflow_id"
             params["workflow_id"] = workflow_id
         if workflow_version:
-            wf_filter += " AND t.workflow_version = :workflow_version"
             params["workflow_version"] = workflow_version
+        wf_filter = self._workflow_scope(
+            "t", workflow_id, workflow_version, include_all_workflows
+        )
 
         sql = text(
             f"""

--- a/tests/test_cohorts_router.py
+++ b/tests/test_cohorts_router.py
@@ -13,7 +13,7 @@ import uuid
 from datetime import datetime, timezone
 
 import pytest
-from sqlalchemy import insert, select, text
+from sqlalchemy import insert, select, text, update
 from sqlalchemy.ext.asyncio import create_async_engine
 
 
@@ -319,6 +319,58 @@ def test_summary_excludes_samples_not_in_cohort(integration_client, db_url, coho
     assert body["total_jobs"] == 1
     assert body["job_status_counts"]["completed"] == 1
     assert body["failure_by_process"] == []
+
+
+def _set_workflow_status(db_url: str, workflow_id: str, version: str, status: str) -> None:
+    from nextflow_telemetry.db import workflows_tbl
+
+    _run(_exec(
+        db_url,
+        update(workflows_tbl)
+        .where(workflows_tbl.c.workflow_id == workflow_id, workflows_tbl.c.version == version)
+        .values(status=status),
+    ))
+
+
+def test_summary_completion_scoped_to_active_version(integration_client, db_url, cohort_data):
+    """#116: completed work under a RETIRED version must not dilute or inflate
+    completion. Default view scopes to the active version and measures distinct
+    samples; all_workflows=true opts back into the across-all-versions view.
+    """
+    client, _ = integration_client
+    tag = cohort_data
+    cid = f"COHORT-{tag}"
+    wf = f"wf-{tag}"
+    samples = [f"S-{tag}-{i}" for i in range(4)]
+    _seed_cohort(db_url, collection_id=cid, sample_ids=samples)
+
+    # Active version 2.0.0: two completed, one pending, one with no job at all.
+    _seed_jobs(db_url, samples[0], "completed", workflow_id=wf, workflow_version="2.0.0")
+    _seed_jobs(db_url, samples[1], "completed", workflow_id=wf, workflow_version="2.0.0")
+    _seed_jobs(db_url, samples[2], "pending",   workflow_id=wf, workflow_version="2.0.0")
+    # Retired version 1.0.0: ALL four completed (prior pipeline run).
+    for s in samples:
+        _seed_jobs(db_url, s, "completed", workflow_id=wf, workflow_version="1.0.0")
+    _set_workflow_status(db_url, wf, "1.0.0", "retired")  # 2.0.0 stays active
+
+    # Default: active version only, completion in distinct samples.
+    resp = client.get(f"/api/cohorts/{cid}/summary")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["sample_count"] == 4
+    assert body["total_jobs"] == 3            # only the 2.0.0 jobs
+    assert body["job_status_counts"]["completed"] == 2
+    assert body["job_status_counts"]["pending"] == 1
+    assert body["samples_completed"] == 2
+    assert body["completion_pct"] == 50.0     # 2 of 4 samples, NOT 6/7 job rows
+
+    # Opt-in to all versions: retired-version completions reappear.
+    resp_all = client.get(f"/api/cohorts/{cid}/summary?all_workflows=true")
+    body_all = resp_all.json()
+    assert body_all["total_jobs"] == 7        # 3 active + 4 retired
+    assert body_all["job_status_counts"]["completed"] == 6
+    assert body_all["samples_completed"] == 4  # all four completed under 1.0.0
+    assert body_all["completion_pct"] == 100.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -943,9 +943,10 @@ def test_admin_stats_shape_and_increments(integration_client):
     before = client.get("/api/admin/stats")
     assert before.status_code == 200
     pre = before.json()
-    for key in ("samples", "workflows", "jobs_by_status", "runs_by_status", "dead_letter_unresolved"):
+    for key in ("samples", "workflows", "jobs_by_status", "jobs_by_status_active", "runs_by_status", "dead_letter_unresolved"):
         assert key in pre
     assert isinstance(pre["jobs_by_status"], dict)
+    assert isinstance(pre["jobs_by_status_active"], dict)
     assert isinstance(pre["runs_by_status"], dict)
 
     sample_id = f"SRR-stats-{uuid.uuid4().hex[:6]}"
@@ -960,3 +961,33 @@ def test_admin_stats_shape_and_increments(integration_client):
     pending_before = pre["jobs_by_status"].get("pending", 0)
     pending_after = after["jobs_by_status"].get("pending", 0)
     assert pending_after >= pending_before + 1
+    # The new workflow is active, so the active-scoped bucket increments too.
+    active_pending_before = pre["jobs_by_status_active"].get("pending", 0)
+    active_pending_after = after["jobs_by_status_active"].get("pending", 0)
+    assert active_pending_after >= active_pending_before + 1
+
+
+def test_admin_stats_active_bucket_excludes_retired_versions(integration_client):
+    """#114/#116: jobs under a retired workflow version count in jobs_by_status
+    but NOT in jobs_by_status_active."""
+    client, _ = integration_client
+    sample_id = f"SRR-retstat-{uuid.uuid4().hex[:6]}"
+    wf_id = f"retstat-{uuid.uuid4().hex[:6]}"
+    assert client.post("/api/samples", json={"sample_id": sample_id, "ncbi_accession": "SRR000001"}).status_code == 201
+    # Active version -> reconcile creates a pending job under it.
+    assert client.post("/api/workflows", json=_wf_payload(workflow_id=wf_id, version="1.0.0")).status_code in (200, 201)
+    assert client.post("/api/admin/reconcile-jobs").status_code == 200
+
+    baseline = client.get("/api/admin/stats").json()
+    all_pending = baseline["jobs_by_status"].get("pending", 0)
+    active_pending = baseline["jobs_by_status_active"].get("pending", 0)
+
+    # Retire the version: its pending job stays in `jobs` but must drop out of
+    # the active bucket. All-versions bucket is unchanged.
+    wf_pk = client.get(f"/api/workflows?status=active").json()
+    pk = next(w["id"] for w in wf_pk if w["workflow_id"] == wf_id)
+    assert client.patch(f"/api/workflows/{pk}/status", json={"status": "retired"}).status_code == 200
+
+    after = client.get("/api/admin/stats").json()
+    assert after["jobs_by_status"].get("pending", 0) == all_pending          # unchanged
+    assert after["jobs_by_status_active"].get("pending", 0) == active_pending - 1  # dropped


### PR DESCRIPTION
## Summary

Kicks off the roadmap: settles **Epic A** (the identity model) and lands the highest-leverage **Epic B** correctness fixes that depended on it. All changes are read-path / additive — no schema migration, safe to deploy.

### Epic A — design doc
`docs/study-sample-version-identity.md` settles the three identity decisions the backlog's correctness/UX pain traces to:
- **Study is first-class**, one source of truth for membership (`collections`/`collection_samples`); `metadata_.cohort` retired as source of truth.
- **Sample↔study is many-to-many** — a content-addressed `sample_id` recurs across studies, which structurally rules out a scalar cohort field.
- **Completion is measured in distinct samples under the active workflow version.**
- Resolved forks: **unified** study entity (a cMD study is a `collections` row with `source='cmd'`); **exactly one active version** per `workflow_id`.

### #116 — completion measured in samples under the active version
`completion_pct` was `completed_jobs / total_jobs` across **all** workflow versions, so a study done under the active pipeline but carrying retired-version jobs read as near-0% (observed: `ArtachoA_2021` at **0.5% = 3/552** over 8 versions).
- `cohort.summary()` now scopes to the active version by default (correlated `EXISTS`) and reports **distinct completed samples / total cohort samples**.
- Additive `samples_completed` field → the frontend shows correct numbers with **no frontend change**.
- Explicit `workflow_id/version` still scopes precisely; new `all_workflows=true` opts into the old across-versions view. Same scoping applied to failure-by-process + failures drill-down.

### #114 (stats half) — the "298 pending illusion"
`/admin/stats` gains `jobs_by_status_active` alongside the all-versions `jobs_by_status`, so orphaned retired-version jobs are distinguishable from actionable pending work.

## Tests
- New: active-version scoping for cohorts (retired-version completions no longer dilute — default reads honest 50% vs the old ~86% over job rows).
- New: admin-stats active bucket excludes retired versions.
- **Full suite: 137 passed**, mypy clean.

## Not in this PR (follow-ups)
- Frontend: samples-based labels + #119 cross-study leaderboard on the corrected semantics.
- #114 remainder: reconcile-on-retire behavior.
- Migration to enforce single-active-version (needs a prod data-cleanup step first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)