### PR TITLE
Reject non-run-accession rows when seeding samples

### DIFF
--- a/scripts/seed_from_tsv.py
+++ b/scripts/seed_from_tsv.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+import re
 import sys
 from pathlib import Path
 
@@ -19,6 +20,10 @@ import httpx
 REPO_ROOT = Path(__file__).parent.parent
 DEFAULT_TSV = REPO_ROOT / "ArtachoA_2021_sample.tsv"
 DEFAULT_SERVER = "http://localhost:8000"
+
+# A real SRA / ENA / DDBJ run accession (SRR/ERR/DRR + digits). Used to reject
+# curation-TSV placeholders (e.g. "Not applicable") before seeding.
+_RUN_ACCESSION = re.compile(r"\b[SED]RR\d+\b")
 
 NF_TESTING_WORKFLOW = {
     "workflow_id": "nf_testing",
@@ -60,7 +65,12 @@ def main() -> None:
         ncbi_accession = row.get("ncbi_accession", "").strip()
         cohort = row.get("study_name", "").strip()
 
-        if not ncbi_accession:
+        # Hygiene: skip rows without a real run accession. Curation TSVs use
+        # placeholders like "Not applicable" in ncbi_accession, which parse_srrs
+        # is lenient enough to pass through — seeding one produces a sample whose
+        # fasterq_dump can never succeed. Require at least one SRA/ENA/DDBJ run
+        # accession token.
+        if not ncbi_accession or not _RUN_ACCESSION.search(ncbi_accession):
             skipped += 1
             continue
 

--- a/scripts/seed_studies_from_cmd.py
+++ b/scripts/seed_studies_from_cmd.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Seed samples from curatedMetagenomicData curation studies.
+
+Fetches each study's `<study>_sample.tsv` straight from the waldronlab
+curatedMetagenomicDataCuration repo, registers up to `--limit` samples per study
+(content-addressed sample_id = md5 of the SRR set), tags each with
+`metadata.cohort = <study>`, and reconciles once at the end.
+
+Only rows with a real SRA/ENA/DDBJ run accession are seeded — curation TSVs
+carry placeholders like "Not applicable" in `ncbi_accession`, and seeding one
+produces a sample whose fasterq_dump can never succeed.
+
+Usage:
+    uv run --with httpx python scripts/seed_studies_from_cmd.py \
+        --study WirbelJ_2018 --study GuptaA_2019 --limit 25 \
+        --server https://nf-telemetry.cancerdatasci.org
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+import httpx
+
+REPO_ROOT = Path(__file__).parent.parent
+DEFAULT_BASE = (
+    "https://raw.githubusercontent.com/waldronlab/"
+    "curatedMetagenomicDataCuration/master/inst/curated"
+)
+_RUN_ACCESSION = re.compile(r"\b[SED]RR\d+\b")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Seed samples from cMD curation studies")
+    ap.add_argument("--study", action="append", required=True, help="Study name (repeatable).")
+    ap.add_argument("--limit", type=int, default=25, help="Max samples per study (default 25).")
+    ap.add_argument("--server", default="http://localhost:8000")
+    ap.add_argument("--base", default=DEFAULT_BASE, help="Raw base URL for curated TSVs.")
+    ap.add_argument("--no-reconcile", action="store_true", help="Skip the final reconcile call.")
+    args = ap.parse_args()
+
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+    from nextflow_telemetry.utils import parse_srrs, srrs_to_sample_id
+
+    server = args.server.rstrip("/")
+    client = httpx.Client(base_url=f"{server}/api/", timeout=60)
+    try:
+        httpx.get(f"{server}/health", timeout=10).raise_for_status()
+    except Exception as e:
+        print(f"ERROR: cannot reach {server}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    total = rejected = 0
+    for study in args.study:
+        try:
+            raw = urllib.request.urlopen(f"{args.base}/{study}/{study}_sample.tsv", timeout=30).read().decode()
+        except Exception as e:
+            print(f"  {study}: FETCH FAILED {e}", file=sys.stderr)
+            continue
+        rows = list(csv.DictReader(io.StringIO(raw), delimiter="\t"))
+        seeded = rej = 0
+        for row in rows:
+            if seeded >= args.limit:
+                break
+            acc = (row.get("ncbi_accession") or "").strip()
+            if not acc or not _RUN_ACCESSION.search(acc):
+                if acc:
+                    rej += 1
+                continue
+            srrs = parse_srrs(acc)
+            if not srrs:
+                continue
+            sid = srrs_to_sample_id(srrs)
+            resp = client.post("samples", json={
+                "sample_id": sid, "ncbi_accession": acc, "metadata": {"cohort": study},
+            })
+            if resp.status_code in (200, 201):
+                seeded += 1
+            else:
+                print(f"    WARN {study} {sid}: {resp.status_code} {resp.text[:100]}", file=sys.stderr)
+        print(f"  {study:24s} seeded {seeded}  (rejected {rej} non-accession rows)")
+        total += seeded
+        rejected += rej
+
+    print(f"TOTAL seeded {total}, rejected {rejected} non-accession rows")
+
+    if not args.no_reconcile:
+        r = client.post("admin/reconcile-jobs")
+        r.raise_for_status()
+        print(f"Reconcile: {r.json().get('jobs_created')} pending jobs created")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
A cMD curation TSV had `Not applicable` in `ncbi_accession`; `parse_srrs` is lenient enough to pass it, so a dead sample got seeded (its `fasterq_dump` can never succeed — this was one of the 4 batch-poisoners in the live incident). Adds a run-accession guard (SRR/ERR/DRR) to `seed_from_tsv.py`, and lands `scripts/seed_studies_from_cmd.py` — the reusable cMD-study seeder used to load the exercise studies, with the same guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)