### PR TITLE
Enforce one active version per workflow_id (#116, Epic A)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -46,6 +46,13 @@ migration plan. Blocks B, D, E.
   re-run semantics; human-in-the-loop review. Scope: human + mouse hosts only.
 - Make **study/collection first-class and consistent** (one source of truth for
   membership; subsumes the data-model half of #116/#119).
+- **Single-active-version enforcement** DONE: partial unique index
+  `uq_one_active_version_per_workflow` (in `db.py` + migration `f4a5b6c7` with data
+  cleanup + orphan-pending purge); `WorkflowService.register`/`update_status` auto-retire
+  the prior active version (and purge its pending jobs) so the invariant holds at
+  runtime. Migration verified end-to-end against real Postgres. Remaining Epic A:
+  the membership-consolidation migrations (collections as SoT, demote `metadata.cohort`,
+  unify `curated_studies`).
 
 ### Epic B — Operational-state correctness  (cheap, high-value, unblocks the UI)
 - **#114** retiring a workflow reconciles its pending jobs; bucket pending by

--- a/src/nextflow_telemetry/db.py
+++ b/src/nextflow_telemetry/db.py
@@ -17,6 +17,7 @@ from sqlalchemy import (
     Table,
     Text,
     UniqueConstraint,
+    text,
 )
 from sqlalchemy.dialects.postgresql import JSONB
 
@@ -150,6 +151,16 @@ workflows_tbl = Table(
     UniqueConstraint("workflow_id", "version", name="uq_workflow_id_version"),
     Index("ix_workflows_status", "status"),
     Index("ix_workflows_workflow_id", "workflow_id"),
+    # At most one active version per workflow_id (Epic A identity model,
+    # docs/study-sample-version-identity.md). Makes "the active version"
+    # unambiguous for completion metrics. Maintained in the app by
+    # WorkflowService (register + promote auto-retire the prior active).
+    Index(
+        "uq_one_active_version_per_workflow",
+        "workflow_id",
+        unique=True,
+        postgresql_where=text("status = 'active'"),
+    ),
 )
 
 # ---------------------------------------------------------------------------

--- a/src/nextflow_telemetry/migrations/versions/20260702_f4a5b6c7_one_active_version_per_workflow.py
+++ b/src/nextflow_telemetry/migrations/versions/20260702_f4a5b6c7_one_active_version_per_workflow.py
@@ -1,0 +1,68 @@
+"""one active version per workflow
+
+Revision ID: f4a5b6c7
+Revises: e3f4a5b6
+Create Date: 2026-07-02
+
+Enforces the Epic A identity decision (docs/study-sample-version-identity.md):
+**exactly one active version per workflow_id**. This makes "the active version"
+unambiguous, which the completion metrics (#116) assume.
+
+Data cleanup first, because existing databases may already have several active
+versions of the same workflow_id (prod had 2 at time of writing):
+  1. For each workflow_id, keep the most-recently-created active version active
+     and retire the rest.
+  2. Purge the newly-retired versions' still-`pending` jobs (never-dispatched
+     orphans — same rule as retiring a workflow at runtime, #114).
+Then add the partial unique index that guarantees the invariant going forward.
+
+Going forward the invariant is *maintained* by WorkflowService: registering a
+new version or promoting one to active auto-retires the prior active version in
+the same transaction, so this index never actually rejects an app-driven write —
+it is a backstop against direct SQL / bugs.
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "f4a5b6c7"
+down_revision: Union[str, Sequence[str], None] = "e3f4a5b6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# active versions that are NOT the newest for their workflow_id
+_STALE_ACTIVE = """
+    SELECT id FROM workflows
+    WHERE status = 'active'
+      AND id NOT IN (
+          SELECT DISTINCT ON (workflow_id) id
+          FROM workflows
+          WHERE status = 'active'
+          ORDER BY workflow_id, created_at DESC, id DESC
+      )
+"""
+
+
+def upgrade() -> None:
+    # 1. Purge orphaned pending jobs of the versions we're about to retire
+    #    (do this while they are still 'active' so the subquery selects them).
+    op.execute(
+        f"DELETE FROM jobs WHERE status = 'pending' AND workflow_pk IN ({_STALE_ACTIVE})"
+    )
+    # 2. Retire all but the newest active version per workflow_id.
+    op.execute(
+        f"UPDATE workflows SET status = 'retired', updated_at = now() WHERE id IN ({_STALE_ACTIVE})"
+    )
+    # 3. Enforce the invariant going forward.
+    op.execute(
+        "CREATE UNIQUE INDEX uq_one_active_version_per_workflow "
+        "ON workflows (workflow_id) WHERE status = 'active'"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS uq_one_active_version_per_workflow")

--- a/src/nextflow_telemetry/services/workflow.py
+++ b/src/nextflow_telemetry/services/workflow.py
@@ -21,6 +21,48 @@ logger = logging.getLogger(__name__)
 class WorkflowService:
     engine: AsyncEngine
 
+    async def _retire_other_active(
+        self, conn, workflow_id: str, now, *,
+        keep_pk: int | None = None, keep_version: str | None = None,
+    ) -> int:
+        """Retire every *other* active version of ``workflow_id`` and purge its
+        pending jobs, upholding the one-active-version-per-workflow invariant
+        (docs/study-sample-version-identity.md). Returns the number retired.
+
+        Called before a version is made active (register / promote) so the
+        partial unique index `uq_one_active_version_per_workflow` is never
+        violated. Purging pending jobs mirrors the manual-retire rule (#114).
+        """
+        conds = [
+            workflows_tbl.c.workflow_id == workflow_id,
+            workflows_tbl.c.status == "active",
+        ]
+        if keep_pk is not None:
+            conds.append(workflows_tbl.c.id != keep_pk)
+        if keep_version is not None:
+            conds.append(workflows_tbl.c.version != keep_version)
+        others = (await conn.execute(
+            select(workflows_tbl.c.id).where(*conds)
+        )).scalars().all()
+        if not others:
+            return 0
+        await conn.execute(
+            delete(jobs_tbl).where(
+                jobs_tbl.c.workflow_pk.in_(others),
+                jobs_tbl.c.status == "pending",
+            )
+        )
+        await conn.execute(
+            update(workflows_tbl)
+            .where(workflows_tbl.c.id.in_(others))
+            .values(status="retired", updated_at=now)
+        )
+        logger.info(
+            "auto-retired %d prior active version(s) of workflow_id=%s",
+            len(others), workflow_id,
+        )
+        return len(others)
+
     async def register(
         self,
         *,
@@ -32,9 +74,16 @@ class WorkflowService:
         max_retries: int = 3,
         description: str | None = None,
     ) -> dict:
-        """Insert a new workflow or update its mutable fields if already present."""
+        """Insert a new workflow or update its mutable fields if already present.
+
+        Registering a version implies it is the one to run, so any *other*
+        active version of the same workflow_id is auto-retired first (its pending
+        jobs purged) — the release-flow's "retire the prior revision" step is now
+        automatic and the one-active-version invariant is upheld.
+        """
         now = datetime.now(timezone.utc)
         async with self.engine.begin() as conn:
+            await self._retire_other_active(conn, workflow_id, now, keep_version=version)
             stmt = (
                 pg_insert(workflows_tbl)
                 .values(
@@ -79,6 +128,15 @@ class WorkflowService:
             raise ValueError(f"status must be one of {VALID_STATUSES}")
         now = datetime.now(timezone.utc)
         async with self.engine.begin() as conn:
+            # Promoting to active must first retire any other active version of
+            # the same workflow_id, or the partial unique index would reject it.
+            if status == "active":
+                target = (await conn.execute(
+                    select(workflows_tbl.c.workflow_id).where(workflows_tbl.c.id == workflow_pk)
+                )).scalar_one_or_none()
+                if target is not None:
+                    await self._retire_other_active(conn, target, now, keep_pk=workflow_pk)
+
             result = await conn.execute(
                 update(workflows_tbl)
                 .where(workflows_tbl.c.id == workflow_pk)

--- a/tests/test_cohorts_router.py
+++ b/tests/test_cohorts_router.py
@@ -93,7 +93,7 @@ def _seed_cohort(db_url: str, *, collection_id: str, sample_ids: list[str]) -> N
     _run(_exec(db_url, *stmts))
 
 
-def _seed_jobs(db_url: str, sample_id: str, status: str, *, workflow_id: str, workflow_version: str = "1.0.0") -> None:
+def _seed_jobs(db_url: str, sample_id: str, status: str, *, workflow_id: str, workflow_version: str = "1.0.0", workflow_status: str = "active") -> None:
     from nextflow_telemetry.db import jobs_tbl, workflows_tbl
 
     now = _ts()
@@ -102,7 +102,9 @@ def _seed_jobs(db_url: str, sample_id: str, status: str, *, workflow_id: str, wo
 
     async def _do():
         async with engine.begin() as conn:
-            # upsert workflow
+            # upsert workflow. workflow_status lets a caller seed a retired
+            # version directly, avoiding a transient second-active row that the
+            # uq_one_active_version_per_workflow partial index would reject.
             existing = (await conn.execute(
                 select(workflows_tbl).where(
                     workflows_tbl.c.workflow_id == workflow_id,
@@ -117,7 +119,7 @@ def _seed_jobs(db_url: str, sample_id: str, status: str, *, workflow_id: str, wo
                         repository_url="https://example.com/wf",
                         revision="main",
                         max_retries=3,
-                        status="active",
+                        status=workflow_status,
                         created_at=now,
                         updated_at=now,
                     )
@@ -342,8 +344,7 @@ def test_leaderboard_ranks_cohorts_by_active_completion(integration_client, db_u
     b = [f"SB-{tag}-{i}" for i in range(2)]
     _seed_cohort(db_url, collection_id=cid_b, sample_ids=b)
     _seed_jobs(db_url, b[0], "failed", workflow_id=wf)
-    _seed_jobs(db_url, b[1], "completed", workflow_id=wf, workflow_version="9.9.9")
-    _set_workflow_status(db_url, wf, "9.9.9", "retired")
+    _seed_jobs(db_url, b[1], "completed", workflow_id=wf, workflow_version="9.9.9", workflow_status="retired")
 
     rows = client.get("/api/cohorts/leaderboard").json()
     by_id = {r["collection_id"]: r for r in rows}
@@ -391,10 +392,10 @@ def test_summary_completion_scoped_to_active_version(integration_client, db_url,
     _seed_jobs(db_url, samples[0], "completed", workflow_id=wf, workflow_version="2.0.0")
     _seed_jobs(db_url, samples[1], "completed", workflow_id=wf, workflow_version="2.0.0")
     _seed_jobs(db_url, samples[2], "pending",   workflow_id=wf, workflow_version="2.0.0")
-    # Retired version 1.0.0: ALL four completed (prior pipeline run).
+    # Retired version 1.0.0: ALL four completed (prior pipeline run). Seeded
+    # already-retired so 2.0.0 remains the sole active version.
     for s in samples:
-        _seed_jobs(db_url, s, "completed", workflow_id=wf, workflow_version="1.0.0")
-    _set_workflow_status(db_url, wf, "1.0.0", "retired")  # 2.0.0 stays active
+        _seed_jobs(db_url, s, "completed", workflow_id=wf, workflow_version="1.0.0", workflow_status="retired")
 
     # Default: active version only, completion in distinct samples.
     resp = client.get(f"/api/cohorts/{cid}/summary")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -220,6 +220,50 @@ def test_workflow_invalid_status_rejected(integration_client):
     assert resp.status_code == 422
 
 
+def test_registering_new_version_auto_retires_prior_active(integration_client, db_url):
+    """Epic A invariant: registering a new version retires the prior active one
+    (and purges its pending jobs), keeping exactly one active per workflow_id."""
+    from nextflow_telemetry.db import jobs_tbl, workflows_tbl
+
+    client, _ = integration_client
+    tag = uuid.uuid4().hex[:6]
+    wf_id = f"autoretire-{tag}"
+    sample_id = f"SRR-ar-{tag}"
+    assert client.post("/api/samples", json={"sample_id": sample_id, "ncbi_accession": "SRR000001"}).status_code == 201
+    assert client.post("/api/workflows", json=_wf_payload(workflow_id=wf_id, version="1.0.0")).status_code in (200, 201)
+    assert client.post("/api/admin/reconcile-jobs").status_code == 200
+
+    v1_before = _run(_query(db_url, select(jobs_tbl.c.status).where(
+        jobs_tbl.c.sample_id == sample_id, jobs_tbl.c.workflow_id == wf_id, jobs_tbl.c.workflow_version == "1.0.0")))
+    assert any(j["status"] == "pending" for j in v1_before)
+
+    # Register 2.0.0 -> 1.0.0 auto-retired, its pending job purged.
+    assert client.post("/api/workflows", json=_wf_payload(workflow_id=wf_id, version="2.0.0")).status_code in (200, 201)
+
+    active = client.get("/api/workflows?status=active").json()
+    assert [w["version"] for w in active if w["workflow_id"] == wf_id] == ["2.0.0"]
+    statuses = {r["version"]: r["status"] for r in _run(_query(db_url, select(
+        workflows_tbl.c.version, workflows_tbl.c.status).where(workflows_tbl.c.workflow_id == wf_id)))}
+    assert statuses == {"1.0.0": "retired", "2.0.0": "active"}
+    v1_after = _run(_query(db_url, select(jobs_tbl.c.status).where(
+        jobs_tbl.c.sample_id == sample_id, jobs_tbl.c.workflow_id == wf_id, jobs_tbl.c.workflow_version == "1.0.0")))
+    assert v1_after == []
+
+
+def test_promoting_version_auto_retires_current_active(integration_client):
+    """Promoting a version to active retires whichever version was active."""
+    client, _ = integration_client
+    tag = uuid.uuid4().hex[:6]
+    wf_id = f"promote-{tag}"
+    pk1 = client.post("/api/workflows", json=_wf_payload(workflow_id=wf_id, version="1.0.0")).json()["id"]
+    client.post("/api/workflows", json=_wf_payload(workflow_id=wf_id, version="2.0.0"))  # retires 1.0.0
+
+    # Promote 1.0.0 back -> 2.0.0 must be retired so only one stays active.
+    assert client.patch(f"/api/workflows/{pk1}/status", json={"status": "active"}).status_code == 200
+    active = client.get("/api/workflows?status=active").json()
+    assert sorted(w["version"] for w in active if w["workflow_id"] == wf_id) == ["1.0.0"]
+
+
 def test_workflow_revision_update(integration_client):
     client, _ = integration_client
     resp = client.post("/api/workflows", json=_wf_payload(revision="v1.0"))


### PR DESCRIPTION
## Summary
Closes the Epic A identity decision (`docs/study-sample-version-identity.md`): **exactly one active version per `workflow_id`**, so "the active version" that completion metrics (#116) depend on is unambiguous.

### Schema
- Partial unique index `uq_one_active_version_per_workflow ON workflows(workflow_id) WHERE status='active'` — added to `db.py` (so testcontainers enforces it) **and** migration `f4a5b6c7` for existing DBs.
- The migration first **retires all-but-newest** active version per `workflow_id` and **purges those versions' orphaned pending jobs** (the #114 rule), then adds the index.
- **Verified end-to-end against a real Postgres**: seeded 2 active versions of one workflow + pending jobs → after migration, older retired, newest active, orphan pending purged, index present, and a second active insert correctly rejected.

### Runtime
- `WorkflowService.register` and `update_status(status='active')` auto-retire any *other* active version of the same `workflow_id` (purging its pending jobs) before activating the target — so the invariant is maintained by the app and the index never rejects a legitimate write. The release flow's manual "retire the prior revision" step is now automatic (and idempotent).

## Tests
- Registering a new version auto-retires + purges the prior; promoting a version retires the current active.
- Cohort tests that seeded a transient second-active row now seed the old version already-retired (via a new `workflow_status` param on the `_seed_jobs` helper).
- Full suite **141 passed**, mypy clean.

## Follow-up (remaining Epic A)
Membership consolidation migrations: `collections` as the single source of truth, demote `metadata.cohort`, unify `curated_studies` (`source='cmd'`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)