### PR TITLE
Heartbeat-staleness watchdog for zombie runs (#115)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -61,6 +61,10 @@ migration plan. Blocks B, D, E.
   labels + the #119 leaderboard on top of the corrected semantics._
 - **#115** server-side heartbeat-staleness watchdog — makes `running` honest; a
   walltime-killed run currently sits `running` forever (observed live 2026-07-01).
+  _DONE: `POST /admin/heartbeat-watchdog?stale_after_minutes=15` fails `running` runs
+  whose `last_heartbeat_at` (fallback `started_at`) is stale and sweeps their jobs
+  through retry/DLQ; queued `submitted` runs (no heartbeat by design) are untouched.
+  Operator-invokable via a new Dispatch → Heartbeat Watchdog tab; cron-safe._
 
 ### Epic C — Run-lifecycle observability  (finish the #62 epic)
 Tracker: **#62**. "Know when/why a run died."

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -16,6 +16,7 @@ import type {
   ReconcileResult,
   RequeueResult,
   RequeueDlqResult,
+  WatchdogResult,
   DispatchabilityResult,
   SampleResponse,
   SampleRegisterRequest,
@@ -129,6 +130,8 @@ export const api = {
   admin: {
     reconcile: () => post<ReconcileResult>('/admin/reconcile-jobs'),
     requeueDeadLetter: () => post<RequeueDlqResult>('/admin/requeue-dead-letter'),
+    heartbeatWatchdog: (staleAfterMinutes?: number) =>
+      post<WatchdogResult>(`/admin/heartbeat-watchdog${staleAfterMinutes != null ? `?stale_after_minutes=${staleAfterMinutes}` : ''}`),
     dispatchability: () => get<DispatchabilityResult>('/admin/dispatchability'),
   },
 

--- a/frontend/src/pages/DispatchPage.tsx
+++ b/frontend/src/pages/DispatchPage.tsx
@@ -10,7 +10,7 @@ import KPICard from '../components/KPICard'
 import SectionHeader from '../components/SectionHeader'
 import Panel from '../components/Panel'
 import PageWrap from '../components/PageWrap'
-import type { DispatchBatchResponse, ReconcileResult, RequeueResult, RequeueDlqResult, WorkflowResponse } from '../types'
+import type { DispatchBatchResponse, ReconcileResult, RequeueResult, RequeueDlqResult, WatchdogResult, WorkflowResponse } from '../types'
 
 function DispatchBatchPanel() {
   const [wfId,      setWfId]      = useState('')
@@ -239,13 +239,56 @@ function RequeueDlqPanel() {
   )
 }
 
-type Tab = 'dispatch' | 'submitted' | 'requeue' | 'reconcile' | 'requeue-dlq'
+function WatchdogPanel() {
+  const [minutes, setMinutes] = useState('15')
+  const [result,  setResult]  = useState<WatchdogResult | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  function run() {
+    setLoading(true)
+    const m = Number(minutes)
+    api.admin.heartbeatWatchdog(Number.isFinite(m) && m > 0 ? m : undefined)
+      .then(r => { setResult(r); setLoading(false) })
+      .catch(e => { console.error(e); setLoading(false) })
+  }
+
+  return (
+    <Panel>
+      <SectionHeader title="POST /admin/heartbeat-watchdog"
+        sub="Fail zombie 'running' runs that stopped heartbeating — the SLURM walltime/OOM backstop; safe to call from cron" />
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 14, maxWidth: 560 }}>
+        <div style={{ fontSize: 13, color: T.muted, lineHeight: 1.6 }}>
+          Finds <Badge label="running" variant="neutral" /> runs whose last{' '}
+          <code style={{ fontFamily: 'DM Mono, monospace', color: T.accent }}>heartbeat</code>{' '}
+          is older than the window, marks them <Badge label="failed" variant="error" />, and sweeps
+          their jobs through retry / dead-letter. Queued{' '}
+          <Badge label="submitted" variant="neutral" /> runs (no heartbeat by design) are left alone.
+        </div>
+        <div style={{ display: 'flex', gap: 10, alignItems: 'flex-end' }}>
+          <Input label="Stale after (min)" value={minutes} onChange={setMinutes} type="number" mono />
+          <Btn onClick={run} disabled={loading}>{loading ? 'Scanning…' : 'Run Watchdog'}</Btn>
+        </div>
+        {result && (
+          <div style={{ display: 'flex', gap: 12 }}>
+            <KPICard label="Runs failed" value={result.stale_runs_failed}
+              sub={`no heartbeat > ${result.stale_after_minutes}m`} accent={result.stale_runs_failed ? T.red : T.green} />
+            <KPICard label="Jobs swept" value={result.jobs_swept.toLocaleString()}
+              sub="retry / dead-letter" accent={T.amber} />
+          </div>
+        )}
+      </div>
+    </Panel>
+  )
+}
+
+type Tab = 'dispatch' | 'submitted' | 'requeue' | 'reconcile' | 'requeue-dlq' | 'watchdog'
 const TABS: Array<{ id: Tab; label: string }> = [
   { id: 'dispatch',    label: 'Dispatch Batch'      },
   { id: 'submitted',   label: 'Confirm Submitted'   },
   { id: 'requeue',     label: 'Requeue Expired'     },
   { id: 'requeue-dlq', label: 'Requeue Dead-Letter' },
   { id: 'reconcile',   label: 'Reconcile Jobs'      },
+  { id: 'watchdog',    label: 'Heartbeat Watchdog'  },
 ]
 
 export default function DispatchPage() {
@@ -312,6 +355,7 @@ export default function DispatchPage() {
       {tab === 'requeue'     && <RequeuePanel />}
       {tab === 'requeue-dlq' && <RequeueDlqPanel />}
       {tab === 'reconcile'   && <ReconcilePanel />}
+      {tab === 'watchdog'    && <WatchdogPanel />}
     </PageWrap>
   )
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -259,6 +259,14 @@ export interface RequeueDlqResult {
   requeued: number
 }
 
+export interface WatchdogResult {
+  checked_at: string
+  stale_after_minutes: number
+  stale_runs_failed: number
+  jobs_swept: number
+  runs: Array<{ run_name: string; last_signal_at: string | null; jobs_swept: number }>
+}
+
 export interface RunListItem {
   run_name: string
   workflow_id: string

--- a/src/nextflow_telemetry/routers/admin.py
+++ b/src/nextflow_telemetry/routers/admin.py
@@ -14,6 +14,11 @@ from ..services.reconcile import ReconcileService, sweep_run_incomplete
 # its last heartbeat is within this window.
 _DAEMON_ACTIVE_THRESHOLD = datetime.timedelta(minutes=2)
 
+# Default staleness window for the heartbeat watchdog. Matches the read-only
+# "stalled" classifier in routers/runs.py (_RUN_STALE_THRESHOLD = 15 min). The
+# nf-client run wrapper heartbeats every 60s, so 15 min ≈ 15 missed beats.
+_HEARTBEAT_STALE_MINUTES_DEFAULT = 15.0
+
 
 def create_admin_router(engine: AsyncEngine) -> APIRouter:
     router = APIRouter(prefix="/admin", tags=["admin"])
@@ -144,6 +149,68 @@ def create_admin_router(engine: AsyncEngine) -> APIRouter:
                 total_swept += await sweep_run_incomplete(conn, run_name, now)
 
         return {"stale_runs_closed": len(stale), "jobs_swept": total_swept}
+
+    @router.post(
+        "/heartbeat-watchdog",
+        summary="Fail zombie 'running' runs that stopped heartbeating",
+        description=(
+            "Finds runs in `running` state whose most recent liveness signal "
+            "(`last_heartbeat_at`, falling back to `started_at`) is older than "
+            "`stale_after_minutes`, marks each `failed`, and sweeps its jobs "
+            "through the retry/dead-letter logic. This is the real backstop for "
+            "SLURM walltime-TIMEOUT and node failures, where the run wrapper (and "
+            "its heartbeat thread) is killed but no Nextflow `completed` event is "
+            "ever sent — so the run would otherwise sit `running` forever. "
+            "Intended to be called periodically (cron / daemon loop). "
+            "Deliberately does NOT touch `submitted` runs: those are queued in "
+            "SLURM and legitimately have no heartbeat yet (queue wait, e.g. behind "
+            "a maintenance reservation); the coarse `expire-stale-runs` covers that."
+        ),
+    )
+    async def heartbeat_watchdog(stale_after_minutes: float = _HEARTBEAT_STALE_MINUTES_DEFAULT):
+        now = datetime.datetime.now(datetime.timezone.utc)
+        cutoff = now - datetime.timedelta(minutes=stale_after_minutes)
+        # Fresh heartbeats keep this in the future of the cutoff; a wrapper that
+        # died stops updating it, so it falls behind. started_at is the fallback
+        # for a run that reached 'running' before its first heartbeat landed.
+        signal = func.coalesce(
+            workflow_runs_tbl.c.last_heartbeat_at,
+            workflow_runs_tbl.c.started_at,
+        )
+        reason = f"heartbeat watchdog: no heartbeat for >{stale_after_minutes:g} min"
+        swept_runs: list[dict] = []
+        total_swept = 0
+
+        async with engine.begin() as conn:
+            stale = (await conn.execute(
+                select(workflow_runs_tbl.c.run_name, signal.label("last_signal"))
+                .where(
+                    workflow_runs_tbl.c.status == "running",
+                    signal < cutoff,
+                )
+            )).all()
+
+            for r in stale:
+                await conn.execute(
+                    update(workflow_runs_tbl)
+                    .where(workflow_runs_tbl.c.run_name == r.run_name)
+                    .values(status="failed", completed_at=now, slurm_reason=reason)
+                )
+                jobs = await sweep_run_incomplete(conn, r.run_name, now)
+                total_swept += jobs
+                swept_runs.append({
+                    "run_name": r.run_name,
+                    "last_signal_at": r.last_signal,
+                    "jobs_swept": jobs,
+                })
+
+        return {
+            "checked_at": now,
+            "stale_after_minutes": stale_after_minutes,
+            "stale_runs_failed": len(stale),
+            "jobs_swept": total_swept,
+            "runs": swept_runs,
+        }
 
     @router.post(
         "/requeue-dead-letter",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -992,3 +992,74 @@ def test_retiring_workflow_purges_its_pending_jobs(integration_client):
     # The orphaned pending job is gone from both buckets.
     assert after["jobs_by_status"].get("pending", 0) == all_pending - 1
     assert after["jobs_by_status_active"].get("pending", 0) == active_pending - 1
+
+
+def test_heartbeat_watchdog_fails_zombie_running_runs(integration_client, db_url):
+    """#115: a 'running' run whose wrapper died (no heartbeat) is failed and its
+    jobs swept; a freshly-heartbeating 'running' run is left alone; a queued
+    'submitted' run (no heartbeat by design) is never touched."""
+    from datetime import timedelta
+    from sqlalchemy import update
+    from nextflow_telemetry.db import jobs_tbl, workflow_runs_tbl
+
+    client, _ = integration_client
+    tag = uuid.uuid4().hex[:8]
+    now = datetime.now(timezone.utc)
+
+    # One sample + active workflow -> one pending job.
+    sample_id = f"SRR-hbwd-{tag}"
+    wf_id = f"hbwd-{tag}"
+    assert client.post("/api/samples", json={"sample_id": sample_id, "ncbi_accession": "SRR000001"}).status_code == 201
+    assert client.post("/api/workflows", json=_wf_payload(workflow_id=wf_id, version="1.0.0")).status_code in (200, 201)
+    assert client.post("/api/admin/reconcile-jobs").status_code == 200
+
+    rn_zombie = f"run-zombie-{tag}"
+    rn_fresh = f"run-fresh-{tag}"
+    rn_queued = f"run-queued-{tag}"
+
+    def _seed_run(run_name, status, *, heartbeat=None, started=None, submitted=None):
+        return insert(workflow_runs_tbl).values(
+            run_name=run_name, workflow_id=wf_id, workflow_version="1.0.0",
+            status=status, claimed_at=now - timedelta(hours=1),
+            submitted_at=submitted, started_at=started, last_heartbeat_at=heartbeat,
+        )
+
+    _run(_exec(
+        db_url,
+        # Zombie: running, last heartbeat 30 min ago (wrapper died).
+        _seed_run(rn_zombie, "running", heartbeat=now - timedelta(minutes=30), started=now - timedelta(minutes=40)),
+        # Fresh: running, heartbeat 1 min ago (alive) — must be left alone.
+        _seed_run(rn_fresh, "running", heartbeat=now - timedelta(minutes=1), started=now - timedelta(minutes=40)),
+        # Queued: submitted 45 min ago, never heartbeated — must be left alone.
+        _seed_run(rn_queued, "submitted", submitted=now - timedelta(minutes=45)),
+        # Attach the pending job to the zombie run and mark it running.
+        update(jobs_tbl).where(jobs_tbl.c.sample_id == sample_id, jobs_tbl.c.workflow_id == wf_id)
+        .values(status="running", run_name=rn_zombie),
+    ))
+
+    resp = client.post("/api/admin/heartbeat-watchdog?stale_after_minutes=15")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    swept_names = {r["run_name"] for r in body["runs"]}
+    assert rn_zombie in swept_names
+    assert rn_fresh not in swept_names and rn_queued not in swept_names
+
+    run_rows = _run(_query(
+        db_url,
+        select(workflow_runs_tbl.c.run_name, workflow_runs_tbl.c.status, workflow_runs_tbl.c.slurm_reason)
+        .where(workflow_runs_tbl.c.run_name.in_([rn_zombie, rn_fresh, rn_queued])),
+    ))
+    by_run = {r["run_name"]: r for r in run_rows}
+    assert by_run[rn_zombie]["status"] == "failed"
+    assert "heartbeat" in (by_run[rn_zombie]["slurm_reason"] or "")
+    assert by_run[rn_fresh]["status"] == "running"      # alive, untouched
+    assert by_run[rn_queued]["status"] == "submitted"   # queued, untouched
+
+    # The zombie's job was swept back to pending (retries remain).
+    job_rows = _run(_query(
+        db_url,
+        select(jobs_tbl.c.status, jobs_tbl.c.run_name)
+        .where(jobs_tbl.c.sample_id == sample_id, jobs_tbl.c.workflow_id == wf_id),
+    ))
+    assert job_rows[0]["status"] == "pending"
+    assert job_rows[0]["run_name"] is None


### PR DESCRIPTION
## Summary
Closes the silent-death gap: a run killed by SLURM walltime/OOM/node-failure loses its wrapper (and heartbeat thread) but never emits a Nextflow `completed` event, so it sits `running` forever (observed live on Alpine, 2026-07-01). This adds the real server-side backstop.

- **`POST /admin/heartbeat-watchdog?stale_after_minutes=15`** — fails `running` runs whose last liveness signal (`last_heartbeat_at`, fallback `started_at`) is older than the window, records a diagnostic `slurm_reason`, and sweeps their jobs through the existing retry/dead-letter logic (`sweep_run_incomplete`).
- **Keyed on heartbeat freshness, not claim age** — a healthy long run keeps heartbeating and is never killed; the existing `expire-stale-runs` (claim age + 2h) was the wrong signal for this.
- **Skips `submitted` runs by design** — those are queued in SLURM with no heartbeat yet; queue wait can exceed the window (e.g. behind a maintenance reservation), so heartbeat-based staleness would false-positive them. The coarse `expire-stale-runs` still covers that case.
- **Frontend**: Dispatch → "Heartbeat Watchdog" tab (mirrors the other admin actions) with a configurable window + result KPIs. Cron-safe for periodic invocation.

## Tests
- A zombie `running` run is failed and its job swept to `pending`; a freshly-heartbeating `running` run and a queued `submitted` run are both left untouched.
- Backend **139 passed**, mypy clean; frontend `tsc -b` + `vite build` clean.

## Note
Matches the existing read-only 15-min "stalled" classifier in `routers/runs.py` — now there's a mutation path behind that signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)