### PR TITLE
Server-side pagination + filtering for the Samples catalog (#118)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -92,7 +92,11 @@ Built on B's corrected semantics. From the UI eval (#116–#122) + older UI issu
   + sortable leaderboard table on CohortsPage with a "stalled" flag (no completion in
   7d). Single-cohort drill-down kept below._
 - **#118** server-side pagination for Samples/Runs/cohort-failures (Samples is broken
-  past 1000 rows today).
+  past 1000 rows today). _Samples DONE: `GET /samples` returns a paginated envelope
+  `{items,total,limit,offset}` with server-side `search`+`cohort` filters, plus
+  `GET /samples/facets/cohorts` for whole-catalog chip counts; SamplesPage is now fully
+  server-driven (debounced search, server pagination). Runs/cohort-failures pagination
+  still TODO._
 - **#120** failure-triage drill-down: failed task → its log (`task_hash` exists,
   `<TaskLogViewer>` already built — wire it up).
 - **#121** legibility (human run-name labels, explain `ENDED-NO-LOG` / `exit

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -19,6 +19,8 @@ import type {
   WatchdogResult,
   DispatchabilityResult,
   SampleResponse,
+  SampleListResponse,
+  CohortFacetsResponse,
   SampleRegisterRequest,
   SubmittedRequest,
   DaemonAgentResponse,
@@ -90,12 +92,13 @@ export const api = {
   },
 
   samples: {
-    list:   (page: number, size: number, search?: string, cohort?: string) => {
-      const params = new URLSearchParams({ skip: String(page * size), limit: String(size) })
+    list:   (offset: number, limit: number, search?: string, cohort?: string) => {
+      const params = new URLSearchParams({ offset: String(offset), limit: String(limit) })
       if (search) params.set('search', search)
       if (cohort) params.set('cohort', cohort)
-      return get<SampleResponse[]>(`/samples?${params}`)
+      return get<SampleListResponse>(`/samples?${params}`)
     },
+    cohortFacets: () => get<CohortFacetsResponse>('/samples/facets/cohorts'),
     create: (body: SampleRegisterRequest) => post<SampleResponse>('/samples', body),
   },
 

--- a/frontend/src/pages/SamplesPage.tsx
+++ b/frontend/src/pages/SamplesPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { T } from '../tokens'
 import { usePoll, fmtUpdated } from '../lib/usePoll'
 import { fmtNum, fmtDate, fmtAgo } from '../lib/format'
@@ -72,33 +72,39 @@ function SampleFormModal({
 export default function SamplesPage({ pollInterval = 30_000 }: { pollInterval?: number }) {
   const [page,     setPage]     = useState(0)
   const [search,   setSearch]   = useState('')
+  const [debouncedSearch, setDebouncedSearch] = useState('')
   const [cohort,   setCohort]   = useState('')
-  const [allRows,  setAllRows]  = useState<SampleResponse[]>([])
+  const [items,    setItems]    = useState<SampleResponse[]>([])
+  const [total,    setTotal]    = useState(0)
+  const [facets,   setFacets]   = useState<{ total: number; cohorts: Array<{ cohort: string; count: number }> }>({ total: 0, cohorts: [] })
   const [showForm, setShowForm] = useState(false)
   const { tick, refresh, lastUpdated } = usePoll(pollInterval)
   const isAdmin = useRole('admin')
 
+  // Debounce the search box so we don't fire a request per keystroke.
   useEffect(() => {
-    api.samples.list(0, 1000).then(setAllRows).catch(console.error)
+    const id = setTimeout(() => setDebouncedSearch(search), 250)
+    return () => clearTimeout(id)
+  }, [search])
+
+  // Server-side page fetch — filters + pagination happen in Postgres, so the
+  // catalog stays correct past the old 1000-row client ceiling (#118).
+  useEffect(() => {
+    let ignore = false
+    api.samples.list(page * PAGE_SIZE, PAGE_SIZE, debouncedSearch || undefined, cohort || undefined)
+      .then(r => { if (!ignore) { setItems(r.items); setTotal(r.total) } })
+      .catch(console.error)
+    return () => { ignore = true }
+  }, [page, debouncedSearch, cohort, tick])
+
+  // Cohort chips + grand total come from a whole-catalog facet query, so they
+  // don't shift as the user pages or filters.
+  useEffect(() => {
+    api.samples.cohortFacets().then(setFacets).catch(console.error)
   }, [tick])
 
-  const cohorts = useMemo(() => {
-    const seen = new Set<string>()
-    for (const r of allRows) {
-      const c = (r.metadata as Record<string, string> | null)?.['cohort']
-      if (c) seen.add(c)
-    }
-    return [...seen].sort()
-  }, [allRows])
-
-  const filtered = useMemo(() => allRows.filter(r => {
-    if (cohort && (r.metadata as Record<string, string> | null)?.['cohort'] !== cohort) return false
-    if (search && !r.sample_id.toLowerCase().includes(search.toLowerCase())) return false
-    return true
-  }), [allRows, cohort, search])
-
-  const totalPages = Math.ceil(filtered.length / PAGE_SIZE)
-  const rows = filtered.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE)
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
+  const rows = items
 
   const handleSearch = useCallback((v: string) => {
     setSearch(v)
@@ -117,7 +123,7 @@ export default function SamplesPage({ pollInterval = 30_000 }: { pollInterval?: 
           <div style={{ fontSize: 20, fontWeight: 700, color: T.text }}>Sample Catalog</div>
           <div style={{ fontSize: 13, color: T.muted, marginTop: 4 }}>
             <span style={{ color: T.text, fontFamily: 'DM Mono, monospace', fontWeight: 600 }}>
-              {allRows.length.toLocaleString()}
+              {facets.total.toLocaleString()}
             </span>{' '}total samples registered
           </div>
         </div>
@@ -129,24 +135,19 @@ export default function SamplesPage({ pollInterval = 30_000 }: { pollInterval?: 
       </div>
 
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(150px, 1fr))', gap: 10 }}>
-        {cohorts.map(c => {
-          const cohortCount = allRows.filter(r =>
-            (r.metadata as Record<string, string> | null)?.['cohort'] === c
-          ).length
-          return (
-            <button key={c} onClick={() => handleCohort(c)} style={{
-              background: cohort === c ? T.accentDim : T.surface,
-              border: `1px solid ${cohort === c ? T.accent : T.border}`,
-              borderRadius: 6, padding: '10px 14px', cursor: 'pointer',
-              textAlign: 'left', transition: 'all 0.15s',
-            }}>
-              <div style={{ fontSize: 11, color: cohort === c ? T.accent : T.muted,
-                fontWeight: 600, letterSpacing: '0.04em', textTransform: 'uppercase' }}>{c}</div>
-              <div style={{ fontSize: 18, fontWeight: 700, color: T.text, marginTop: 4,
-                fontFamily: 'DM Mono, monospace' }}>{fmtNum(cohortCount)}</div>
-            </button>
-          )
-        })}
+        {facets.cohorts.map(({ cohort: c, count }) => (
+          <button key={c} onClick={() => handleCohort(c)} style={{
+            background: cohort === c ? T.accentDim : T.surface,
+            border: `1px solid ${cohort === c ? T.accent : T.border}`,
+            borderRadius: 6, padding: '10px 14px', cursor: 'pointer',
+            textAlign: 'left', transition: 'all 0.15s',
+          }}>
+            <div style={{ fontSize: 11, color: cohort === c ? T.accent : T.muted,
+              fontWeight: 600, letterSpacing: '0.04em', textTransform: 'uppercase' }}>{c}</div>
+            <div style={{ fontSize: 18, fontWeight: 700, color: T.text, marginTop: 4,
+              fontFamily: 'DM Mono, monospace' }}>{fmtNum(count)}</div>
+          </button>
+        ))}
       </div>
 
       <div style={{ display: 'flex', gap: 10, alignItems: 'flex-end', flexWrap: 'wrap' }}>
@@ -187,10 +188,10 @@ export default function SamplesPage({ pollInterval = 30_000 }: { pollInterval?: 
           <span style={{ fontSize: 12, color: T.muted }}>
             Showing{' '}
             <span style={{ color: T.text, fontFamily: 'DM Mono, monospace' }}>
-              {filtered.length === 0 ? 0 : (page * PAGE_SIZE + 1).toLocaleString()}–{Math.min((page + 1) * PAGE_SIZE, filtered.length).toLocaleString()}
+              {total === 0 ? 0 : (page * PAGE_SIZE + 1).toLocaleString()}–{Math.min((page + 1) * PAGE_SIZE, total).toLocaleString()}
             </span>{' '}of{' '}
             <span style={{ color: T.text, fontFamily: 'DM Mono, monospace' }}>
-              {filtered.length.toLocaleString()}
+              {total.toLocaleString()}
             </span>
           </span>
           <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
@@ -213,10 +214,10 @@ export default function SamplesPage({ pollInterval = 30_000 }: { pollInterval?: 
             if (phenotype) metadata['phenotype'] = phenotype
             if (source)    metadata['source']    = source
             api.samples.create({ sample_id: sampleId, metadata })
-              .then(created => {
-                setAllRows(rs => [...rs, created])
+              .then(() => {
                 api.admin.reconcile().catch(console.error)
                 setShowForm(false)
+                refresh()  // refetch page + facets to include the new sample
               })
               .catch(console.error)
           }}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -12,6 +12,18 @@ export interface SampleResponse {
   updated_at: string
 }
 
+export interface SampleListResponse {
+  items: SampleResponse[]
+  total: number
+  limit: number
+  offset: number
+}
+
+export interface CohortFacetsResponse {
+  total: number
+  cohorts: Array<{ cohort: string; count: number }>
+}
+
 export interface WorkflowResponse {
   id: number
   workflow_id: string

--- a/src/nextflow_telemetry/routers/samples.py
+++ b/src/nextflow_telemetry/routers/samples.py
@@ -39,6 +39,24 @@ class SampleResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class SampleListResponse(BaseModel):
+    """A page of samples plus the total count matching the current filters."""
+    items: list[SampleResponse]
+    total: int = Field(description="Total samples matching the filters (for pagination).")
+    limit: int
+    offset: int
+
+
+class CohortFacet(BaseModel):
+    cohort: str
+    count: int
+
+
+class CohortFacetsResponse(BaseModel):
+    total: int = Field(description="Total samples in the catalog (all cohorts, incl. none).")
+    cohorts: list[CohortFacet] = Field(description="Per-cohort counts across the whole catalog, largest first.")
+
+
 def _row_to_response(row: dict) -> SampleResponse:
     return SampleResponse(
         id=row["id"],
@@ -78,16 +96,40 @@ def create_samples_router(engine: AsyncEngine) -> APIRouter:
 
     @router.get(
         "",
-        response_model=list[SampleResponse],
-        summary="List samples",
-        description="Returns a paginated list of all samples, ordered by insertion time.",
+        response_model=SampleListResponse,
+        summary="List samples (paginated, filterable)",
+        description=(
+            "Returns a page of samples plus the total matching count. Filter "
+            "server-side with `search` (case-insensitive `sample_id` substring) "
+            "and `cohort` (exact `metadata.cohort`), so the catalog stays usable "
+            "well past the old client-side 1000-row ceiling (#118)."
+        ),
     )
     async def list_samples(
         limit: int = Query(default=100, ge=1, le=1000, description="Maximum number of samples to return."),
         offset: int = Query(default=0, ge=0, description="Number of samples to skip."),
+        search: str | None = Query(default=None, description="Case-insensitive substring match on sample_id."),
+        cohort: str | None = Query(default=None, description="Exact match on metadata.cohort."),
     ):
-        rows = await svc.list_samples(limit=limit, offset=offset)
-        return [_row_to_response(r) for r in rows]
+        rows, total = await svc.list_samples(limit=limit, offset=offset, search=search, cohort=cohort)
+        return SampleListResponse(
+            items=[_row_to_response(r) for r in rows],
+            total=total, limit=limit, offset=offset,
+        )
+
+    @router.get(
+        "/facets/cohorts",
+        response_model=CohortFacetsResponse,
+        summary="Cohort facet counts across the whole catalog",
+        description=(
+            "Per-cohort sample counts (from `metadata.cohort`) over ALL samples, "
+            "plus the grand total — powers the Samples-page cohort chips so they "
+            "stay correct regardless of the current page or filters."
+        ),
+    )
+    async def cohort_facets():
+        total, cohorts = await svc.cohort_facets()
+        return CohortFacetsResponse(total=total, cohorts=[CohortFacet(**c) for c in cohorts])
 
     @router.get(
         "/by-srr/{srr_accession}",

--- a/src/nextflow_telemetry/services/sample.py
+++ b/src/nextflow_telemetry/services/sample.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncEngine
 
@@ -62,13 +62,59 @@ class SampleService:
             result = await conn.execute(stmt)
             return dict(result.mappings().one())
 
-    async def list_samples(self, limit: int = 100, offset: int = 0) -> list[dict]:
+    async def list_samples(
+        self,
+        limit: int = 100,
+        offset: int = 0,
+        *,
+        search: str | None = None,
+        cohort: str | None = None,
+    ) -> tuple[list[dict], int]:
+        """Return (page_of_samples, total_matching_count).
+
+        Filtering is server-side so the catalog is usable past the old
+        client-side 1000-row ceiling (#118): ``search`` is a case-insensitive
+        substring match on ``sample_id``; ``cohort`` matches
+        ``metadata_->>'cohort'`` exactly.
+        """
+        conds = []
+        if search:
+            conds.append(samples_tbl.c.sample_id.ilike(f"%{search}%"))
+        if cohort:
+            conds.append(samples_tbl.c.metadata_["cohort"].astext == cohort)
+
         async with self.engine.connect() as conn:
-            result = await conn.execute(
-                select(samples_tbl).order_by(samples_tbl.c.created_at.desc())
+            page = await conn.execute(
+                select(samples_tbl).where(*conds)
+                .order_by(samples_tbl.c.created_at.desc())
                 .limit(limit).offset(offset)
             )
-            return [dict(r) for r in result.mappings()]
+            rows = [dict(r) for r in page.mappings()]
+            total = (await conn.execute(
+                select(func.count()).select_from(samples_tbl).where(*conds)
+            )).scalar_one()
+        return rows, total
+
+    async def cohort_facets(self) -> tuple[int, list[dict]]:
+        """Return (total_samples, [{cohort, count}]) across the whole catalog.
+
+        Powers the Samples-page cohort chips at scale — global counts that don't
+        shift as the user pages. Uses the current free-text ``metadata_->>'cohort''``
+        representation; this becomes membership-driven once the Epic A
+        consolidation lands (docs/study-sample-version-identity.md).
+        """
+        cohort_expr = samples_tbl.c.metadata_["cohort"].astext
+        async with self.engine.connect() as conn:
+            total = (await conn.execute(
+                select(func.count()).select_from(samples_tbl)
+            )).scalar_one()
+            rows = (await conn.execute(
+                select(cohort_expr.label("cohort"), func.count().label("count"))
+                .where(cohort_expr.isnot(None))
+                .group_by(cohort_expr)
+                .order_by(func.count().desc(), cohort_expr)
+            )).mappings().all()
+        return total, [{"cohort": r["cohort"], "count": r["count"]} for r in rows]
 
     async def get(self, sample_id: str) -> dict | None:
         async with self.engine.connect() as conn:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -134,8 +134,49 @@ def test_list_samples(integration_client):
 
     resp = client.get("/api/samples")
     assert resp.status_code == 200
-    ids = [r["sample_id"] for r in resp.json()]
-    assert sample_id in ids
+    body = resp.json()
+    assert sample_id in [r["sample_id"] for r in body["items"]]
+    assert body["total"] >= 1
+    assert body["limit"] == 100 and body["offset"] == 0
+
+
+def test_list_samples_search_and_cohort_filter(integration_client):
+    client, _ = integration_client
+    tag = uuid.uuid4().hex[:8]
+    coh = f"COH-{tag}"
+    ids = [f"SRR-{tag}-{i}" for i in range(3)]
+    for i, sid in enumerate(ids):
+        client.post("/api/samples", json={"sample_id": sid, "ncbi_accession": f"SRR00000{i+1}", "metadata": {"cohort": coh}})
+    client.post("/api/samples", json={"sample_id": f"OTHER-{tag}", "ncbi_accession": "SRR000009", "metadata": {"cohort": "different"}})
+
+    by_search = client.get(f"/api/samples?search=SRR-{tag}").json()
+    assert by_search["total"] == 3
+    assert {x["sample_id"] for x in by_search["items"]} == set(ids)
+
+    by_cohort = client.get(f"/api/samples?cohort={coh}").json()
+    assert by_cohort["total"] == 3
+    assert all(x["metadata"]["cohort"] == coh for x in by_cohort["items"])
+
+    # Pagination over the filtered set.
+    p0 = client.get(f"/api/samples?search=SRR-{tag}&limit=2&offset=0").json()
+    assert p0["total"] == 3 and len(p0["items"]) == 2
+    p1 = client.get(f"/api/samples?search=SRR-{tag}&limit=2&offset=2").json()
+    assert len(p1["items"]) == 1
+
+
+def test_cohort_facets(integration_client):
+    client, _ = integration_client
+    tag = uuid.uuid4().hex[:8]
+    coh = f"FAC-{tag}"
+    for i in range(2):
+        client.post("/api/samples", json={"sample_id": f"SRR-fac-{tag}-{i}", "ncbi_accession": f"SRR00000{i+1}", "metadata": {"cohort": coh}})
+
+    resp = client.get("/api/samples/facets/cohorts")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] >= 2
+    counts = {c["cohort"]: c["count"] for c in body["cohorts"]}
+    assert counts.get(coh) == 2
 
 
 def test_get_sample_not_found(integration_client):


### PR DESCRIPTION
## Summary
The Samples page fetched ≤1000 rows and did pagination, search, cohort grouping, and the total count **client-side**, so past 1000 samples the header total, cohort chips, and search silently truncated — unusable at 100k scale.

### Backend
- `GET /samples` → paginated envelope `{items, total, limit, offset}` with server-side `search` (case-insensitive `sample_id` substring) and `cohort` (exact `metadata.cohort`) filters. `total` is the filtered count, so pagination is correct.
- `GET /samples/facets/cohorts` → `{total, cohorts:[{cohort,count}]}` across the whole catalog — powers the cohort chips + grand total independent of the current page/filters. (Uses the current `metadata.cohort` representation; becomes membership-driven when the Epic A consolidation lands.)

### Frontend
- `SamplesPage` is fully server-driven: debounced search, server pagination, facet-backed chips. Also fixes a latent bug where `api.samples.list` sent `skip` while the backend expects `offset`.

## Tests
- Paginated envelope shape; search + cohort filtering with pagination; cohort facet counts.
- Backend **143 passed**, mypy clean; frontend `tsc -b` + `vite build` clean.

## Note
This is the Samples slice of #118; Runs and cohort-failures pagination remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)