### PR TITLE
Don't flag actively-running cohorts as stalled (#119)

### DIFF
--- a/frontend/src/pages/CohortsPage.tsx
+++ b/frontend/src/pages/CohortsPage.tsx
@@ -19,7 +19,8 @@ const STALL_DAYS = 7
 
 function isStalled(r: CohortLeaderboardRow): boolean {
   if (r.samples_remaining <= 0) return false            // nothing left to do
-  if (!r.last_completed_at) return true                 // remaining, never completed
+  if (r.samples_running > 0) return false               // actively progressing, not stalled
+  if (!r.last_completed_at) return true                 // remaining, nothing running, never completed
   const days = (Date.now() - new Date(r.last_completed_at).getTime()) / 86_400_000
   return days > STALL_DAYS
 }


### PR DESCRIPTION
Found via live UI verification: a cohort with 15/15 samples actively running showed a STALLED badge. `isStalled()` flagged `remaining>0 && no completion yet` without checking for running work. Now returns false when `samples_running > 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)