### PR TITLE
Cross-study completeness leaderboard (#119)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -76,7 +76,10 @@ Tracker: **#62**. "Know when/why a run died."
 Built on B's corrected semantics. From the UI eval (#116–#122) + older UI issues.
 - **#117** completion timeline endpoint → burndown + ETA + rate-based stall alert
   (the single biggest missing thing for a 100k operator).
-- **#119** cross-study completeness leaderboard (depends on #116).
+- **#119** cross-study completeness leaderboard (depends on #116). _DONE: batched
+  `GET /api/cohorts/leaderboard` (active-version completion in samples, laggards-first)
+  + sortable leaderboard table on CohortsPage with a "stalled" flag (no completion in
+  7d). Single-cohort drill-down kept below._
 - **#118** server-side pagination for Samples/Runs/cohort-failures (Samples is broken
   past 1000 rows today).
 - **#120** failure-triage drill-down: failed task → its log (`task_hash` exists,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -24,6 +24,7 @@ import type {
   RunsListResponse,
   RunDetail,
   CohortListItem,
+  CohortLeaderboardRow,
   CohortSummaryResponse,
   CohortFailuresResponse,
 } from '../types'
@@ -150,6 +151,7 @@ export const api = {
 
   cohorts: {
     list: () => get<CohortListItem[]>('/cohorts'),
+    leaderboard: () => get<CohortLeaderboardRow[]>('/cohorts/leaderboard'),
     summary: (collectionId: string, opts: { workflowId?: string; workflowVersion?: string } = {}) => {
       const p = new URLSearchParams()
       if (opts.workflowId)      p.set('workflow_id',      opts.workflowId)

--- a/frontend/src/pages/CohortsPage.tsx
+++ b/frontend/src/pages/CohortsPage.tsx
@@ -9,10 +9,139 @@ import SectionHeader from '../components/SectionHeader'
 import Btn from '../components/Btn'
 import type {
   CohortListItem,
+  CohortLeaderboardRow,
   CohortSummaryResponse,
   CohortFailureRow,
   WorkflowResponse,
 } from '../types'
+
+const STALL_DAYS = 7
+
+function isStalled(r: CohortLeaderboardRow): boolean {
+  if (r.samples_remaining <= 0) return false            // nothing left to do
+  if (!r.last_completed_at) return true                 // remaining, never completed
+  const days = (Date.now() - new Date(r.last_completed_at).getTime()) / 86_400_000
+  return days > STALL_DAYS
+}
+
+type LbSortKey = 'collection_id' | 'sample_count' | 'samples_completed' | 'samples_remaining' | 'completion_pct'
+
+function CompletionBar({ pct }: { pct: number }) {
+  const color = pct >= 99.5 ? T.green : pct >= 50 ? T.amber : T.red
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <div style={{ position: 'relative', flex: 1, height: 6, background: T.border, borderRadius: 3, overflow: 'hidden' }}>
+        <div style={{ position: 'absolute', top: 0, left: 0, height: '100%', width: `${Math.min(100, pct)}%`, background: color }} />
+      </div>
+      <div style={{ fontSize: 12, color: T.text, fontFamily: 'DM Mono, monospace', minWidth: 48, textAlign: 'right' }}>
+        {pct.toFixed(1)}%
+      </div>
+    </div>
+  )
+}
+
+const LB_COLS = '1fr 70px 80px 80px 60px 60px 200px 96px'
+
+function LeaderboardTable({
+  rows, selected, onSelect,
+}: {
+  rows: CohortLeaderboardRow[]
+  selected: string
+  onSelect: (id: string) => void
+}) {
+  const [sortKey, setSortKey] = useState<LbSortKey>('completion_pct')
+  const [dir, setDir] = useState<'asc' | 'desc'>('asc')
+
+  const sorted = useMemo(() => {
+    const s = [...rows].sort((a, b) => {
+      const av = a[sortKey]
+      const bv = b[sortKey]
+      if (typeof av === 'string' && typeof bv === 'string') return av.localeCompare(bv)
+      return (av as number) - (bv as number)
+    })
+    return dir === 'asc' ? s : s.reverse()
+  }, [rows, sortKey, dir])
+
+  const toggle = (k: LbSortKey) => {
+    if (k === sortKey) setDir(d => (d === 'asc' ? 'desc' : 'asc'))
+    else { setSortKey(k); setDir('asc') }
+  }
+
+  const Th = ({ k, label, align = 'right' }: { k: LbSortKey; label: string; align?: 'left' | 'right' }) => (
+    <button
+      type="button"
+      onClick={() => toggle(k)}
+      style={{
+        font: 'inherit', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0,
+        fontSize: 10, color: sortKey === k ? T.text : T.muted, textTransform: 'uppercase', letterSpacing: '0.06em',
+        textAlign: align, justifySelf: align === 'right' ? 'end' : 'start',
+      }}
+    >
+      {label}{sortKey === k ? (dir === 'asc' ? ' ↑' : ' ↓') : ''}
+    </button>
+  )
+
+  if (rows.length === 0) {
+    return <div style={{ fontSize: 12, color: T.muted, padding: 14 }}>No cohorts yet.</div>
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column' }}>
+      <div style={{
+        display: 'grid', gridTemplateColumns: LB_COLS, gap: 12, padding: '8px 12px',
+        borderBottom: `1px solid ${T.border}`,
+      }}>
+        <Th k="collection_id" label="Study" align="left" />
+        <Th k="sample_count" label="Samples" />
+        <Th k="samples_completed" label="Done" />
+        <Th k="samples_remaining" label="Left" />
+        <div style={{ fontSize: 10, color: T.muted, textTransform: 'uppercase', letterSpacing: '0.06em', textAlign: 'right' }}>Fail</div>
+        <div style={{ fontSize: 10, color: T.muted, textTransform: 'uppercase', letterSpacing: '0.06em', textAlign: 'right' }}>Run</div>
+        <Th k="completion_pct" label="Completion (active)" align="left" />
+        <div style={{ fontSize: 10, color: T.muted, textTransform: 'uppercase', letterSpacing: '0.06em', textAlign: 'right' }}>Last done</div>
+      </div>
+      {sorted.map(r => {
+        const stalled = isStalled(r)
+        const isSel = r.collection_id === selected
+        return (
+          <button
+            key={r.collection_id}
+            type="button"
+            onClick={() => onSelect(r.collection_id)}
+            aria-pressed={isSel}
+            style={{
+              display: 'grid', gridTemplateColumns: LB_COLS, gap: 12, padding: '10px 12px', alignItems: 'center',
+              borderBottom: `1px solid ${T.border}`, borderLeft: `2px solid ${isSel ? T.accent : 'transparent'}`,
+              background: isSel ? T.accentDim : 'transparent',
+              font: 'inherit', color: 'inherit', textAlign: 'inherit', width: '100%', cursor: 'pointer',
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, overflow: 'hidden' }}>
+              <span style={{ fontFamily: 'DM Mono, monospace', fontSize: 12, color: T.text, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {r.collection_id}
+              </span>
+              {stalled && (
+                <span style={{
+                  fontSize: 9, color: T.red, border: `1px solid ${T.red}`, borderRadius: 3,
+                  padding: '1px 5px', textTransform: 'uppercase', letterSpacing: '0.05em', flexShrink: 0,
+                }}>
+                  Stalled
+                </span>
+              )}
+            </div>
+            <div style={{ fontSize: 12, color: T.text, textAlign: 'right', fontFamily: 'DM Mono, monospace' }}>{fmtNum(r.sample_count)}</div>
+            <div style={{ fontSize: 12, color: T.green, textAlign: 'right', fontFamily: 'DM Mono, monospace' }}>{fmtNum(r.samples_completed)}</div>
+            <div style={{ fontSize: 12, color: T.muted, textAlign: 'right', fontFamily: 'DM Mono, monospace' }}>{fmtNum(r.samples_remaining)}</div>
+            <div style={{ fontSize: 12, color: r.samples_failed ? T.red : T.muted, textAlign: 'right', fontFamily: 'DM Mono, monospace' }}>{fmtNum(r.samples_failed)}</div>
+            <div style={{ fontSize: 12, color: r.samples_running ? T.amber : T.muted, textAlign: 'right', fontFamily: 'DM Mono, monospace' }}>{fmtNum(r.samples_running)}</div>
+            <CompletionBar pct={r.completion_pct} />
+            <div style={{ fontSize: 10, color: T.muted, textAlign: 'right' }}>{r.last_completed_at ? fmtDate(r.last_completed_at) : '—'}</div>
+          </button>
+        )
+      })}
+    </div>
+  )
+}
 
 function StatusChip({ label, count, color }: { label: string; count: number; color: string }) {
   return (
@@ -130,6 +259,7 @@ export default function CohortsPage({ pollInterval = 30_000 }: { pollInterval?: 
   const { tick, refresh, lastUpdated } = usePoll(pollInterval)
 
   const [cohorts, setCohorts] = useState<CohortListItem[]>([])
+  const [leaderboard, setLeaderboard] = useState<CohortLeaderboardRow[]>([])
   const [selectedCohort, setSelectedCohort] = useState<string>('')
   const [workflows, setWorkflows] = useState<WorkflowResponse[]>([])
   const [workflowKey, setWorkflowKey] = useState<string>('')  // "wf_id|version" or ""
@@ -140,6 +270,7 @@ export default function CohortsPage({ pollInterval = 30_000 }: { pollInterval?: 
 
   useEffect(() => {
     api.cohorts.list().then(setCohorts).catch(console.error)
+    api.cohorts.leaderboard().then(setLeaderboard).catch(console.error)
     api.workflows.list().then(setWorkflows).catch(console.error)
   }, [tick])
 
@@ -254,6 +385,16 @@ export default function CohortsPage({ pollInterval = 30_000 }: { pollInterval?: 
         </div>
       </Panel>
 
+      <Panel>
+        <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 12 }}>
+          <div style={{ fontSize: 12, fontWeight: 700, color: T.text }}>Study leaderboard</div>
+          <div style={{ fontSize: 11, color: T.muted }}>
+            {leaderboard.length} stud{leaderboard.length === 1 ? 'y' : 'ies'} · completion in samples under the active workflow version
+          </div>
+        </div>
+        <LeaderboardTable rows={leaderboard} selected={selectedCohort} onSelect={setSelectedCohort} />
+      </Panel>
+
       {summary && (
         <>
           <Panel>
@@ -278,6 +419,9 @@ export default function CohortsPage({ pollInterval = 30_000 }: { pollInterval?: 
                 <div style={{ fontSize: 10, color: T.muted, textTransform: 'uppercase', letterSpacing: '0.06em' }}>Completion</div>
                 <div style={{ fontSize: 20, fontWeight: 700, color: T.green, fontFamily: 'DM Mono, monospace' }}>
                   {summary.completion_pct.toFixed(1)}%
+                </div>
+                <div style={{ fontSize: 10, color: T.muted, fontFamily: 'DM Mono, monospace' }}>
+                  {fmtNum(summary.samples_completed)} / {fmtNum(summary.sample_count)} samples
                 </div>
               </div>
             </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -434,11 +434,25 @@ export interface CohortSummaryResponse {
   workflow_id: string | null
   workflow_version: string | null
   sample_count: number
+  samples_completed: number
   total_jobs: number
   job_status_counts: CohortJobStatusCounts
   completion_pct: number
   failure_by_process: CohortFailureByProcessRow[]
   generated_at_utc: string
+}
+
+export interface CohortLeaderboardRow {
+  collection_id: string
+  source: string
+  label: string | null
+  sample_count: number
+  samples_completed: number
+  samples_failed: number
+  samples_running: number
+  samples_remaining: number
+  completion_pct: number
+  last_completed_at: string | null
 }
 
 export interface CohortFailureRow {

--- a/src/nextflow_telemetry/routers/cohorts.py
+++ b/src/nextflow_telemetry/routers/cohorts.py
@@ -29,6 +29,21 @@ class CohortListItem(BaseModel):
     updated_at: datetime.datetime
 
 
+class CohortLeaderboardRow(BaseModel):
+    collection_id: str
+    source: str
+    label: Optional[str] = None
+    sample_count: int
+    samples_completed: int
+    samples_failed: int
+    samples_running: int
+    samples_remaining: int
+    completion_pct: float = Field(description="samples_completed / sample_count × 100, active version.")
+    last_completed_at: Optional[datetime.datetime] = Field(
+        default=None, description="Most recent sample completion; null if none. Use to flag stalled studies."
+    )
+
+
 class CohortJobStatusCounts(BaseModel):
     pending: int = 0
     claimed: int = 0
@@ -99,6 +114,22 @@ def create_cohorts_router(engine: AsyncEngine) -> APIRouter:
     async def list_cohorts() -> list[CohortListItem]:
         rows = await svc.list_cohorts()
         return [CohortListItem(**r) for r in rows]
+
+    @router.get(
+        "/leaderboard",
+        response_model=list[CohortLeaderboardRow],
+        summary="Cross-study completeness leaderboard",
+        description=(
+            "One row per cohort with active-version completion, sorted "
+            "laggards-first (least complete, then largest). Lets an operator rank "
+            "many studies by completeness in a single call instead of opening each "
+            "cohort's summary. Completion semantics match /summary (distinct "
+            "samples completed under the active workflow version)."
+        ),
+    )
+    async def leaderboard() -> list[CohortLeaderboardRow]:
+        rows = await svc.leaderboard()
+        return [CohortLeaderboardRow(**r) for r in rows]
 
     @router.get(
         "/{collection_id}/summary",

--- a/src/nextflow_telemetry/services/cohort.py
+++ b/src/nextflow_telemetry/services/cohort.py
@@ -82,6 +82,70 @@ class CohortService:
             f"AND w.status = 'active')"
         )
 
+    async def leaderboard(self) -> list[dict]:
+        """Return every cohort with active-version completion, one row each.
+
+        The cross-study view for #119: a PI monitoring many studies sees them
+        ranked by completeness without opening each. Completion is measured the
+        same way as summary() — distinct samples with a completed job under the
+        active workflow version ÷ distinct samples in the cohort — but computed
+        for all cohorts in a single query. Sorted laggards-first (least complete,
+        then largest) so the study that needs attention floats to the top.
+        """
+        sql = text(
+            """
+            SELECT c.collection_id,
+                   c.source,
+                   c.label,
+                   COUNT(DISTINCT cs.sample_id) AS sample_count,
+                   COUNT(DISTINCT cs.sample_id) FILTER (
+                       WHERE j.status = 'completed') AS samples_completed,
+                   COUNT(DISTINCT cs.sample_id) FILTER (
+                       WHERE j.status = 'failed') AS samples_failed,
+                   COUNT(DISTINCT cs.sample_id) FILTER (
+                       WHERE j.status = 'running') AS samples_running,
+                   MAX(j.completed_at) FILTER (
+                       WHERE j.status = 'completed') AS last_completed_at
+            FROM collections c
+            LEFT JOIN collection_samples cs USING (collection_id)
+            LEFT JOIN jobs j
+                   ON j.sample_id = cs.sample_id
+                  AND EXISTS (
+                      SELECT 1 FROM workflows w
+                      WHERE w.workflow_id = j.workflow_id
+                        AND w.version = j.workflow_version
+                        AND w.status = 'active')
+            GROUP BY c.collection_id, c.source, c.label
+            ORDER BY (CASE WHEN COUNT(DISTINCT cs.sample_id) = 0 THEN 0
+                           ELSE COUNT(DISTINCT cs.sample_id) FILTER (WHERE j.status = 'completed')::float
+                                / COUNT(DISTINCT cs.sample_id) END) ASC,
+                     sample_count DESC,
+                     c.collection_id ASC
+            """
+        )
+        async with self.engine.connect() as conn:
+            rows = (await conn.execute(sql)).mappings().all()
+        out: list[dict] = []
+        for r in rows:
+            total = r["sample_count"] or 0
+            completed = r["samples_completed"] or 0
+            pct = (completed / total * 100.0) if total > 0 else 0.0
+            out.append(
+                {
+                    "collection_id": r["collection_id"],
+                    "source": r["source"],
+                    "label": r["label"],
+                    "sample_count": total,
+                    "samples_completed": completed,
+                    "samples_failed": r["samples_failed"] or 0,
+                    "samples_running": r["samples_running"] or 0,
+                    "samples_remaining": total - completed,
+                    "completion_pct": round(pct, 2),
+                    "last_completed_at": r["last_completed_at"],
+                }
+            )
+        return out
+
     async def summary(
         self,
         collection_id: str,

--- a/tests/test_cohorts_router.py
+++ b/tests/test_cohorts_router.py
@@ -139,6 +139,7 @@ def _seed_jobs(db_url: str, sample_id: str, status: str, *, workflow_id: str, wo
                     status=status,
                     retry_count=0,
                     created_at=now,
+                    completed_at=(now if status == "completed" else None),
                 )
             )
     try:
@@ -319,6 +320,48 @@ def test_summary_excludes_samples_not_in_cohort(integration_client, db_url, coho
     assert body["total_jobs"] == 1
     assert body["job_status_counts"]["completed"] == 1
     assert body["failure_by_process"] == []
+
+
+def test_leaderboard_ranks_cohorts_by_active_completion(integration_client, db_url, cohort_data):
+    """#119: one row per cohort, active-version completion, laggards first."""
+    client, _ = integration_client
+    tag = cohort_data
+    wf = f"wf-{tag}"
+
+    # Cohort A: 4 samples, 3 completed under active -> 75%.
+    cid_a = f"COHORT-A-{tag}"
+    a = [f"SA-{tag}-{i}" for i in range(4)]
+    _seed_cohort(db_url, collection_id=cid_a, sample_ids=a)
+    for s in a[:3]:
+        _seed_jobs(db_url, s, "completed", workflow_id=wf)
+    _seed_jobs(db_url, a[3], "running", workflow_id=wf)
+
+    # Cohort B: 2 samples, 0 completed under active (one completed only under a
+    # retired version) -> 0%, must sort ABOVE A (laggard first).
+    cid_b = f"COHORT-B-{tag}"
+    b = [f"SB-{tag}-{i}" for i in range(2)]
+    _seed_cohort(db_url, collection_id=cid_b, sample_ids=b)
+    _seed_jobs(db_url, b[0], "failed", workflow_id=wf)
+    _seed_jobs(db_url, b[1], "completed", workflow_id=wf, workflow_version="9.9.9")
+    _set_workflow_status(db_url, wf, "9.9.9", "retired")
+
+    rows = client.get("/api/cohorts/leaderboard").json()
+    by_id = {r["collection_id"]: r for r in rows}
+    assert by_id[cid_a]["sample_count"] == 4
+    assert by_id[cid_a]["samples_completed"] == 3
+    assert by_id[cid_a]["samples_running"] == 1
+    assert by_id[cid_a]["samples_remaining"] == 1
+    assert by_id[cid_a]["completion_pct"] == 75.0
+    assert by_id[cid_a]["last_completed_at"] is not None
+
+    assert by_id[cid_b]["samples_completed"] == 0      # retired-version completion excluded
+    assert by_id[cid_b]["samples_failed"] == 1
+    assert by_id[cid_b]["completion_pct"] == 0.0
+    assert by_id[cid_b]["last_completed_at"] is None
+
+    # Laggard-first ordering: B (0%) appears before A (75%).
+    ordered = [r["collection_id"] for r in rows if r["collection_id"] in (cid_a, cid_b)]
+    assert ordered.index(cid_b) < ordered.index(cid_a)
 
 
 def _set_workflow_status(db_url: str, workflow_id: str, version: str, status: str) -> None:


### PR DESCRIPTION
## Summary
Builds the cross-study leaderboard on the corrected #116 completion semantics (merged in #125). A PI monitoring many studies can now rank them by completeness in one view instead of paging a dropdown one cohort at a time.

### Backend
- `GET /api/cohorts/leaderboard` — one row per cohort in a single query: active-version completion (distinct samples completed / total), plus failed/running/remaining sample counts and `last_completed_at`. Sorted laggards-first (least complete, then largest).

### Frontend (CohortsPage)
- Sortable leaderboard table (completion %, samples, remaining, name) with a completion bar and a **"stalled"** badge — remaining work but no completion in 7 days.
- Clicking a row drives the existing single-cohort drill-down (kept below).
- Completion chip now reads "done / total samples".

## Tests / checks
- New: leaderboard ranks by active completion, excludes retired-version completions, surfaces `last_completed_at`, orders laggards first.
- Backend suite **138 passed**; frontend `tsc -b` + `vite build` clean.

## Follow-ups (not here)
- Per-study ETA/burndown (#117) can hang off `last_completed_at` + a timeline endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)