### PR TITLE
Daily fleet-health report + per-version GitHub issue publishing

### DIFF
--- a/.claude/skills/alpine-daemon/SKILL.md
+++ b/.claude/skills/alpine-daemon/SKILL.md
@@ -22,6 +22,44 @@ can't SSH into clusters to push work. Instead daemons live on the clusters and
 make **outbound HTTPS** to the API. Anything that assumes "the server connects to
 the cluster" is wrong for this deployment.
 
+## Cluster inventory (SSH, users, paths)
+
+Two live SLURM clusters run `cmgd_nextflow`. Any triage/report agent needs this
+to reach `sacct` / `squeue` / `srun`. The live roster + each daemon's full config
+is also queryable at runtime — `GET /api/daemons/` returns `config_yaml`
+(`profile`, `template_path`, `slurm_export_none`, batch size) per daemon.
+
+| | Alpine (CU Boulder) | Anvil (Purdue) |
+|---|---|---|
+| SSH | `ssh alpine` (key-based, tailnet jump via dccapp720; works with `-o BatchMode=yes`) | `ssh anvil` (key-based; BatchMode ok) |
+| Login / daemon host | `login-ci4` | `login07.anvil.rcac.purdue.edu` |
+| Cluster user | `seda0001_amc` | `x-seandavi` |
+| SLURM account | (default) | `cis240955` |
+| Nextflow `-profile` | `alpine,gcs` | `anvil` |
+| `store_dir` (persistent) | `/projects/seda0001_amc/cmgd/store` | `/anvil/projects/x-cis240955/cmgd/store` |
+| Per-run workDir | `/scratch/alpine/$USER/nf_worker/$SLURM_JOB_ID` (ephemeral, `rm -rf` at job end; realpath `/gpfs/alpine1/scratch/...`) | `/anvil/scratch/x-seandavi/cmgd_data/work` |
+| `slurm_export_none` | `true` (login env leaks to compute) | `false` (clean) |
+| batch / max concurrent runs | 25 / 10 | 200 / 5 |
+| Submit template | `/projects/seda0001_amc/nf_client/nextflow_telemetry/templates/submit_alpine.sh.j2` | `/anvil/projects/x-cis240955/cmgd/nf_worker/templates/submit_anvil.sh.j2` |
+| Short test partition (`srun`) | `--partition=atesting --qos=testing` (1 h cap) | use a short-walltime partition |
+| GCS access | `rclone gs1:` only (no gcloud/gsutil) | — |
+
+`onclappc02` also appears in `/api/daemons/` — a dead `nf_testing` daemon; ignore
+it (and its perpetual entry in `dispatchability.stuck`).
+
+**Container repro must run on a compute node.** Login nodes have **no
+`singularity`/`apptainer`** (`module load singularity` fails there); the binary
+(`/usr/bin/singularity`) exists only on compute nodes. To reproduce a task's
+container command, `srun` into a short partition (Alpine: `atesting`) and exec
+there. Note `$TMPDIR` inside a task container points at a per-job path that is
+**not** bind-mounted — tools that write scratch there (KMA) fail with
+`Error: 2 (No such file or directory)` unless the process sets `TMPDIR="$PWD"`
+(fixed pipeline 2.2.1).
+
+**Anvil specifics:** nextflow is pinned to **23.10.1** (Java-11 only); the daemon
+runs in `tmux` on login07; project space `/anvil/projects/x-cis240955` is
+persistent (not scratch).
+
 ## Restart on Alpine
 
 ```bash

--- a/.claude/skills/cmgd-config/SKILL.md
+++ b/.claude/skills/cmgd-config/SKILL.md
@@ -32,7 +32,9 @@ is the authoritative index of what lives where and how to change it.
 - Bottom: `includeConfig` lines pull in every `conf/profiles/*.config`.
 
 ### `conf/base.config` — process resources & error handling
-- `errorStrategy` (`finish` since 2.0.4), retries, per-`withName` cpu/mem/time.
+- `errorStrategy` — tiered: per-sample processes retry OOM/kill (137–140) up to
+  4×, else retry 2×, then `ignore` (drop the sample); DB-setup/finalize end in
+  `finish` (fail the run). Retries, per-`withName` cpu/mem/time.
 - Change resource escalation here (`memory = { N.GB * task.attempt }`).
 - **No `time > 24h`** on Alpine — escalate memory, not wall-time.
 

--- a/.claude/skills/cmgd-triage/SKILL.md
+++ b/.claude/skills/cmgd-triage/SKILL.md
@@ -26,6 +26,87 @@ curl -s "$API/api/admin/dispatchability" | python3 -m json.tool       # is it ev
 curl -s "$API/api/runs/?limit=80" | python3 -c 'import sys,json;from collections import Counter;r=json.load(sys.stdin);print(Counter(x["classification"] for x in r))'
 ```
 
+## Fleet health report (read-only, unattended-safe)
+
+A "how's it going + what's failing" sweep that **mutates nothing** — safe to run
+on a schedule with no human present. Do NOT call the Recovery POSTs below in an
+unattended run. Cluster-side detail (`sacct`/`squeue`) needs SSH — see
+`alpine-daemon` → **Cluster inventory**.
+
+**Ready-made:** `scripts/health_report.py` runs this whole sweep, applies the
+signal-vs-noise rules below, prints a report, and exits `0`=GREEN / `1`=ATTENTION
+(a regression signal fired) / `2`=API unreachable — the natural hook for an LLM
+deep-dive. Stdlib only. `scripts/run_daily_report.sh` wraps it for scheduling
+(logs to `~/.cmgd-health/`, drops `attention-latest.txt` when non-green) and, via
+`scripts/post_github.py`, publishes to a **per-(workflow, version) GitHub tracking
+issue** in `seandavi/nextflow_telemetry`:
+
+- **One issue per version** (`cmgd_nextflow 2.2.1 — fleet health`), auto-rotating
+  when a new version goes active after a release (the old issue is closed with a
+  pointer). The issue is that version's whole-rollout health record.
+- **Body is rewritten each run** (status + rolling table + latest report) —
+  editing an issue body does **not** notify: a silent daily heartbeat.
+- **A comment is posted only on non-green or recovery**, `@`-mentioning on
+  ATTENTION/ERROR — so notification volume == bad days. Toggle with `CMGD_GITHUB=0`;
+  override `CMGD_REPO` / `CMGD_MENTION`. `gh` token in `~/.config/gh/hosts.yml`
+  works headless.
+- **A flipping `status:green|attention|error` label** is kept in sync each run
+  (label edits don't notify) so the issue list / project board is scannable at a
+  glance. Set `CMGD_PROJECT=<number>` to auto-add each new version-issue to a
+  GitHub Project; group that board's Board view by **Labels** (view creation is
+  UI-only). Current deployment: project 19, owner `seandavi`.
+
+On the onclappc02-adjacent workstation the wrapper runs as the
+`cmgd-health-report.timer` systemd **user** timer (daily 08:00 MT, linger on;
+`systemctl --user list-timers`). The timer runs a stable copy under
+`~/.local/share/cmgd-health/`, so **re-copy all three scripts there after editing
+them here**. The manual recipe below is the same read-only sweep by hand:
+
+```bash
+API=https://nf-telemetry.cancerdatasci.org
+PK=$(curl -s "$API/api/workflows?status=active" | python3 -c 'import sys,json;print([w["id"] for w in json.load(sys.stdin) if w["workflow_id"]=="cmgd_nextflow"][0])')
+V=$(curl -s "$API/api/workflows/$PK" | python3 -c 'import sys,json;print(json.load(sys.stdin)["version"])')
+
+curl -s "$API/api/workflows/$PK/job-summary"                    # completion %, failed, dead_letter (authoritative)
+curl -s "$API/api/admin/stats"                                  # global; watch dead_letter_unresolved trend
+curl -s "$API/api/admin/dispatchability"                        # cmgd_nextflow must NOT be in stuck[]
+curl -s "$API/api/daemons/"                                     # both cluster daemons: fresh last_seen_at
+curl -s "$API/api/metrics/processes/running"                    # what stage the batch is in
+curl -s "$API/api/metrics/processes/failure-signatures?workflow_version=$V&window_hours=24"
+curl -s "$API/api/metrics/processes/timeline?workflow_version=$V&bucket=hour&window_hours=24"   # spike vs steady
+# per suspect process, is the retry recovering? (failures by attempt)
+curl -s "$API/api/metrics/processes/tasks?workflow_version=$V&process=<p>&status=FAILED&window_hours=24&limit=200"
+```
+
+Interpret failures against **Expected background failures** below before flagging
+anything. `dead_letter_unresolved` in `/stats` is **global across all versions** —
+compare to the active workflow's own `job-summary.dead_letter` to isolate the
+current batch.
+
+## Expected background failures (signal vs noise)
+
+At 100k scale a few % of tasks fail-and-recover every hour. These are **normal**
+— a daily report should NOT page on them:
+
+- **metaphlan `*` exit 137 (OOM), action RETRY.** `bowtie2-align` OOM-killed
+  (stderr: `bowtie2-align exited with value 137` + a downstream `BrokenPipeError`).
+  Memory scales `N.GB * task.attempt`, so the retry gets more RAM and succeeds.
+  **Healthy iff the failures are attempt-1 only** (check the `attempt` field). Page
+  only if attempt-2+ failures appear (scaling not keeping up) or its DLQ grows.
+- **fasterq_dump exit 3 (SRA/ENA download).** Interrupted read download; retried,
+  then per-sample `ignore`. Persistently-undownloadable accessions exhaust job
+  retries → land in the **DLQ**. That's a *data* problem (withdrawn/embargoed
+  accession), not a pipeline bug. Page only if the *rate* spikes (ENA/SRA outage)
+  or one study is ~100% failing.
+- **Baseline:** ~0.5–2%/hr steady task-failure is normal; a `timeline` spike
+  usually tracks a stage transition into compute-heavy metaphlan/resistome — cross
+  check `failure-signatures` before assuming an incident.
+
+**Regression signals — DO investigate:** `resistome_kma_*` failing at all (fixed
+2.2.1, expect 0); any process ~100% failing across many samples; a brand-new exit
+code dominating a process; DLQ climbing fast; a cluster daemon with a stale
+`last_seen_at`; `cmgd_nextflow` in `dispatchability.stuck`.
+
 ## Decision tree by classification
 
 ### `wrapper-failed` (wrapper_exit_code ≠ 0)
@@ -45,7 +126,8 @@ The driver died before/without uploading its log — usually the driver job itse
 was killed, not a task.
 - **Tasks ABORTED + 0 FAILED + no logs ⇒ the driver (wrapper) SLURM job was
   killed, classically OOM.** Do NOT look in telemetry for a failed task — there
-  isn't one. Check SLURM directly: `sacct -j <driver_jobid> --format=JobID,State,ExitCode,MaxRSS,ReqMem`. Exit `1:0` / `OUT_OF_MEMORY` → bump driver mem in the
+  isn't one. Check SLURM directly (SSH to the right cluster — `alpine-daemon` →
+  Cluster inventory for the `ssh` alias + user): `sacct -j <driver_jobid> --format=JobID,State,ExitCode,MaxRSS,ReqMem`. Exit `1:0` / `OUT_OF_MEMORY` → bump driver mem in the
   client yaml (`submission.defaults.mem`) and resubmit.
 
 ### `stalled` (non-terminal, heartbeat > 15 min old)
@@ -78,6 +160,9 @@ No active daemon claims this workflow_id.
 
 ## Recovery actions
 
+**These mutate dispatch state — never run them in an unattended report.** Reserve
+for a human-driven recovery; after any of them, confirm via `job-summary`.
+
 ```bash
 API=https://nf-telemetry.cancerdatasci.org
 curl -s -X POST "$API/api/admin/requeue-dead-letter"             # DLQ → pending
@@ -89,9 +174,13 @@ daemon will reclaim on its next poll. Confirm via job-summary.
 
 ## Gotchas
 
-- `errorStrategy` is `finish` (since 2.0.4): one bad task no longer aborts the
-  batch — so `wrapper-failed` with a high `COMPLETED` count is "almost worked,"
-  not "catastrophe."
+- **`errorStrategy` is tiered, not plain `finish`.** Per-sample processes: retry
+  OOM/kill (exit 137–140) up to 4×, else retry twice, then **`ignore`** — drop
+  just that sample so its batch-mates finish. DB-setup and finalize processes
+  (publish/manifest, MARK_COMPLETE) end in **`finish`** instead — a broken shared
+  DB or failed publish must stop the run rather than silently corrupt output. Net:
+  one bad per-sample task no longer aborts the batch, so `wrapper-failed` with a
+  high `COMPLETED` count is "almost worked," not "catastrophe."
 - Per-task `.command.out` (stdout) is uploaded since pipeline 2.0.1; before that,
   stdout-only tools (kraken2) were log-less. If a run predates 2.0.1, missing
   stdout is expected.

--- a/.claude/skills/cmgd-triage/scripts/health_report.py
+++ b/.claude/skills/cmgd-triage/scripts/health_report.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Daily cmgd_nextflow fleet health report — read-only, safe to cron.
+
+Runs the `cmgd-triage` "Fleet health report" sweep against the telemetry API,
+applies the documented signal-vs-noise rules, prints a concise report, and sets
+its exit code so cron/monitoring (or a follow-on LLM deep-dive) can react:
+
+    exit 0  → GREEN     (healthy, or only expected background noise)
+    exit 1  → ATTENTION (a documented regression signal fired)
+    exit 2  → ERROR     (couldn't reach the API / malformed response)
+
+Mutates nothing (GET only). Stdlib only — no deps. See the skill's
+"Expected background failures" section for why each rule is what it is.
+
+Usage:
+    health_report.py [--api URL] [--version X.Y.Z] [--window-hours N]
+                     [--daemon-stale-min N] [--json]
+"""
+import argparse
+import json
+import sys
+import urllib.request
+import urllib.error
+from datetime import datetime, timezone
+
+DEFAULT_API = "https://nf-telemetry.cancerdatasci.org"
+WORKFLOW_ID = "cmgd_nextflow"
+
+# Processes whose failures are expected background (retry-recovers or per-sample
+# ignore). See skill. Anything NOT here that fails notably is worth a look.
+OOM_RECOVER_PREFIXES = ("metaphlan",)          # exit 137, recovers on retry w/ more mem
+DOWNLOAD_NOISE = ("fasterq_dump",)             # SRA/ENA download flakiness -> retry/ignore/DLQ
+# These were fixed in 2.2.1 (KMA TMPDIR bug, exit 2). A *logic* failure here is a
+# regression; an infra-abort/OOM (killed task, retries) is not — discriminate below.
+REGRESSION_ZERO = ("resistome_kma_full", "resistome_kma_rarefied")
+
+# Exit codes that mean "task was killed" (node failure, preemption, SIGKILL, OOM),
+# not "the code ran and errored". Telemetry uses 2147483647 (INT_MAX) when no exit
+# code was captured (ABORTED). These retry and are infra noise, not logic bugs.
+INFRA_ABORT_CODES = {"2147483647", "-1", "143"}
+
+
+def is_infra_abort(exit_code):
+    if str(exit_code) in INFRA_ABORT_CODES:
+        return True
+    try:
+        return 137 <= int(exit_code) <= 140  # SIGKILL/OOM family
+    except (TypeError, ValueError):
+        return False
+
+
+def get(api, path, timeout=30):
+    url = f"{api}{path}"
+    with urllib.request.urlopen(url, timeout=timeout) as r:
+        return json.load(r)
+
+
+def total_for(api, version, process, status, window_hours, limit=1):
+    q = (f"/api/metrics/processes/tasks?workflow_version={version}"
+         f"&process={process}&status={status}&window_hours={window_hours}&limit={limit}")
+    return get(api, q)
+
+
+class Report:
+    def __init__(self):
+        self.lines = []
+        self.attention = []   # regression signals -> exit 1
+        self.notes = []       # expected background -> informational
+
+    def say(self, s=""):
+        self.lines.append(s)
+
+    def flag(self, s):
+        self.attention.append(s)
+
+    def note(self, s):
+        self.notes.append(s)
+
+    def verdict(self):
+        return "ATTENTION" if self.attention else "GREEN"
+
+
+def run(args):
+    api = args.api
+    r = Report()
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%SZ")
+    r.say(f"cmgd_nextflow health report — {now}")
+    r.say(f"api: {api}")
+    r.say("=" * 60)
+
+    # --- active workflow (pk + version) ---
+    workflows = get(api, "/api/workflows?status=active")
+    active = [w for w in workflows if w["workflow_id"] == WORKFLOW_ID]
+    if len(active) != 1:
+        r.flag(f"expected exactly 1 active {WORKFLOW_ID} row, found {len(active)} "
+               f"(reconcile double-dispatches every sample if >1)")
+        if not active:
+            r.say("no active cmgd_nextflow workflow — nothing to report")
+            return r
+    wf = active[0]
+    pk = wf["id"]
+    version = args.version or wf["version"]
+    r.say(f"active workflow: pk={pk} version={version} revision={wf['revision']}")
+
+    # --- job summary (authoritative) ---
+    js = get(api, f"/api/workflows/{pk}/job-summary")
+    r.say("")
+    r.say(f"jobs: {js['completed']}/{js['total']} complete ({js['completion_pct']}%)  "
+          f"running={js['running']} pending={js['pending']} "
+          f"failed={js['failed']} dead_letter={js['dead_letter']}")
+    if js["total"]:
+        dlq_pct = 100.0 * js["dead_letter"] / js["total"]
+        if dlq_pct >= args.dlq_pct:
+            r.flag(f"dead-letter is {dlq_pct:.1f}% of this batch "
+                   f"({js['dead_letter']}/{js['total']}) — over {args.dlq_pct}% threshold")
+
+    # --- global stats ---
+    stats = get(api, "/api/admin/stats")
+    r.say(f"global dead_letter_unresolved: {stats.get('dead_letter_unresolved')} "
+          f"(all versions; batch's own = {js['dead_letter']})")
+
+    # --- dispatchability ---
+    disp = get(api, "/api/admin/dispatchability")
+    stuck = [s for s in disp.get("stuck", [])
+             if WORKFLOW_ID in json.dumps(s)]  # ignore nf_testing/onclappc02
+    if stuck:
+        r.flag(f"{WORKFLOW_ID} has pending jobs but no daemon claiming them: {stuck}")
+    else:
+        r.say(f"dispatchability: ok (cmgd not stuck)")
+
+    # --- daemons freshness ---
+    daemons = get(api, "/api/daemons/")
+    r.say("")
+    r.say("daemons:")
+    for d in daemons:
+        if not d.get("is_active") and "nf_testing" in (d.get("workflow_id") or ""):
+            continue  # dead onclappc02 daemon — documented, ignore
+        seen = d.get("last_seen_at")
+        stale = _age_minutes(seen)
+        flagstr = ""
+        if WORKFLOW_ID in (d.get("workflow_id") or ""):
+            if stale is None or stale > args.daemon_stale_min:
+                r.flag(f"daemon {d['agent_id']} heartbeat stale "
+                       f"(last_seen {seen}, ~{stale}min)")
+                flagstr = "  <-- STALE"
+        r.say(f"  {d['agent_id']:<40} status={d.get('status')} "
+              f"active_runs={d.get('active_runs')} last_seen={seen}{flagstr}")
+
+    # --- failure signatures (what's breaking) ---
+    sigs = get(api, f"/api/metrics/processes/failure-signatures"
+                    f"?workflow_version={version}&window_hours={args.window_hours}")
+    r.say("")
+    r.say(f"failure signatures (last {args.window_hours}h):")
+    if not sigs.get("rows"):
+        r.say("  none")
+    for row in sigs.get("rows", []):
+        r.say(f"  {row['process']:<40} exit={row['exit_code']:<6} "
+              f"action={row['error_action']:<8} n={row['failures']}")
+
+    # --- classify each failing process ---
+    r.say("")
+    r.say("assessment:")
+    for row in sigs.get("rows", []):
+        proc, n, code = row["process"], row["failures"], row["exit_code"]
+        if any(proc.startswith(p) for p in REGRESSION_ZERO):
+            # fixed in 2.2.1 (exit 2). A logic exit code = regression; a killed
+            # task (infra-abort/OOM) is retryable noise, not the bug's return.
+            if is_infra_abort(code):
+                r.note(f"{proc}: {n} killed/aborted (exit {code}) — infra, retried, "
+                       f"not the KMA bug")
+            else:
+                r.flag(f"{proc}: {n} FAILED with exit {code} — regression "
+                       f"(fixed 2.2.1, expected 0)")
+        elif any(proc.startswith(p) for p in OOM_RECOVER_PREFIXES):
+            # healthy iff failures are attempt-1 only
+            tasks = total_for(api, version, proc, "FAILED", args.window_hours, limit=500)
+            attempts = sorted({t["attempt"] for t in tasks.get("rows", [])})
+            retried = [a for a in attempts if a and a >= 2]
+            if retried:
+                r.flag(f"{proc}: {n} OOM failures include retries (attempts {attempts}) "
+                       f"— memory scaling not keeping up")
+            else:
+                r.note(f"{proc}: {n} attempt-1 OOMs, all recover on retry — expected")
+        elif any(proc.startswith(p) for p in DOWNLOAD_NOISE):
+            r.note(f"{proc}: {n} download failures (exit {row['exit_code']}) "
+                   f"— SRA/ENA noise; undownloadable accessions -> DLQ")
+        elif is_infra_abort(code):
+            r.note(f"{proc}: {n} killed/aborted (exit {code}) — infra (node/preempt/"
+                   f"kill), retried; noise")
+        elif n >= args.min_unknown or row["error_action"] not in ("RETRY", "IGNORE"):
+            # unexpected process failing in volume, or giving up (not recovering)
+            r.flag(f"{proc}: {n} failures (exit {row['exit_code']}, "
+                   f"action {row['error_action']}) — not a known-noise process, investigate")
+        else:
+            # a handful of retryable failures on an unlisted process — recovers, noise
+            r.note(f"{proc}: {n} failure(s) (exit {row['exit_code']}, retryable) "
+                   f"— below investigate threshold ({args.min_unknown})")
+
+    # --- recent failure-rate trend ---
+    tl = get(api, f"/api/metrics/processes/timeline"
+                  f"?workflow_version={version}&bucket=hour&window_hours={args.window_hours}")
+    rows = tl.get("rows", [])
+    if rows:
+        recent = rows[-3:]
+        tot = sum(x["total"] for x in recent)
+        fail = sum(x["failed"] for x in recent)
+        pct = 100.0 * fail / tot if tot else 0.0
+        r.say("")
+        r.say(f"recent task failure rate (last {len(recent)}h): {pct:.1f}% ({fail}/{tot})")
+        if pct >= args.fail_pct:
+            r.flag(f"recent failure rate {pct:.1f}% over {args.fail_pct}% threshold "
+                   f"— check failure-signatures / for an SRA/cluster incident")
+
+    for nt in r.notes:
+        r.say(f"  [expected] {nt}")
+
+    return r
+
+
+def _age_minutes(iso):
+    if not iso:
+        return None
+    try:
+        t = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+        return int((datetime.now(timezone.utc) - t).total_seconds() // 60)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--api", default=DEFAULT_API)
+    ap.add_argument("--version", default=None, help="override workflow version (default: active row's)")
+    ap.add_argument("--window-hours", type=int, default=24)
+    ap.add_argument("--daemon-stale-min", type=int, default=15)
+    ap.add_argument("--dlq-pct", type=float, default=3.0, help="flag if batch DLQ exceeds this %%")
+    ap.add_argument("--fail-pct", type=float, default=8.0, help="flag if recent hourly failure %% exceeds this")
+    ap.add_argument("--min-unknown", type=int, default=10, help="flag an unlisted failing process only at/above this count")
+    ap.add_argument("--json", action="store_true", help="emit machine-readable summary too")
+    args = ap.parse_args()
+
+    try:
+        r = run(args)
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, ValueError) as e:
+        print(f"ERROR: could not produce report: {e}", file=sys.stderr)
+        return 2
+
+    print("\n".join(r.lines))
+    print("=" * 60)
+    verdict = r.verdict()
+    print(f"VERDICT: {verdict}")
+    for a in r.attention:
+        print(f"  ! {a}")
+    if args.json:
+        print(json.dumps({"verdict": verdict, "attention": r.attention}, indent=2))
+    return 1 if r.attention else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/cmgd-triage/scripts/post_github.py
+++ b/.claude/skills/cmgd-triage/scripts/post_github.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Post a cmgd health report to a per-version GitHub tracking issue.
+
+One issue per (workflow_id, version) — e.g. `cmgd_nextflow 2.2.1 — fleet health`.
+It rotates automatically when a new version goes active (i.e. after a release):
+the report's active version changes, a fresh issue is opened, and the prior
+version's issue is closed with a pointer. The issue is that version's health
+record for its whole rollout.
+
+Notification model (deliberate — see cmgd-triage skill):
+  * Every run EDITS the issue body (current status + rolling table + latest
+    report). Body edits do NOT notify — a silent daily heartbeat.
+  * A COMMENT is posted only when the run is non-green (ATTENTION/ERROR) or on
+    recovery (non-green -> green). Comments notify; non-green ones @-mention to
+    hard-ping. So notification volume == number of bad days.
+
+Consumes the text report + exit status from health_report.py (via
+run_daily_report.sh); does not re-query telemetry. GitHub I/O via `gh` (token in
+~/.config/gh/hosts.yml, works headless). Best-effort: a `gh` failure must not mask
+the health verdict, so the caller keeps its own exit code.
+
+Usage:
+  post_github.py --report-file OUT.txt --status {0|1|2} \
+                 --repo seandavi/nextflow_telemetry \
+                 --state-file ~/.cmgd-health/issue.json [--mention @seandavi] [--dry-run]
+"""
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+
+VERDICT = {0: ("GREEN", "🟢"), 1: ("ATTENTION", "🔴"), 2: ("ERROR", "⚠️")}
+EMOJI = {"GREEN": "🟢", "ATTENTION": "🔴", "ERROR": "⚠️"}
+# Flipping status label — makes the issue list / project board scannable at a
+# glance. Label changes do NOT notify, so no added noise. (name, color, desc)
+STATUS_LABELS = {
+    "GREEN":     ("status:green",     "0e8a16", "fleet health: all green"),
+    "ATTENTION": ("status:attention", "d93f0b", "fleet health: regression signal"),
+    "ERROR":     ("status:error",     "fbca04", "fleet health: report could not run"),
+}
+
+
+def gh(args, dry_run=False):
+    cmd = ["gh"] + args
+    if dry_run:
+        print(f"[dry-run] {' '.join(cmd)}")
+        return ""
+    r = subprocess.run(cmd, text=True, capture_output=True, timeout=60)
+    if r.returncode != 0:
+        raise RuntimeError(f"gh {' '.join(args[:3])} failed: {r.stderr.strip()}")
+    return (r.stdout or "").strip()
+
+
+def load_state(path):
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (OSError, ValueError):
+        return {}
+
+
+def save_state(path, state):
+    tmp = path + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(state, f, indent=2)
+    os.replace(tmp, path)
+
+
+def parse_report(text):
+    """-> (workflow_id, version, date). version None if the report couldn't
+    determine an active workflow (e.g. API-unreachable run)."""
+    head = text.splitlines()[0] if text else ""
+    wf = head.split()[0] if head else "cmgd_nextflow"
+    vm = re.search(r"active workflow:.*version=(\S+)", text)
+    dm = re.search(r"(\d{4}-\d{2}-\d{2})", head)
+    date = dm.group(1) if dm else datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    return wf, (vm.group(1) if vm else None), date
+
+
+def attention_lines(text):
+    return [ln.strip()[2:].strip() for ln in text.splitlines()
+            if ln.lstrip().startswith("! ")]
+
+
+def sync_status_label(repo, num, verdict, dry_run):
+    """Set status:<verdict>, remove the other two. Ensures the labels exist.
+    Label changes don't notify subscribers."""
+    want = STATUS_LABELS[verdict][0]
+    for v, (name, color, desc) in STATUS_LABELS.items():
+        try:  # best-effort ensure the label exists in the repo
+            gh(["label", "create", name, "--repo", repo, "--color", color,
+                "--description", desc], dry_run=dry_run)
+        except RuntimeError:
+            pass
+    drop = [name for v, (name, _, _) in STATUS_LABELS.items() if name != want]
+    args = ["issue", "edit", str(num), "--repo", repo, "--add-label", want]
+    for d in drop:
+        args += ["--remove-label", d]
+    try:
+        gh(args, dry_run=dry_run)
+    except RuntimeError as e:
+        print(f"WARN: status label sync failed: {e}", file=sys.stderr)
+
+
+def issue_open(repo, num):
+    try:
+        info = json.loads(gh(["issue", "view", str(num), "--repo", repo,
+                              "--json", "state"]))
+        return info.get("state") == "OPEN"
+    except (RuntimeError, ValueError):
+        return None  # missing/deleted
+
+
+def create_issue(repo, title, dry_run):
+    if dry_run:
+        gh(["issue", "create", "--repo", repo, "--title", title,
+            "--label", "health", "--body", "(init)"], dry_run=True)
+        return 999999
+    try:  # best-effort: ensure the label exists so --label sticks
+        gh(["label", "create", "health", "--repo", repo, "--color", "0e8a16",
+            "--description", "automated fleet-health heartbeat"])
+    except RuntimeError:
+        pass  # already exists (or no perms) — create below falls back if needed
+    try:
+        url = gh(["issue", "create", "--repo", repo, "--title", title,
+                  "--label", "health", "--body", "_initializing…_"])
+    except RuntimeError:
+        url = gh(["issue", "create", "--repo", repo, "--title", title,
+                  "--body", "_initializing…_"])  # retry w/o label
+    return int(url.rstrip("/").rsplit("/", 1)[-1])
+
+
+def build_body(entry, wf, version, verdict, date, report_text):
+    hist = entry.get("history", [])[-30:]
+    rows = "\n".join(f"| {d} | {EMOJI.get(v, '')} {v} |"
+                     for d, v in reversed(hist)) or "| — | — |"
+    return (
+        f"**{wf} `{version}` — Status: {EMOJI[verdict]} {verdict}** · "
+        f"last run {date} ({datetime.now(timezone.utc).strftime('%H:%MZ')})\n\n"
+        f"Automated per-version fleet-health heartbeat (read-only). The body is "
+        f"rewritten each run — **no notification**. A **comment** is posted only on "
+        f"non-green days and on recovery. Rotates to a new issue when a new version "
+        f"goes active. See the `cmgd-triage` skill.\n\n"
+        f"| date | verdict |\n|---|---|\n{rows}\n\n"
+        f"<details><summary>latest report ({date})</summary>\n\n"
+        f"```\n{report_text.strip()}\n```\n</details>\n"
+    )
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--report-file", required=True)
+    ap.add_argument("--status", type=int, required=True, choices=[0, 1, 2])
+    ap.add_argument("--repo", default="seandavi/nextflow_telemetry")
+    ap.add_argument("--state-file",
+                    default=os.path.expanduser("~/.cmgd-health/issue.json"))
+    ap.add_argument("--mention", default="")
+    ap.add_argument("--project", default="", help="project number to add new version-issues to")
+    ap.add_argument("--project-owner", default="seandavi")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    with open(args.report_file) as f:
+        report_text = f.read()
+    verdict, emoji = VERDICT[args.status]
+    wf, version, date = parse_report(report_text)
+
+    state = load_state(args.state_file)
+    state.setdefault("repo", args.repo)
+    issues = state.setdefault("issues", {})  # key "wf@ver" -> {number,last_verdict,history}
+
+    # No version (API-unreachable run): fall back to the current issue so the
+    # ERROR still pings; never create a versionless issue.
+    if version is None:
+        key = state.get("current_key")
+        if not key or key not in issues:
+            print("WARN: no active version and no known issue — skipping github",
+                  file=sys.stderr)
+            return 3
+    else:
+        key = f"{wf}@{version}"
+
+    try:
+        entry = issues.get(key)
+        created = False
+
+        if entry is None:
+            # new version -> new issue; close the prior current issue
+            number = create_issue(args.repo, f"{wf} {version} — fleet health", args.dry_run)
+            prior_key = state.get("current_key")
+            prior = issues.get(prior_key) if prior_key and prior_key != key else None
+            if prior and issue_open(args.repo, prior["number"]):
+                try:
+                    gh(["issue", "close", str(prior["number"]), "--repo", args.repo,
+                        "--comment", f"Superseded by {version} — see #{number}."],
+                       dry_run=args.dry_run)
+                except RuntimeError:
+                    pass
+            entry = {"number": number, "last_verdict": None, "history": []}
+            issues[key] = entry
+            created = True
+        else:
+            number = entry["number"]
+            st = issue_open(args.repo, number)
+            if st is None:                     # deleted -> recreate
+                number = create_issue(args.repo, f"{wf} {version} — fleet health", args.dry_run)
+                entry["number"] = number
+                created = True
+            elif st is False and args.status != 0:   # closed but now non-green -> reopen
+                try:
+                    gh(["issue", "reopen", str(number), "--repo", args.repo], dry_run=args.dry_run)
+                except RuntimeError:
+                    pass
+
+        state["current_key"] = key
+        prev_verdict = entry.get("last_verdict")
+
+        # rolling history (dedupe same-day re-runs)
+        hist = [hv for hv in entry.get("history", []) if hv[0] != date]
+        hist.append([date, verdict])
+        entry["history"] = hist[-60:]
+
+        body = build_body(entry, wf, version or "?", verdict, date, report_text)
+        with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as tf:
+            tf.write(body)
+            body_path = tf.name
+        gh(["issue", "edit", str(number), "--repo", args.repo,
+            "--body-file", body_path], dry_run=args.dry_run)
+        os.unlink(body_path)
+
+        sync_status_label(args.repo, number, verdict, args.dry_run)
+
+        # add a freshly-created version issue to the project board (best-effort)
+        if created and args.project:
+            try:
+                url = f"https://github.com/{args.repo}/issues/{number}"
+                gh(["project", "item-add", args.project, "--owner", args.project_owner,
+                    "--url", url], dry_run=args.dry_run)
+            except RuntimeError as e:
+                print(f"WARN: project add failed: {e}", file=sys.stderr)
+
+        comment = None
+        if args.status != 0:
+            bullets = "\n".join(f"- {b}" for b in attention_lines(report_text)) or "- (see report)"
+            m = (args.mention + " ") if args.mention else ""
+            comment = (f"{m}{emoji} **{verdict}** — {wf} `{version}` — {date}\n\n{bullets}\n\n"
+                       f"<details><summary>full report</summary>\n\n"
+                       f"```\n{report_text.strip()}\n```\n</details>")
+        elif prev_verdict and prev_verdict != "GREEN":
+            comment = f"🟢 **Recovered** — GREEN as of {date} (was {prev_verdict})."
+        if comment:
+            gh(["issue", "comment", str(number), "--repo", args.repo,
+                "--body", comment], dry_run=args.dry_run)
+
+        entry["last_verdict"] = verdict
+        if not args.dry_run:
+            save_state(args.state_file, state)
+        print(f"github: {key} -> issue #{number} ({'created' if created else 'updated'}); "
+              f"verdict={verdict}; comment={'yes' if comment else 'no'}")
+        return 0
+    except (RuntimeError, OSError, ValueError) as e:
+        print(f"WARN: github post failed (report still logged locally): {e}", file=sys.stderr)
+        return 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/cmgd-triage/scripts/run_daily_report.sh
+++ b/.claude/skills/cmgd-triage/scripts/run_daily_report.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Daily cmgd health-report runner (for cron). Read-only; mutates nothing.
+# Writes a dated report + latest.txt to $CMGD_HEALTH_DIR (default ~/.cmgd-health),
+# keeps 30 days, and drops an attention marker when the report is non-green so a
+# follow-on step (notification, or an LLM deep-dive) can pick it up.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOGDIR="${CMGD_HEALTH_DIR:-$HOME/.cmgd-health}"
+PY="${PYTHON:-python3}"
+mkdir -p "$LOGDIR"
+
+STAMP="$(date -u +%Y-%m-%dT%H%M%SZ)"
+OUT="$LOGDIR/report-$STAMP.txt"
+
+"$PY" "$SCRIPT_DIR/health_report.py" "$@" >"$OUT" 2>&1
+rc=$?
+
+cp -f "$OUT" "$LOGDIR/latest.txt"
+if [ "$rc" -ne 0 ]; then
+    cp -f "$OUT" "$LOGDIR/attention-latest.txt"
+    # Surface on stdout too so cron MAILTO (if configured) delivers it.
+    echo "cmgd health report: NON-GREEN (rc=$rc) — see $OUT"
+    tail -n 20 "$OUT"
+fi
+
+# Publish to the per-version GitHub tracking issue (best-effort — never masks the
+# health verdict). Disable with CMGD_GITHUB=0.
+if [ "${CMGD_GITHUB:-1}" = "1" ]; then
+    "$PY" "$SCRIPT_DIR/post_github.py" \
+        --report-file "$OUT" --status "$rc" \
+        --repo "${CMGD_REPO:-seandavi/nextflow_telemetry}" \
+        --state-file "$LOGDIR/issue.json" \
+        --mention "${CMGD_MENTION:-@seandavi}" \
+        --project "${CMGD_PROJECT:-}" --project-owner "${CMGD_PROJECT_OWNER:-seandavi}" \
+        || echo "WARN: github publish failed (rc=$?); local report at $OUT"
+fi
+
+# retention: keep 30 days of dated reports
+find "$LOGDIR" -name 'report-*.txt' -mtime +30 -delete 2>/dev/null
+
+exit "$rc"

--- a/.claude/skills/telemetry-api/SKILL.md
+++ b/.claude/skills/telemetry-api/SKILL.md
@@ -61,6 +61,28 @@ Path = base + `/api` + router-prefix + route.
 - `POST /batch` `/submitted` `/requeue-expired`
 
 ### process metrics (`/api/metrics/processes`) — per-process aggregates
+The backbone of any health/failure report. All GET. Common filters:
+`workflow_version`, `process`, `status` (`COMPLETED|FAILED`), `window_hours` /
+`window_days`, `limit`.
+- `GET /running` — live counts of in-flight/queued tasks by process (the "what
+  stage is the batch in" view)
+- `GET /summary` — KPI cards: totals, success/failure/retry rates, worst processes
+- `GET /failure-signatures` — failures grouped by `process` + `exit_code` +
+  `error_action` (the "what's breaking and how" table)
+- `GET /failures` — failure rate by process
+- `GET /timeline?bucket=hour|day|week` — success/failed counts per bucket (spike
+  vs steady-state)
+- `GET /tasks` — individual task rows (run_name, task_hash, exit_code, `attempt`,
+  wall/RSS). Filter to a process+status; `total` gives the count. `attempt`
+  distribution tells you whether retries are recovering.
+
+## Read-only vs. mutating (important for unattended runs)
+
+Everything above is **GET / read-only** and safe to poll on a schedule. These
+**mutate dispatch state** and must never fire in an unattended report —
+gate them behind a human:
+`POST /api/admin/reconcile-jobs`, `/reset-running`, `/requeue-dead-letter`,
+`/expire-stale-runs`, `/close-run`, and all `PATCH /api/workflows/*`.
 
 ## Quick recipes
 


### PR DESCRIPTION
Adds a deterministic, **read-only** daily health report for the `cmgd_nextflow` fleet, and fills in the cluster/ops context the skills previously assumed but never documented — so the skills can be used independently (and unattended).

## Scripts (`.claude/skills/cmgd-triage/scripts/`, stdlib + `gh` only)
- **`health_report.py`** — read-only telemetry sweep + signal-vs-noise rules (metaphlan OOM-retry-recovers, fasterq_dump SRA noise, infra-abort vs. the resistome KMA regression). Exits `0`=GREEN / `1`=ATTENTION / `2`=ERROR.
- **`run_daily_report.sh`** — scheduling wrapper: local logs + attention marker, then best-effort GitHub publish (never masks the health verdict).
- **`post_github.py`** — **one tracking issue per (workflow, version)**: rewrites the body each run (silent heartbeat, no notification), comments only on non-green/recovery (`@`-mention), flips a `status:green|attention|error` label, optional project auto-add.

## Skill docs
- **alpine-daemon**: full Alpine/Anvil cluster inventory (SSH, users, accounts, store/work paths, test partitions, login-node-has-no-singularity).
- **telemetry-api**: process-metrics endpoints + read-only vs. mutating split.
- **cmgd-triage**: fleet-report recipe, expected-background-failures baselines, unattended read-only guardrails, GitHub publishing model.
- **cmgd-config / cmgd-triage**: corrected the stale `errorStrategy=finish` note to the current tiered retry→ignore / finish policy.

## Deployment (this host)
Runs as a `systemd` **user** timer (daily 08:00 MT, linger on). Publishes to a per-version issue in this repo; live example: #143 (`cmgd_nextflow 2.2.1`). Board: seandavi/projects/19.

The resistome `TMPDIR` bug this report was born from shipped separately as pipeline **2.2.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)