### PR TITLE
Retiring a workflow purges its orphaned pending jobs (#114)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -49,10 +49,10 @@ migration plan. Blocks B, D, E.
 
 ### Epic B — Operational-state correctness  (cheap, high-value, unblocks the UI)
 - **#114** retiring a workflow reconciles its pending jobs; bucket pending by
-  active/retired in stats (fixes the "298 pending" illusion). _Stats-bucketing half
-  DONE (branch `epic-b/completion-semantics`): `/admin/stats` now returns
-  `jobs_by_status_active` alongside the all-versions `jobs_by_status`. Still TODO: the
-  reconcile-on-retire behavior itself._
+  active/retired in stats (fixes the "298 pending" illusion). _DONE: `/admin/stats`
+  returns `jobs_by_status_active` alongside the all-versions `jobs_by_status` (#125);
+  and retiring a workflow now purges its still-pending (never-dispatched) jobs at the
+  source, leaving in-flight/completed jobs untouched (pausing purges nothing)._
 - **#116** per-sample completion under the **active** workflow version (depends on A).
   _DONE (branch `epic-b/completion-semantics`): cohort `summary()` now measures
   completion as distinct samples with a completed job under the active version

--- a/src/nextflow_telemetry/services/workflow.py
+++ b/src/nextflow_telemetry/services/workflow.py
@@ -4,13 +4,17 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
-from sqlalchemy import select, update
+import logging
+
+from sqlalchemy import delete, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncEngine
 
-from ..db import workflows_tbl
+from ..db import jobs_tbl, workflows_tbl
 
 VALID_STATUSES = {"active", "paused", "retired"}
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -62,7 +66,15 @@ class WorkflowService:
             return dict(result.mappings().one())
 
     async def update_status(self, workflow_pk: int, status: str) -> dict | None:
-        """Transition workflow lifecycle: active → paused → retired."""
+        """Transition workflow lifecycle: active → paused → retired.
+
+        Retiring is permanent and excludes the workflow from reconciliation and
+        dispatch, so its still-`pending` jobs are orphans that would never run —
+        they are purged here (the actionable half of #114, so the "298 pending"
+        illusion is fixed at the source, not just hidden in stats). In-flight
+        jobs (claimed/submitted/running) and completed/failed history are left
+        untouched; pausing is reversible and purges nothing.
+        """
         if status not in VALID_STATUSES:
             raise ValueError(f"status must be one of {VALID_STATUSES}")
         now = datetime.now(timezone.utc)
@@ -74,7 +86,25 @@ class WorkflowService:
                 .returning(*workflows_tbl.c)
             )
             row = result.mappings().one_or_none()
-            return dict(row) if row else None
+            if not row:
+                return None
+            purged = 0
+            if status == "retired":
+                purge = await conn.execute(
+                    delete(jobs_tbl).where(
+                        jobs_tbl.c.workflow_pk == workflow_pk,
+                        jobs_tbl.c.status == "pending",
+                    )
+                )
+                purged = purge.rowcount or 0
+                if purged:
+                    logger.info(
+                        "retired workflow_pk=%s purged %d pending jobs",
+                        workflow_pk, purged,
+                    )
+            out = dict(row)
+            out["purged_pending_jobs"] = purged
+            return out
 
     async def update_revision(self, workflow_pk: int, revision: str) -> dict | None:
         """Update the git revision for a workflow without forcing reruns."""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -967,9 +967,10 @@ def test_admin_stats_shape_and_increments(integration_client):
     assert active_pending_after >= active_pending_before + 1
 
 
-def test_admin_stats_active_bucket_excludes_retired_versions(integration_client):
-    """#114/#116: jobs under a retired workflow version count in jobs_by_status
-    but NOT in jobs_by_status_active."""
+def test_retiring_workflow_purges_its_pending_jobs(integration_client):
+    """#114: retiring a workflow deletes its still-pending (never-dispatched)
+    jobs, so they vanish from BOTH the all-versions and active stats buckets —
+    the "298 pending" illusion is fixed at the source, not just hidden."""
     client, _ = integration_client
     sample_id = f"SRR-retstat-{uuid.uuid4().hex[:6]}"
     wf_id = f"retstat-{uuid.uuid4().hex[:6]}"
@@ -981,13 +982,13 @@ def test_admin_stats_active_bucket_excludes_retired_versions(integration_client)
     baseline = client.get("/api/admin/stats").json()
     all_pending = baseline["jobs_by_status"].get("pending", 0)
     active_pending = baseline["jobs_by_status_active"].get("pending", 0)
+    assert all_pending >= 1 and active_pending >= 1
 
-    # Retire the version: its pending job stays in `jobs` but must drop out of
-    # the active bucket. All-versions bucket is unchanged.
     wf_pk = client.get(f"/api/workflows?status=active").json()
     pk = next(w["id"] for w in wf_pk if w["workflow_id"] == wf_id)
     assert client.patch(f"/api/workflows/{pk}/status", json={"status": "retired"}).status_code == 200
 
     after = client.get("/api/admin/stats").json()
-    assert after["jobs_by_status"].get("pending", 0) == all_pending          # unchanged
-    assert after["jobs_by_status_active"].get("pending", 0) == active_pending - 1  # dropped
+    # The orphaned pending job is gone from both buckets.
+    assert after["jobs_by_status"].get("pending", 0) == all_pending - 1
+    assert after["jobs_by_status_active"].get("pending", 0) == active_pending - 1


### PR DESCRIPTION
## Summary
Completes #114. #125 made retired-version jobs *distinguishable* in stats; this removes the root cause: retiring a workflow now **purges its still-pending jobs**, so the "298 pending" illusion is fixed at the source.

- `WorkflowService.update_status`: on transition to `retired`, delete `jobs` for that workflow that are still `pending` (never dispatched — no `workflow_run`, no dead-letter refs, FK-safe). In-flight (`claimed`/`submitted`/`running`) and completed/failed history are untouched. Pausing is reversible and purges nothing. Purge count is returned + logged.

## Tests
- Reworked `test_retiring_workflow_purges_its_pending_jobs`: retiring drops the pending job from **both** the all-versions and active stats buckets.
- Existing status-lifecycle tests unaffected (they don't reconcile jobs first).
- Full suite **138 passed**, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)