### PR TITLE
feat(submissions): study-by-accession submissions + nf-client operator CLI + add-study GitHub flow

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-study.yml
+++ b/.github/ISSUE_TEMPLATE/add-study.yml
@@ -1,0 +1,26 @@
+name: Add study
+description: Request registration of a study/BioProject's samples by INSDC accession.
+title: "[add-study] "
+labels: ["add-study"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Submitting this issue triggers a **dry-run preview** (how many samples the
+        accession expands to, and how many are new). A maintainer then applies the
+        `approved` label to register them for real.
+  - type: input
+    id: accession
+    attributes:
+      label: Accession
+      description: An INSDC study or BioProject accession.
+      placeholder: PRJNA694605  (also SRP…, ERP…, DRP…)
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes (optional)
+      description: Anything a reviewer should know (cohort, context, urgency).
+    validations:
+      required: false

--- a/.github/workflows/add-study.yml
+++ b/.github/workflows/add-study.yml
@@ -1,0 +1,111 @@
+# Study-submission workflow: an "add-study" issue drives a dry-run preview; a
+# maintainer's `approved` label registers the study for real via `nf-client`.
+#
+# Requires two repo settings:
+#   - Variable NF_TELEMETRY_URL  → the API base URL, e.g. https://nf-telemetry.cancerdatasci.org/api
+#   - Secret   NF_OPERATOR_TOKEN → mirror of GCP SM secret `cmgd-api-operator-token`
+name: add-study
+
+on:
+  issues:
+    types: [opened, edited, labeled]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  preview:
+    # Any edit/open of an add-study issue (but NOT the `approved` label event,
+    # which the apply job handles) produces a fresh dry-run preview.
+    if: >
+      contains(github.event.issue.labels.*.name, 'add-study') &&
+      (github.event.action == 'opened' || github.event.action == 'edited' ||
+       (github.event.action == 'labeled' && github.event.label.name == 'add-study'))
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      NF_TELEMETRY_URL: ${{ vars.NF_TELEMETRY_URL }}
+      NF_OPERATOR_TOKEN: ${{ secrets.NF_OPERATOR_TOKEN }}
+      ISSUE_BODY: ${{ github.event.issue.body }}
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install ./packages/nf_client
+      - name: Extract accession
+        id: acc
+        run: |
+          # From env (never inline-interpolated) to avoid script injection.
+          ACC=$(printf '%s' "$ISSUE_BODY" | grep -oiE 'PRJ[EDN][A-Z]?[0-9]+|[SED]RP[0-9]+' | head -1 || true)
+          echo "accession=$ACC" >> "$GITHUB_OUTPUT"
+      - name: Dry-run preview
+        run: |
+          ACC="${{ steps.acc.outputs.accession }}"
+          if [ -z "$ACC" ]; then
+            gh issue comment "$ISSUE_NUMBER" --body "❌ Could not find a study/BioProject accession (PRJ… / SRP… / ERP… / DRP…) in this issue."
+            exit 1
+          fi
+          if OUT=$(nf-client submit-study "$ACC" --dry-run --json 2>err.txt); then
+            FOUND=$(printf '%s' "$OUT" | python -c "import sys,json;print(json.load(sys.stdin)['samples_found'])")
+            NEW=$(printf '%s' "$OUT"  | python -c "import sys,json;print(json.load(sys.stdin)['samples_added'])")
+            EXIST=$(printf '%s' "$OUT" | python -c "import sys,json;print(json.load(sys.stdin)['samples_existing'])")
+            gh issue comment "$ISSUE_NUMBER" --body "🔍 **Dry-run: \`$ACC\`** — found **$FOUND** samples (**$NEW** new, **$EXIST** already registered).
+
+          A maintainer: add the **\`approved\`** label to register these for real."
+          else
+            gh issue comment "$ISSUE_NUMBER" --body "❌ Dry-run for \`$ACC\` failed:
+          \`\`\`
+          $(cat err.txt)
+          \`\`\`"
+            exit 1
+          fi
+
+  apply:
+    # A maintainer applying `approved` to an add-study issue registers it for real.
+    if: >
+      github.event.action == 'labeled' && github.event.label.name == 'approved' &&
+      contains(github.event.issue.labels.*.name, 'add-study')
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      NF_TELEMETRY_URL: ${{ vars.NF_TELEMETRY_URL }}
+      NF_OPERATOR_TOKEN: ${{ secrets.NF_OPERATOR_TOKEN }}
+      ISSUE_BODY: ${{ github.event.issue.body }}
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install ./packages/nf_client
+      - name: Extract accession
+        id: acc
+        run: |
+          ACC=$(printf '%s' "$ISSUE_BODY" | grep -oiE 'PRJ[EDN][A-Z]?[0-9]+|[SED]RP[0-9]+' | head -1 || true)
+          echo "accession=$ACC" >> "$GITHUB_OUTPUT"
+      - name: Register
+        run: |
+          ACC="${{ steps.acc.outputs.accession }}"
+          if [ -z "$ACC" ]; then
+            gh issue comment "$ISSUE_NUMBER" --body "❌ No accession found — cannot register."
+            exit 1
+          fi
+          if OUT=$(nf-client submit-study "$ACC" --json 2>err.txt); then
+            SID=$(printf '%s' "$OUT" | python -c "import sys,json;print(json.load(sys.stdin)['submission_id'])")
+            NEW=$(printf '%s' "$OUT" | python -c "import sys,json;print(json.load(sys.stdin)['samples_added'])")
+            EXIST=$(printf '%s' "$OUT" | python -c "import sys,json;print(json.load(sys.stdin)['samples_existing'])")
+            gh issue comment "$ISSUE_NUMBER" --body "✅ **Registered \`$ACC\`** — $NEW new samples, $EXIST already present.
+
+          Submission ID: \`$SID\`
+          Jobs are not dispatched automatically — run \`nf-client reconcile\` (or the reconcile endpoint) when ready."
+            gh issue close "$ISSUE_NUMBER"
+          else
+            gh issue comment "$ISSUE_NUMBER" --body "❌ Registration of \`$ACC\` failed:
+          \`\`\`
+          $(cat err.txt)
+          \`\`\`"
+            exit 1
+          fi

--- a/deploy/onclappc02/.env.example
+++ b/deploy/onclappc02/.env.example
@@ -43,6 +43,7 @@ SQLALCHEMY_URI=postgresql+asyncpg://nf_telemetry:CHANGEME@pg_main:5432/nf_teleme
 #   OAUTH_CLIENT_ID       ← cancerdatasci-oauth-client-id
 #   OAUTH_CLIENT_SECRET   ← cancerdatasci-oauth-client-secret
 #   SESSION_SECRET        ← cmgd-api-session-secret
+#   OPERATOR_TOKEN        ← cmgd-api-operator-token  (operator/CI auth for POST /submissions)
 #
 # docker-compose reads both .env and .env.secrets. Run fetch-secrets.sh
 # once before first `docker compose up`, and again after any rotation

--- a/deploy/onclappc02/fetch-secrets.sh
+++ b/deploy/onclappc02/fetch-secrets.sh
@@ -30,6 +30,7 @@ trap 'rm -f "$tmp"' EXIT
     echo "OAUTH_CLIENT_ID=$(get cancerdatasci-oauth-client-id)"
     echo "OAUTH_CLIENT_SECRET=$(get cancerdatasci-oauth-client-secret)"
     echo "SESSION_SECRET=$(get cmgd-api-session-secret)"
+    echo "OPERATOR_TOKEN=$(get cmgd-api-operator-token)"
 } > "$tmp"
 
 chmod 600 "$tmp"

--- a/packages/nf_client/src/nf_client/cli.py
+++ b/packages/nf_client/src/nf_client/cli.py
@@ -13,6 +13,8 @@ Usage:
 from __future__ import annotations
 
 import asyncio
+import json as _json
+import os
 import re
 import socket
 import subprocess
@@ -61,6 +63,64 @@ def _count_active_slurm_jobs() -> int:
 
 config_option = typer.Option(..., "--config", "-c", help="Path to client YAML config")
 dry_run_option = typer.Option(False, "--dry-run", help="Print what would be submitted without executing")
+
+# Operator/CI commands don't need the full daemon YAML — server URL and token can
+# come from flags/env. Config is optional here (contrast with config_option above).
+opt_config = typer.Option(None, "--config", "-c", help="Path to client YAML config (optional for operator commands).")
+opt_server = typer.Option(None, "--server", help="Telemetry API base URL. Overrides config; falls back to $NF_TELEMETRY_URL.")
+json_option = typer.Option(False, "--json", help="Emit raw JSON (for scripts/CI) instead of human text.")
+
+ENV_SERVER = "NF_TELEMETRY_URL"
+ENV_TOKEN = "NF_OPERATOR_TOKEN"
+
+
+def _operator_config(config: Path | None, server: str | None) -> ClientConfig:
+    """Resolve a ClientConfig for an operator/CI command.
+
+    Server URL: --server > $NF_TELEMETRY_URL > config.server_url.
+    Token:      $NF_OPERATOR_TOKEN > config.token  (env overrides YAML, so most
+    uses need no config file at all — just the two env vars).
+    """
+    if config is not None:
+        cfg = ClientConfig.from_yaml(config)
+    else:
+        url = server or os.environ.get(ENV_SERVER)
+        if not url:
+            raise typer.BadParameter(
+                f"Provide --server, set ${ENV_SERVER}, or pass --config with a server_url."
+            )
+        cfg = ClientConfig(server_url=url)
+    if server:
+        cfg = cfg.model_copy(update={"server_url": server})
+    token = os.environ.get(ENV_TOKEN) or cfg.token
+    return cfg.model_copy(update={"token": token})
+
+
+def _run_operator(coro):
+    """Run an operator coroutine, mapping HTTP errors to clean stderr + exit 1 (CI-friendly)."""
+    import httpx
+
+    try:
+        return asyncio.run(coro)
+    except httpx.HTTPStatusError as e:
+        detail = e.response.text
+        try:
+            detail = e.response.json().get("detail", detail)
+        except Exception:
+            pass
+        typer.echo(f"error: {e.response.status_code} {detail}", err=True)
+        raise typer.Exit(1)
+    except httpx.HTTPError as e:
+        typer.echo(f"error: request failed: {e}", err=True)
+        raise typer.Exit(1)
+
+
+def _emit(payload: dict, as_json: bool, human) -> None:
+    """Print payload as JSON or via the human(payload) formatter."""
+    if as_json:
+        typer.echo(_json.dumps(payload, default=str))
+    else:
+        human(payload)
 
 
 @app.command()
@@ -360,34 +420,132 @@ def daemon(
 
 @app.command()
 def stats(
-    config: Path = config_option,
+    config: Path = opt_config,
+    server: str = opt_server,
+    as_json: bool = json_option,
 ) -> None:
     """Print a summary of system state: samples, workflows, jobs/runs by status, DLQ."""
 
     async def _run() -> dict:
-        cfg = ClientConfig.from_yaml(config)
+        cfg = _operator_config(config, server)
         async with JobClient(cfg) as client:
             return await client.get_stats()
 
-    payload = asyncio.run(_run())
+    payload = _run_operator(_run())
 
-    typer.echo(f"samples:   {payload['samples']}")
-    typer.echo(f"workflows: {payload['workflows']}")
-    typer.echo(f"dead-letter (unresolved): {payload['dead_letter_unresolved']}")
-
-    typer.echo("\njobs by status:")
-    if payload["jobs_by_status"]:
-        for status, count in sorted(payload["jobs_by_status"].items()):
+    def human(p: dict) -> None:
+        typer.echo(f"samples:   {p['samples']}")
+        typer.echo(f"workflows: {p['workflows']}")
+        typer.echo(f"dead-letter (unresolved): {p['dead_letter_unresolved']}")
+        typer.echo("\njobs by status:")
+        for status, count in sorted(p["jobs_by_status"].items()) or []:
             typer.echo(f"  {status:<10} {count}")
-    else:
-        typer.echo("  (none)")
-
-    typer.echo("\nruns by status:")
-    if payload["runs_by_status"]:
-        for status, count in sorted(payload["runs_by_status"].items()):
+        if not p["jobs_by_status"]:
+            typer.echo("  (none)")
+        typer.echo("\nruns by status:")
+        for status, count in sorted(p["runs_by_status"].items()) or []:
             typer.echo(f"  {status:<10} {count}")
-    else:
-        typer.echo("  (none)")
+        if not p["runs_by_status"]:
+            typer.echo("  (none)")
+
+    _emit(payload, as_json, human)
+
+
+@app.command(name="submit-study")
+def submit_study(
+    accession: str = typer.Argument(..., help="Study/BioProject accession (PRJNA…, SRP…, ERP…, DRP…)."),
+    config: Path = opt_config,
+    server: str = opt_server,
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview counts without registering anything."),
+    reconcile: bool = typer.Option(False, "--reconcile", help="After a real submit, create pending jobs (POST /admin/reconcile-jobs)."),
+    as_json: bool = json_option,
+) -> None:
+    """Register a study/BioProject's samples by accession (mints a submission_id).
+
+    Requires an operator token: set $NF_OPERATOR_TOKEN (or token: in --config).
+    Registration only unless --reconcile is passed.
+    """
+    async def _run() -> dict:
+        cfg = _operator_config(config, server)
+        async with JobClient(cfg) as client:
+            receipt = await client.create_submission(accession, dry_run=dry_run)
+            if reconcile and not dry_run:
+                receipt["reconcile"] = await client.reconcile()
+            return receipt
+
+    payload = _run_operator(_run())
+
+    def human(p: dict) -> None:
+        typer.echo(
+            f"{p['status']}: {p['collection_id']} "
+            f"({p.get('source')}/{p.get('type')}) — "
+            f"found {p['samples_found']}, added {p['samples_added']}, existing {p['samples_existing']}"
+        )
+        if p.get("submission_id"):
+            typer.echo(f"submission_id: {p['submission_id']}")
+        if "reconcile" in p:
+            typer.echo(f"reconcile: {p['reconcile']}")
+
+    _emit(payload, as_json, human)
+
+
+@app.command()
+def submission(
+    submission_id: str = typer.Argument(..., help="Submission id returned by submit-study."),
+    config: Path = opt_config,
+    server: str = opt_server,
+    as_json: bool = json_option,
+) -> None:
+    """Look up a submission record by id (provenance receipt)."""
+
+    async def _run() -> dict:
+        cfg = _operator_config(config, server)
+        async with JobClient(cfg) as client:
+            return await client.get_submission(submission_id)
+
+    payload = _run_operator(_run())
+
+    def human(p: dict) -> None:
+        for k in ("submission_id", "method", "accession", "collection_id", "submitted_by",
+                  "status", "samples_found", "samples_added", "samples_existing", "created_at", "error"):
+            if p.get(k) is not None:
+                typer.echo(f"{k}: {p[k]}")
+
+    _emit(payload, as_json, human)
+
+
+@app.command()
+def reconcile(
+    config: Path = opt_config,
+    server: str = opt_server,
+    as_json: bool = json_option,
+) -> None:
+    """Create pending jobs for the samples × active-workflows cross-product."""
+
+    async def _run() -> dict:
+        cfg = _operator_config(config, server)
+        async with JobClient(cfg) as client:
+            return await client.reconcile()
+
+    payload = _run_operator(_run())
+    _emit(payload, as_json, lambda p: typer.echo(_json.dumps(p, default=str)))
+
+
+@app.command(name="requeue-dlq")
+def requeue_dlq(
+    config: Path = opt_config,
+    server: str = opt_server,
+    as_json: bool = json_option,
+) -> None:
+    """Requeue dead-letter jobs back to pending."""
+
+    async def _run() -> dict:
+        cfg = _operator_config(config, server)
+        async with JobClient(cfg) as client:
+            return await client.requeue_dead_letter()
+
+    payload = _run_operator(_run())
+    _emit(payload, as_json, lambda p: typer.echo(_json.dumps(p, default=str)))
 
 
 @app.command(name="upload-logs")

--- a/packages/nf_client/src/nf_client/client.py
+++ b/packages/nf_client/src/nf_client/client.py
@@ -37,7 +37,10 @@ class JobClient:
         # trailing slash, the last segment of base_url is replaced. Force a trailing
         # slash so callers can pass `.../api` or `.../api/` interchangeably.
         base_url = self._config.server_url.rstrip("/") + "/"
-        self._http = httpx.AsyncClient(base_url=base_url, timeout=30)
+        headers = {}
+        if self._config.token:
+            headers["Authorization"] = f"Bearer {self._config.token}"
+        self._http = httpx.AsyncClient(base_url=base_url, timeout=30, headers=headers)
         return self
 
     async def __aexit__(self, *_) -> None:
@@ -104,6 +107,36 @@ class JobClient:
     async def get_stats(self) -> dict:
         """Return the server's summary stats payload (samples, workflows, jobs/runs by status, DLQ)."""
         response = await self._client.get("admin/stats")
+        response.raise_for_status()
+        return response.json()
+
+    # ------------------------------------------------------------------
+    # Operator / CI methods (require a bearer token for the mutating ones)
+    # ------------------------------------------------------------------
+
+    async def create_submission(self, accession: str, *, dry_run: bool = False) -> dict:
+        """Register a study/BioProject by accession (or preview it with dry_run)."""
+        response = await self._client.post(
+            "submissions", json={"accession": accession, "dry_run": dry_run}
+        )
+        response.raise_for_status()
+        return response.json()
+
+    async def get_submission(self, submission_id: str) -> dict:
+        """Fetch a submission record by id (provenance receipt)."""
+        response = await self._client.get(f"submissions/{submission_id}")
+        response.raise_for_status()
+        return response.json()
+
+    async def reconcile(self) -> dict:
+        """Create pending jobs for the samples × active workflows cross-product."""
+        response = await self._client.post("admin/reconcile-jobs")
+        response.raise_for_status()
+        return response.json()
+
+    async def requeue_dead_letter(self) -> dict:
+        """Requeue dead-letter jobs back to pending."""
+        response = await self._client.post("admin/requeue-dead-letter")
         response.raise_for_status()
         return response.json()
 

--- a/packages/nf_client/src/nf_client/config.py
+++ b/packages/nf_client/src/nf_client/config.py
@@ -54,7 +54,13 @@ class SubmissionConfig(BaseModel):
 
 class ClientConfig(BaseModel):
     server_url: str
-    weblog_url: str
+    # Only the daemon/run-wrapper needs a weblog sink; operator/CI commands
+    # (study submissions, reconcile, introspection) don't, so it's optional.
+    weblog_url: str = ""
+    # Bearer token for operator/CI mutating endpoints (POST /submissions, …).
+    # Usually supplied via the NF_OPERATOR_TOKEN env var rather than YAML;
+    # the env var overrides this field. Empty ⇒ no Authorization header sent.
+    token: str | None = None
     profile: str = Field(default="standard", description="Nextflow profile passed as -profile to nextflow run. HPC-specific (e.g. 'anvil', 'alpine').")
     continuous: bool = Field(default=False, description="Keep daemon running when queue is empty, polling for new jobs.")
     dispatch: DispatchConfig = Field(default_factory=DispatchConfig)

--- a/src/nextflow_telemetry/config.py
+++ b/src/nextflow_telemetry/config.py
@@ -27,6 +27,11 @@ class Settings:
     # is permissive (logs a one-time warning) so daemons keep working during
     # the rollout window. Flip from empty → populated to enforce.
     DISPATCH_TOKEN: str
+    # Operator/CI auth for mutating catalog endpoints (e.g. POST /submissions).
+    # Separate from DISPATCH_TOKEN so operator/CI credentials and the daemon's
+    # dispatch credential can be revoked independently. Empty ⇒ token auth is
+    # disabled and those endpoints require a logged-in contributor/admin session.
+    OPERATOR_TOKEN: str
     # Cookie domain — set to ".cancerdatasci.org" in prod so the cookie is
     # sent by the SPA at cmgd.cancerdatasci.org to the API at
     # nf-telemetry.cancerdatasci.org (same eTLD+1, so SameSite=Lax works).
@@ -48,6 +53,7 @@ settings = Settings(
     OAUTH_REDIRECT_URI=os.environ.get("OAUTH_REDIRECT_URI", "http://localhost:8000/auth/callback"),
     SESSION_SECRET=os.environ.get("SESSION_SECRET", "dev-insecure-do-not-use-in-prod"),
     DISPATCH_TOKEN=os.environ.get("DISPATCH_TOKEN", ""),
+    OPERATOR_TOKEN=os.environ.get("OPERATOR_TOKEN", ""),
     SESSION_COOKIE_DOMAIN=os.environ.get("SESSION_COOKIE_DOMAIN", ""),
     FRONTEND_URL=os.environ.get("FRONTEND_URL", "/"),
 )

--- a/src/nextflow_telemetry/db.py
+++ b/src/nextflow_telemetry/db.py
@@ -112,7 +112,8 @@ collections_tbl = Table(
     metadata,
     Column("id", Integer, primary_key=True),
     Column("collection_id", String, nullable=False, unique=True),
-    Column("source", String, nullable=False),   # "bioproject" | "sra_study" | "manual"
+    Column("source", String, nullable=False),   # provenance: "bioproject" | "sra_study" | "manual"
+    Column("type", String, nullable=True),       # kind: "meta" | "study" | "project"
     Column("label", String, nullable=True),
     Column("metadata_", JSONB, nullable=True),
     Column("created_at", DateTime(timezone=True), nullable=False),
@@ -126,6 +127,34 @@ collection_samples_tbl = Table(
     Column("collection_id", String, ForeignKey("collections.collection_id"), nullable=False),
     Column("sample_id", String, ForeignKey("samples.sample_id"), nullable=False),
     UniqueConstraint("collection_id", "sample_id", name="uq_collection_sample"),
+)
+
+# ---------------------------------------------------------------------------
+# Submissions — the append-only event log of "register these samples" actions.
+# One row per registration attempt (accession or TSV), regardless of whether it
+# added anything. This is the provenance/audit source of truth; collections and
+# samples are the current-state projections. A no-op re-submission is still a
+# row (samples_added = 0), which the state tables can't otherwise express.
+# ---------------------------------------------------------------------------
+submissions_tbl = Table(
+    "submissions",
+    metadata,
+    Column("submission_id", String, primary_key=True),   # uuid4 hex, minted per attempt
+    Column("method", String, nullable=False),            # "ena_accession" | "curation_tsv" | "manual"
+    Column("accession", String, nullable=True),          # the input accession, when method is accession-based
+    Column("collection_id", String, nullable=True),      # the collection this attempt targeted/created
+    Column("source", String, nullable=True),             # collection source at submit time (bioproject/sra_study)
+    Column("type", String, nullable=True),               # collection kind (project/study/meta)
+    Column("submitted_by", String, nullable=False),      # user email, or "operator-token" for CI
+    Column("status", String, nullable=False),            # "succeeded" | "failed"
+    Column("samples_found", Integer, nullable=True),
+    Column("samples_added", Integer, nullable=True),
+    Column("samples_existing", Integer, nullable=True),
+    Column("error", Text, nullable=True),                # message when status = failed
+    Column("metadata_", JSONB, nullable=True),
+    Column("created_at", DateTime(timezone=True), nullable=False),
+    Index("ix_submissions_collection_id", "collection_id"),
+    Index("ix_submissions_created_at", "created_at"),
 )
 
 # ---------------------------------------------------------------------------

--- a/src/nextflow_telemetry/deps.py
+++ b/src/nextflow_telemetry/deps.py
@@ -29,6 +29,17 @@ class CurrentUser:
     role: str | None  # None when the email isn't in users_tbl (logged in but no role)
 
 
+@dataclass
+class Principal:
+    """Who performed a mutating action — a logged-in user or a service token.
+
+    ``identity`` is written to submissions.submitted_by for provenance:
+    the user's email, or "operator-token" for a valid OPERATOR_TOKEN caller.
+    """
+    identity: str
+    is_service: bool
+
+
 # Cache the "service auth disabled" warning so we log it exactly once at first hit.
 _service_auth_warned = False
 
@@ -64,6 +75,44 @@ def require_role(required: str):
         if required == "contributor" and user.role == "contributor":
             return user
         raise HTTPException(status_code=403, detail=f"Role '{required}' required")
+
+    return _dep
+
+
+def _bearer(authorization: str | None) -> str | None:
+    if not authorization or not authorization.lower().startswith("bearer "):
+        return None
+    return authorization.split(" ", 1)[1].strip()
+
+
+def require_role_or_token(required: str):
+    """Dep factory: accept a session with ``required`` role OR a valid OPERATOR_TOKEN.
+
+    Lets both a browser (session cookie) and CI/CLI (bearer token) drive the same
+    mutating endpoint. Returns a Principal identifying the caller. Anonymous and
+    tokenless → 401; wrong role and bad token → 403.
+    """
+    if required not in {"admin", "contributor"}:
+        raise ValueError(f"Unknown role: {required}")
+
+    async def _dep(
+        authorization: str | None = Header(default=None),
+        user: CurrentUser | None = Depends(get_current_user),
+    ) -> Principal:
+        if user is not None and (
+            user.role == "admin" or (required == "contributor" and user.role == "contributor")
+        ):
+            return Principal(identity=user.email, is_service=False)
+
+        token = _bearer(authorization)
+        if token and settings.OPERATOR_TOKEN and hmac.compare_digest(token, settings.OPERATOR_TOKEN):
+            return Principal(identity="operator-token", is_service=True)
+
+        # 403 only for a logged-in person who lacks the role; anonymous (incl. a
+        # bad/absent token) is unauthenticated → 401, matching require_service.
+        if user is not None:
+            raise HTTPException(status_code=403, detail=f"Role '{required}' or a valid operator token required")
+        raise HTTPException(status_code=401, detail="Authentication required")
 
     return _dep
 

--- a/src/nextflow_telemetry/main.py
+++ b/src/nextflow_telemetry/main.py
@@ -22,6 +22,7 @@ from .routers.dispatch import create_dispatch_router
 from .routers.process_metrics import create_process_metrics_router
 from .routers.runs import create_runs_router
 from .routers.samples import create_samples_router
+from .routers.submissions import create_submissions_router
 from .routers.task_logs import create_task_logs_router
 from .routers.workflows import create_workflows_router
 from .services.process_metrics import ProcessMetricsService
@@ -175,6 +176,7 @@ app.include_router(create_daemons_router(engine), prefix="/api")
 app.include_router(create_curated_router(engine), prefix="/api")
 app.include_router(create_runs_router(engine), prefix="/api")
 app.include_router(create_cohorts_router(engine), prefix="/api")
+app.include_router(create_submissions_router(engine), prefix="/api")
 # /auth/* lives at root (not under /api) so the OAuth redirect URI is a
 # tidy origin-relative path that fits naturally into Google's allowed-redirect
 # list and avoids stuffing /api into user-facing URLs.

--- a/src/nextflow_telemetry/migrations/versions/20260703_a5b6c7d8_collections_type.py
+++ b/src/nextflow_telemetry/migrations/versions/20260703_a5b6c7d8_collections_type.py
@@ -1,0 +1,37 @@
+"""collections_type
+
+Revision ID: a5b6c7d8
+Revises: f4a5b6c7
+Create Date: 2026-07-03
+
+Adds collections.type — the *kind* of collection (meta | study | project),
+a separate axis from collections.source (provenance). Flat model: a
+meta-collection (e.g. CMD) is still a flat bag of samples; nesting is deferred.
+
+Backfill of existing rows uses source, which at this point uniquely implies
+kind: every 'sra_study' row was seeded from a study curation TSV (study), and
+'bioproject' rows are accession-derived (project). 'manual' rows can't be
+inferred (CMD included) and are left NULL for a human to tag.
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "a5b6c7d8"
+down_revision: Union[str, Sequence[str], None] = "f4a5b6c7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("collections", sa.Column("type", sa.String(), nullable=True))
+    op.execute("UPDATE collections SET type = 'study' WHERE source = 'sra_study'")
+    op.execute("UPDATE collections SET type = 'project' WHERE source = 'bioproject'")
+
+
+def downgrade() -> None:
+    op.drop_column("collections", "type")

--- a/src/nextflow_telemetry/migrations/versions/20260703_b6c7d8e9_submissions_table.py
+++ b/src/nextflow_telemetry/migrations/versions/20260703_b6c7d8e9_submissions_table.py
@@ -1,0 +1,53 @@
+"""submissions_table
+
+Revision ID: b6c7d8e9
+Revises: a5b6c7d8
+Create Date: 2026-07-03
+
+Adds the submissions table — the append-only event log of "register these
+samples" actions (accession or, later, curation TSV). Provenance/audit source
+of truth; collections + samples remain the current-state projections. A no-op
+re-submission is still a row (samples_added = 0). Receipt-only for now; a
+submission_samples join (per-attempt sample sets / rollback) is deferred.
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+revision: str = "b6c7d8e9"
+down_revision: Union[str, Sequence[str], None] = "a5b6c7d8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "submissions",
+        sa.Column("submission_id", sa.String(), primary_key=True),
+        sa.Column("method", sa.String(), nullable=False),
+        sa.Column("accession", sa.String(), nullable=True),
+        sa.Column("collection_id", sa.String(), nullable=True),
+        sa.Column("source", sa.String(), nullable=True),
+        sa.Column("type", sa.String(), nullable=True),
+        sa.Column("submitted_by", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("samples_found", sa.Integer(), nullable=True),
+        sa.Column("samples_added", sa.Integer(), nullable=True),
+        sa.Column("samples_existing", sa.Integer(), nullable=True),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column("metadata_", JSONB(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index("ix_submissions_collection_id", "submissions", ["collection_id"])
+    op.create_index("ix_submissions_created_at", "submissions", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_submissions_created_at", table_name="submissions")
+    op.drop_index("ix_submissions_collection_id", table_name="submissions")
+    op.drop_table("submissions")

--- a/src/nextflow_telemetry/routers/submissions.py
+++ b/src/nextflow_telemetry/routers/submissions.py
@@ -1,0 +1,86 @@
+"""Submissions router — register a study/BioProject by accession, with provenance.
+
+A submission is the first-class record of a "register these samples" action.
+v1 supports the ENA-accession method; the ``method`` field leaves room for a
+curation-TSV adapter without changing the resource shape.
+"""
+from __future__ import annotations
+
+from typing import Any, Literal
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from ..deps import Principal, require_role_or_token
+from ..services.submission import AccessionError, SubmissionService
+
+
+class SubmissionRequest(BaseModel):
+    accession: str = Field(description="Study or BioProject accession (e.g. 'PRJNA694605', 'SRP123456').")
+    method: Literal["ena_accession"] = Field(
+        default="ena_accession",
+        description="How samples are supplied. Only 'ena_accession' is supported today.",
+    )
+    dry_run: bool = Field(
+        default=False,
+        description="Preview only: return the counts that would result, write nothing, mint no submission_id.",
+    )
+
+
+class SubmissionReceipt(BaseModel):
+    submission_id: str = Field(description="Unique ID for this registration attempt (provenance handle).")
+    collection_id: str
+    source: str = Field(description="Provenance: 'bioproject' or 'sra_study'.")
+    type: str = Field(description="Kind: 'project' for accession-registered collections.")
+    status: str = Field(description="'succeeded', 'dry_run', or 'failed'.")
+    samples_found: int = Field(description="Distinct samples the accession expanded to.")
+    samples_added: int = Field(description="Samples newly registered by this submission.")
+    samples_existing: int = Field(description="Samples that already existed (membership added, metadata untouched).")
+
+
+def create_submissions_router(engine: AsyncEngine) -> APIRouter:
+    router = APIRouter(prefix="/submissions", tags=["submissions"])
+    svc = SubmissionService(engine=engine)
+
+    @router.post(
+        "",
+        response_model=SubmissionReceipt,
+        status_code=201,
+        summary="Register a study/BioProject's samples from an accession",
+        description=(
+            "Expands an INSDC study or BioProject accession (PRJ… / SRP… / ERP… / DRP…) "
+            "to its runs via the ENA Portal API, registers any new samples, records the "
+            "collection + membership, and mints a submission_id for provenance. "
+            "Registration only — call `POST /admin/reconcile-jobs` afterwards to create "
+            "pending jobs. Existing samples keep their metadata. Requires an authenticated "
+            "contributor/admin session or a valid operator token."
+        ),
+    )
+    async def create_submission(
+        req: SubmissionRequest,
+        principal: Principal = Depends(require_role_or_token("contributor")),
+    ):
+        try:
+            return await svc.register_from_accession(
+                req.accession, submitted_by=principal.identity, dry_run=req.dry_run
+            )
+        except AccessionError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+        except httpx.HTTPError as e:
+            raise HTTPException(status_code=502, detail=f"ENA lookup failed: {e}")
+
+    @router.get(
+        "/{submission_id}",
+        response_model=dict[str, Any],
+        summary="Look up a submission by ID",
+        description="Returns the submission record (provenance receipt). 404 if unknown.",
+    )
+    async def get_submission(submission_id: str):
+        row = await svc.get(submission_id)
+        if not row:
+            raise HTTPException(status_code=404, detail=f"Submission '{submission_id}' not found")
+        return row
+
+    return router

--- a/src/nextflow_telemetry/services/submission.py
+++ b/src/nextflow_telemetry/services/submission.py
@@ -1,0 +1,241 @@
+"""Submission service — register a study/BioProject's samples, with provenance.
+
+Every registration attempt mints a ``submission_id`` and writes an append-only
+``submissions`` row (success or failure), so a no-op re-submission is still a
+recorded, attributable event. The actual sample/collection writes go through one
+shared core; input adapters (ENA accession now, curation TSV later) just produce
+the sample list the core registers.
+"""
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from ..db import collection_samples_tbl, collections_tbl, samples_tbl, submissions_tbl
+from ..utils import normalize_srrs, srrs_to_sample_id
+
+ENA_FILEREPORT = "https://www.ebi.ac.uk/ena/portal/api/filereport"
+ENA_FIELDS = (
+    "run_accession,secondary_sample_accession,sample_accession,"
+    "study_accession,secondary_study_accession,sample_title"
+)
+
+
+class AccessionError(ValueError):
+    """Raised for an accession the endpoint won't accept (bad type / no runs)."""
+
+
+def classify_source(accession: str) -> str:
+    """Return the ``collections.source`` for a study/BioProject accession.
+
+    Rejects run/sample/experiment accessions — a collection must be a study or
+    project, not a single run.
+    """
+    acc = accession.strip().upper()
+    if acc.startswith("PRJ"):
+        return "bioproject"
+    if acc[:3] in ("SRP", "ERP", "DRP"):
+        return "sra_study"
+    raise AccessionError(
+        f"'{accession}' is not a study/BioProject accession "
+        "(expected PRJ… or SRP/ERP/DRP…)"
+    )
+
+
+async def _fetch_runs(accession: str) -> list[dict[str, Any]]:
+    params = {"accession": accession, "result": "read_run", "fields": ENA_FIELDS, "format": "json"}
+    async with httpx.AsyncClient(timeout=60) as client:
+        resp = await client.get(ENA_FILEREPORT, params=params)
+    if resp.status_code == 204 or not resp.content:
+        return []
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _group_samples(rows: list[dict[str, Any]], collection_id: str) -> list[dict[str, Any]]:
+    """Group ENA run rows into samples keyed by SRA sample (secondary_sample_accession)."""
+    groups: dict[str, dict[str, Any]] = {}
+    for r in rows:
+        srr = (r.get("run_accession") or "").strip()
+        srs = (r.get("secondary_sample_accession") or "").strip()
+        if not srr or not srs:
+            continue
+        g = groups.setdefault(srs, {"srrs": [], "row": r})
+        g["srrs"].append(srr)
+
+    samples = []
+    for srs, g in groups.items():
+        r = g["row"]
+        samples.append({
+            "sample_id": srrs_to_sample_id(g["srrs"]),
+            "ncbi_accession": normalize_srrs(g["srrs"]),
+            "biosample_id": (r.get("sample_accession") or "").strip() or None,
+            "metadata": {
+                "sra_sample": srs,
+                "biosample": (r.get("sample_accession") or "").strip() or None,
+                "sra_study": (r.get("secondary_study_accession") or "").strip() or None,
+                "bioproject": (r.get("study_accession") or "").strip() or None,
+                "collection": collection_id,
+            },
+        })
+    return samples
+
+
+@dataclass
+class SubmissionService:
+    engine: AsyncEngine
+
+    async def register_from_accession(
+        self, accession: str, submitted_by: str, dry_run: bool = False
+    ) -> dict[str, Any]:
+        """Fetch runs for a study/BioProject, register new samples, record the submission.
+
+        Existing samples keep their metadata (only a membership row is added), so a
+        sample shared across studies isn't clobbered. Both success and failure write
+        a submissions row. When ``dry_run`` is set, nothing is written (no samples,
+        no collection, no submission row) — just the preview counts are returned with
+        status "dry_run" and an empty submission_id. Returns the submission receipt.
+        """
+        accession = accession.strip()
+        submission_id = "" if dry_run else uuid.uuid4().hex
+        collection_id = accession.upper()
+        try:
+            source = classify_source(accession)
+            rows = await _fetch_runs(accession)
+            samples = _group_samples(rows, collection_id)
+            if not samples:
+                raise AccessionError(f"no runs found for '{accession}'")
+            if dry_run:
+                counts = await self._count_new(samples)
+                status = "dry_run"
+            else:
+                counts = await self._register(
+                    submission_id=submission_id,
+                    method="ena_accession",
+                    accession=accession,
+                    collection_id=collection_id,
+                    source=source,
+                    type_="project",
+                    submitted_by=submitted_by,
+                    samples=samples,
+                )
+                status = "succeeded"
+        except (AccessionError, httpx.HTTPError) as e:
+            if not dry_run:
+                await self._record_failure(
+                    submission_id, "ena_accession", accession, collection_id, submitted_by, str(e)
+                )
+            raise
+        return {
+            "submission_id": submission_id,
+            "collection_id": collection_id,
+            "source": source,
+            "type": "project",
+            "status": status,
+            **counts,
+        }
+
+    async def _count_new(self, samples: list[dict[str, Any]]) -> dict[str, int]:
+        """Preview counts for a dry run — read-only, no writes."""
+        by_id = {s["sample_id"]: s for s in samples}
+        async with self.engine.connect() as conn:
+            existing = {
+                r[0] for r in (await conn.execute(
+                    select(samples_tbl.c.sample_id).where(samples_tbl.c.sample_id.in_(list(by_id)))
+                )).all()
+            }
+        return {
+            "samples_found": len(by_id),
+            "samples_added": len(by_id) - len(existing),
+            "samples_existing": len(existing),
+        }
+
+    async def _register(
+        self, *, submission_id: str, method: str, accession: str | None,
+        collection_id: str, source: str | None, type_: str | None,
+        submitted_by: str, samples: list[dict[str, Any]],
+    ) -> dict[str, int]:
+        """Shared core: upsert new samples, the collection, membership, and the submission row."""
+        by_id = {s["sample_id"]: s for s in samples}
+        now = datetime.now(timezone.utc)
+
+        async with self.engine.begin() as conn:
+            existing = {
+                r[0] for r in (await conn.execute(
+                    select(samples_tbl.c.sample_id).where(samples_tbl.c.sample_id.in_(list(by_id)))
+                )).all()
+            }
+            new_ids = [sid for sid in by_id if sid not in existing]
+
+            if new_ids:
+                await conn.execute(
+                    samples_tbl.insert(),
+                    [{
+                        "sample_id": sid,
+                        "ncbi_accession": by_id[sid]["ncbi_accession"],
+                        "biosample_id": by_id[sid]["biosample_id"],
+                        "metadata_": by_id[sid]["metadata"],
+                        "created_at": now,
+                        "updated_at": now,
+                    } for sid in new_ids],
+                )
+
+            await conn.execute(
+                pg_insert(collections_tbl)
+                .values(
+                    collection_id=collection_id, source=source, type=type_, label=collection_id,
+                    metadata_={"origin": "submission", "accession": accession},
+                    created_at=now, updated_at=now,
+                )
+                .on_conflict_do_update(
+                    index_elements=[collections_tbl.c.collection_id],
+                    set_={"updated_at": now},
+                )
+            )
+            await conn.execute(
+                pg_insert(collection_samples_tbl)
+                .values([{"collection_id": collection_id, "sample_id": sid} for sid in by_id])
+                .on_conflict_do_nothing(constraint="uq_collection_sample")
+            )
+
+            counts = {
+                "samples_found": len(by_id),
+                "samples_added": len(new_ids),
+                "samples_existing": len(existing),
+            }
+            await conn.execute(submissions_tbl.insert().values(
+                submission_id=submission_id, method=method, accession=accession,
+                collection_id=collection_id, source=source, type=type_,
+                submitted_by=submitted_by, status="succeeded", error=None,
+                metadata_=None, created_at=now, **counts,
+            ))
+        return counts
+
+    async def _record_failure(
+        self, submission_id: str, method: str, accession: str | None,
+        collection_id: str | None, submitted_by: str, error: str,
+    ) -> None:
+        """Record a failed attempt in its own transaction (the main one rolled back)."""
+        now = datetime.now(timezone.utc)
+        async with self.engine.begin() as conn:
+            await conn.execute(submissions_tbl.insert().values(
+                submission_id=submission_id, method=method, accession=accession,
+                collection_id=collection_id, source=None, type=None,
+                submitted_by=submitted_by, status="failed", error=error,
+                samples_found=None, samples_added=None, samples_existing=None,
+                metadata_=None, created_at=now,
+            ))
+
+    async def get(self, submission_id: str) -> dict | None:
+        async with self.engine.connect() as conn:
+            row = (await conn.execute(
+                select(submissions_tbl).where(submissions_tbl.c.submission_id == submission_id)
+            )).mappings().one_or_none()
+            return dict(row) if row else None

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -1,0 +1,132 @@
+"""Integration tests for the submission core (real DB, mocked ENA).
+
+Only the external ENA fetch is stubbed; sample/collection/membership/submission
+writes hit real Postgres so the content-addressed grouping and idempotency are
+exercised end-to-end.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from nextflow_telemetry.db import (
+    collection_samples_tbl,
+    collections_tbl,
+    samples_tbl,
+    submissions_tbl,
+)
+from nextflow_telemetry.services import submission as sub_mod
+from nextflow_telemetry.services.submission import AccessionError, SubmissionService
+
+# Two runs share one SRA sample (SRS1), a third is its own (SRS2).
+_ENA_ROWS = [
+    {"run_accession": "SRR2", "secondary_sample_accession": "SRS1", "sample_accession": "SAMN1",
+     "study_accession": "PRJNA1", "secondary_study_accession": "SRP1"},
+    {"run_accession": "SRR1", "secondary_sample_accession": "SRS1", "sample_accession": "SAMN1",
+     "study_accession": "PRJNA1", "secondary_study_accession": "SRP1"},
+    {"run_accession": "SRR3", "secondary_sample_accession": "SRS2", "sample_accession": "SAMN2",
+     "study_accession": "PRJNA1", "secondary_study_accession": "SRP1"},
+]
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+async def _scalar(db_url, stmt):
+    engine = create_async_engine(db_url)
+    try:
+        async with engine.connect() as conn:
+            return (await conn.execute(stmt)).scalar_one()
+    finally:
+        await engine.dispose()
+
+
+def test_submission_registers_and_is_idempotent(db_url, monkeypatch):
+    async def fake_fetch(accession):
+        return _ENA_ROWS
+
+    monkeypatch.setattr(sub_mod, "_fetch_runs", fake_fetch)
+
+    async def scenario():
+        engine = create_async_engine(db_url)
+        try:
+            svc = SubmissionService(engine=engine)
+
+            first = await svc.register_from_accession("PRJNA1", submitted_by="a@b.c")
+            assert first["status"] == "succeeded"
+            assert first["source"] == "bioproject" and first["type"] == "project"
+            assert first["samples_found"] == 2
+            assert first["samples_added"] == 2
+            assert first["samples_existing"] == 0
+            assert first["submission_id"]
+
+            # Second submission: same accession → nothing new, but still recorded.
+            second = await svc.register_from_accession("PRJNA1", submitted_by="a@b.c")
+            assert second["samples_found"] == 2
+            assert second["samples_added"] == 0
+            assert second["samples_existing"] == 2
+            assert second["submission_id"] != first["submission_id"]
+        finally:
+            await engine.dispose()
+
+    _run(scenario())
+
+    # DB state: 2 samples, 1 collection, 2 memberships, 2 submission rows.
+    assert _run(_scalar(db_url, select(func.count()).select_from(samples_tbl))) == 2
+    assert _run(_scalar(db_url, select(func.count()).select_from(collections_tbl).where(
+        collections_tbl.c.collection_id == "PRJNA1"))) == 1
+    assert _run(_scalar(db_url, select(collections_tbl.c.type).where(
+        collections_tbl.c.collection_id == "PRJNA1"))) == "project"
+    assert _run(_scalar(db_url, select(func.count()).select_from(collection_samples_tbl).where(
+        collection_samples_tbl.c.collection_id == "PRJNA1"))) == 2
+    assert _run(_scalar(db_url, select(func.count()).select_from(submissions_tbl))) == 2
+    # The no-op second submission is on record with 0 added.
+    assert _run(_scalar(db_url, select(func.count()).select_from(submissions_tbl).where(
+        submissions_tbl.c.samples_added == 0))) == 1
+
+
+def test_dry_run_previews_without_writing(db_url, monkeypatch):
+    async def fake_fetch(accession):
+        return _ENA_ROWS
+
+    monkeypatch.setattr(sub_mod, "_fetch_runs", fake_fetch)
+
+    async def scenario():
+        engine = create_async_engine(db_url)
+        try:
+            svc = SubmissionService(engine=engine)
+            r = await svc.register_from_accession("PRJNA1", submitted_by="a@b.c", dry_run=True)
+            assert r["status"] == "dry_run"
+            assert r["submission_id"] == ""
+            assert r["samples_found"] == 2 and r["samples_added"] == 2 and r["samples_existing"] == 0
+        finally:
+            await engine.dispose()
+
+    _run(scenario())
+
+    # Nothing was written — no samples, no collection, no submission row.
+    assert _run(_scalar(db_url, select(func.count()).select_from(samples_tbl))) == 0
+    assert _run(_scalar(db_url, select(func.count()).select_from(submissions_tbl))) == 0
+
+
+def test_bad_accession_records_failed_submission(db_url):
+    async def scenario():
+        engine = create_async_engine(db_url)
+        try:
+            svc = SubmissionService(engine=engine)
+            with pytest.raises(AccessionError):
+                await svc.register_from_accession("SRR999", submitted_by="a@b.c")
+        finally:
+            await engine.dispose()
+
+    _run(scenario())
+
+    # A failed attempt is still on record, with status=failed and no counts.
+    assert _run(_scalar(db_url, select(submissions_tbl.c.status).where(
+        submissions_tbl.c.accession == "SRR999"))) == "failed"
+    assert _run(_scalar(db_url, select(submissions_tbl.c.samples_added).where(
+        submissions_tbl.c.accession == "SRR999"))) is None


### PR DESCRIPTION
## What

Add studies to the catalog by INSDC accession (BioProject / SRP / ERP / DRP), **API-first**, with submissions as first-class provenance. Three layers:

### Backend
- **`submissions`** table — append-only event log of registration attempts (success *and* failure). A no-op re-submission is recorded with `samples_added=0`, which the state tables can't otherwise express.
- **`POST /api/submissions`** (+ `GET /api/submissions/{id}`) over a shared registration core; the ENA-accession expansion is the first adapter (`method` field leaves room for a curation-TSV adapter). Grouped by SRA sample so `sample_id`s match omicidx.
- **`collections.type`** (`meta`|`study`|`project`), backfilled from `source`.
- **`dry_run`** mode — preview counts, write nothing, mint no id.
- **`require_role_or_token`** — a logged-in contributor/admin session **or** a dedicated `OPERATOR_TOKEN` bearer drives the same endpoint (401 anonymous/bad-token, 403 logged-in-without-role).

### nf-client (operator/CI)
- New commands: `submit-study <accession> [--dry-run] [--reconcile] [--json]`, `submission <id>`, `reconcile`, `requeue-dlq`, `stats --json`.
- Token/server resolve from env (`NF_OPERATOR_TOKEN`, `NF_TELEMETRY_URL`) or optional YAML; **env overrides config**, so most uses need no config file.

### CI
- `.github` add-study **issue form** + **workflow**: dry-run preview on open/edit, real registration on the `approved` label, `submission_id` commented back and the issue closed.

## Verification
- Backend suite 146 passed; nf-client suite 45 passed.
- Migration applies cleanly on a live Postgres with **zero drift** vs `db.py`.
- E2E against a live server: live ENA dry-run (`PRJEB40922` → 183 samples, no writes), auth gating 401/401/400.

## Deploy follow-ups
1. On the API host: `fetch-secrets.sh` → `just migrate` → recycle container (picks up `OPERATOR_TOKEN`).
2. GitHub repo: secret `NF_OPERATOR_TOKEN` + variable `NF_TELEMETRY_URL` + `approved` label (being set alongside this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)