### PR TITLE
Add --all-into supercohort mode to collection seeding

### DIFF
--- a/scripts/seed_collection_from_cohort.py
+++ b/scripts/seed_collection_from_cohort.py
@@ -41,33 +41,42 @@ from nextflow_telemetry.db import (  # noqa: E402
 )
 
 
-async def _run(cohort: str, source: str, label: str | None, commit: bool) -> int:
+async def _run(cohort: str | None, all_into: str | None, source: str, label: str | None, commit: bool) -> int:
     uri = os.environ.get("SQLALCHEMY_URI")
     if not uri:
         raise click.ClickException("SQLALCHEMY_URI not set")
     if uri.startswith("postgresql://"):
         uri = uri.replace("postgresql://", "postgresql+asyncpg://", 1)
 
+    # Two modes:
+    #   --cohort X    : one collection X ← samples with metadata.cohort == X (a study)
+    #   --all-into N  : one collection N ← EVERY sample (a supercohort, e.g. CMD).
+    # The supercohort mode is what makes sample↔study genuinely many-to-many: a
+    # sample already in its study collection also joins the supercohort, so it
+    # counts toward both (docs/study-sample-version-identity.md, Decision 2).
+    collection_id = all_into or cohort
+    assert collection_id is not None  # guaranteed by the CLI validation
+    if all_into:
+        selection = select(samples_tbl.c.sample_id)
+        meta = {"origin": "seed_collection_from_cohort", "supercohort": True}
+        descr = f"all samples → {all_into!r} (supercohort)"
+    else:
+        selection = select(samples_tbl.c.sample_id).where(
+            samples_tbl.c.metadata_["cohort"].astext == cohort
+        )
+        meta = {"origin": "seed_collection_from_cohort", "cohort_field": cohort}
+        descr = f"cohort {cohort!r}"
+
     now = datetime.datetime.now(datetime.timezone.utc)
     engine = create_async_engine(uri)
     try:
         async with engine.begin() as conn:
-            # Samples whose metadata.cohort matches the requested cohort.
-            sample_ids = [
-                r[0]
-                for r in (
-                    await conn.execute(
-                        select(samples_tbl.c.sample_id).where(
-                            samples_tbl.c.metadata_["cohort"].astext == cohort
-                        )
-                    )
-                ).all()
-            ]
+            sample_ids = [r[0] for r in (await conn.execute(selection)).all()]
             if not sample_ids:
-                click.echo(f"No samples found with metadata.cohort == {cohort!r}. Nothing to do.")
+                click.echo(f"No samples found for {descr}. Nothing to do.")
                 return 0
 
-            click.echo(f"Cohort {cohort!r}: {len(sample_ids)} matching samples.")
+            click.echo(f"{descr}: {len(sample_ids)} matching samples → collection {collection_id!r}.")
 
             if not commit:
                 click.echo("DRY RUN — pass --commit to write the collection + memberships.")
@@ -77,39 +86,42 @@ async def _run(cohort: str, source: str, label: str | None, commit: bool) -> int
             await conn.execute(
                 pg_insert(collections_tbl)
                 .values(
-                    collection_id=cohort,
+                    collection_id=collection_id,
                     source=source,
-                    label=label or cohort,
-                    metadata_={"origin": "seed_collection_from_cohort", "cohort_field": cohort},
+                    label=label or collection_id,
+                    metadata_=meta,
                     created_at=now,
                     updated_at=now,
                 )
                 .on_conflict_do_update(
                     index_elements=[collections_tbl.c.collection_id],
-                    set_={"label": label or cohort, "updated_at": now},
+                    set_={"label": label or collection_id, "updated_at": now},
                 )
             )
 
             # 2. Insert memberships, skipping any that already exist.
             result = await conn.execute(
                 pg_insert(collection_samples_tbl)
-                .values([{"collection_id": cohort, "sample_id": sid} for sid in sample_ids])
+                .values([{"collection_id": collection_id, "sample_id": sid} for sid in sample_ids])
                 .on_conflict_do_nothing(constraint="uq_collection_sample")
             )
-            click.echo(f"Collection {cohort!r} upserted; {result.rowcount} new memberships added "
-                       f"({len(sample_ids)} total in cohort).")
+            click.echo(f"Collection {collection_id!r} upserted; {result.rowcount} new memberships added "
+                       f"({len(sample_ids)} total).")
         return 0
     finally:
         await engine.dispose()
 
 
 @click.command()
-@click.option("--cohort", required=True, help="Value of samples.metadata.cohort to collect.")
+@click.option("--cohort", default=None, help="Value of samples.metadata.cohort to collect into a study collection.")
+@click.option("--all-into", "all_into", default=None, help="Put EVERY sample into this one collection (a supercohort, e.g. CMD). Exercises the many-to-many model.")
 @click.option("--source", default="manual", show_default=True, help="collections.source value.")
-@click.option("--label", default=None, help="Human label (defaults to the cohort name).")
+@click.option("--label", default=None, help="Human label (defaults to the collection id).")
 @click.option("--commit", is_flag=True, default=False, help="Actually write (default: dry run).")
-def main(cohort: str, source: str, label: str | None, commit: bool) -> None:
-    raise SystemExit(asyncio.run(_run(cohort, source, label, commit)))
+def main(cohort: str | None, all_into: str | None, source: str, label: str | None, commit: bool) -> None:
+    if bool(cohort) == bool(all_into):
+        raise click.UsageError("provide exactly one of --cohort or --all-into")
+    raise SystemExit(asyncio.run(_run(cohort, all_into, source, label, commit)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
`seed_collection_from_cohort.py` could only build one collection per `metadata.cohort` (a study). Adds `--all-into NAME` to put **every** sample into one collection — a supercohort like `CMD`.

Because a sample already in its study collection also joins the supercohort, this exercises the many-to-many `sample↔study` model (`docs/study-sample-version-identity.md`, Decision 2): each sample counts toward both its study and the supercohort.

Used live to seed the `CMD` supercohort over `ArtachoA_2021` + `ContevilleLC_2019`, so the cohort leaderboard shows per-study and aggregate completion simultaneously. CLI now requires exactly one of `--cohort` / `--all-into`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)