### PR TITLE
feat(submissions): library-composition sanity check in add-study preview

### DIFF
--- a/.github/workflows/add-study.yml
+++ b/.github/workflows/add-study.yml
@@ -49,12 +49,8 @@ jobs:
             exit 1
           fi
           if OUT=$(nf-client submit-study "$ACC" --dry-run --json 2>err.txt); then
-            FOUND=$(printf '%s' "$OUT" | python -c "import sys,json;print(json.load(sys.stdin)['samples_found'])")
-            NEW=$(printf '%s' "$OUT"  | python -c "import sys,json;print(json.load(sys.stdin)['samples_added'])")
-            EXIST=$(printf '%s' "$OUT" | python -c "import sys,json;print(json.load(sys.stdin)['samples_existing'])")
-            gh issue comment "$ISSUE_NUMBER" --body "🔍 **Dry-run: \`$ACC\`** — found **$FOUND** samples (**$NEW** new, **$EXIST** already registered).
-
-          A maintainer: add the **\`approved\`** label to register these for real."
+            BODY=$(printf '%s' "$OUT" | python scripts/format_study_preview.py "$ACC")
+            gh issue comment "$ISSUE_NUMBER" --body "$BODY"
           else
             gh issue comment "$ISSUE_NUMBER" --body "❌ Dry-run for \`$ACC\` failed:
           \`\`\`

--- a/scripts/format_study_preview.py
+++ b/scripts/format_study_preview.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Format an add-study dry-run receipt (JSON on stdin) into a GitHub issue comment.
+
+Used by .github/workflows/add-study.yml so the approver sees the sample counts
+plus the ENA library composition — a technical sanity check that the study is
+shotgun WGS metagenomics, not 16S/amplicon. Advisory only; never blocks.
+
+    nf-client submit-study PRJEBxxxxx --dry-run --json | python scripts/format_study_preview.py PRJEBxxxxx
+"""
+from __future__ import annotations
+
+import json
+import sys
+
+
+def _fmt(d: dict) -> str:
+    return ", ".join(f"{k} ({n})" for k, n in d.items()) or "—"
+
+
+def render(accession: str, receipt: dict) -> str:
+    comp = receipt.get("library_composition") or {}
+    warnings = receipt.get("warnings") or []
+    lines = [
+        f"🔍 **Dry-run: `{accession}`** — found **{receipt['samples_found']}** samples "
+        f"(**{receipt['samples_added']}** new, **{receipt['samples_existing']}** already registered).",
+        "",
+    ]
+    if comp:
+        lines += [
+            "**Library composition** (sanity check — expect shotgun WGS, not 16S/amplicon):",
+            f"- library_strategy: {_fmt(comp.get('library_strategy', {}))}",
+            f"- library_selection: {_fmt(comp.get('library_selection', {}))}",
+            f"- library_source: {_fmt(comp.get('library_source', {}))}",
+            f"- instrument_platform: {_fmt(comp.get('instrument_platform', {}))}",
+            "",
+        ]
+    for w in warnings:
+        lines.append(f"⚠️ {w}")
+    if warnings:
+        lines.append("")
+    lines.append("A maintainer: add the **`approved`** label to register these for real.")
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    acc = sys.argv[1] if len(sys.argv) > 1 else "?"
+    print(render(acc, json.load(sys.stdin)))

--- a/src/nextflow_telemetry/routers/submissions.py
+++ b/src/nextflow_telemetry/routers/submissions.py
@@ -38,6 +38,15 @@ class SubmissionReceipt(BaseModel):
     samples_found: int = Field(description="Distinct samples the accession expanded to.")
     samples_added: int = Field(description="Samples newly registered by this submission.")
     samples_existing: int = Field(description="Samples that already existed (membership added, metadata untouched).")
+    library_composition: dict[str, Any] | None = Field(
+        default=None,
+        description="Per-run library-metadata tallies (library_strategy/selection/source, instrument_platform) "
+        "so an approver can sanity-check the study is shotgun metagenomics, not 16S/amplicon.",
+    )
+    warnings: list[str] = Field(
+        default_factory=list,
+        description="Advisory flags (e.g. amplicon/16S runs detected). Never blocks a submission.",
+    )
 
 
 def create_submissions_router(engine: AsyncEngine) -> APIRouter:

--- a/src/nextflow_telemetry/services/submission.py
+++ b/src/nextflow_telemetry/services/submission.py
@@ -24,12 +24,45 @@ from ..utils import normalize_srrs, srrs_to_sample_id
 ENA_FILEREPORT = "https://www.ebi.ac.uk/ena/portal/api/filereport"
 ENA_FIELDS = (
     "run_accession,secondary_sample_accession,sample_accession,"
-    "study_accession,secondary_study_accession,sample_title"
+    "study_accession,secondary_study_accession,sample_title,"
+    "library_strategy,library_selection,library_source,instrument_platform"
 )
+
+# Library tags that mark a study as NOT shotgun metagenomics (16S/amplicon).
+_AMPLICON_STRATEGY = {"AMPLICON"}
+_AMPLICON_SELECTION = {"PCR"}
 
 
 class AccessionError(ValueError):
     """Raised for an accession the endpoint won't accept (bad type / no runs)."""
+
+
+def _library_composition(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate per-run library metadata so an approver can eyeball study type
+    (shotgun WGS vs 16S/amplicon). Advisory only — never blocks a submission."""
+    def tally(field: str) -> dict[str, int]:
+        c: dict[str, int] = {}
+        for r in rows:
+            v = (r.get(field) or "").strip() or "unknown"
+            c[v] = c.get(v, 0) + 1
+        return dict(sorted(c.items(), key=lambda kv: -kv[1]))
+
+    strat, sel = tally("library_strategy"), tally("library_selection")
+    n_amplicon = sum(n for k, n in strat.items() if k.upper() in _AMPLICON_STRATEGY)
+    n_pcr = sum(n for k, n in sel.items() if k.upper() in _AMPLICON_SELECTION)
+    warnings = []
+    if n_amplicon or n_pcr:
+        warnings.append(
+            f"{max(n_amplicon, n_pcr)} of {len(rows)} run(s) look like amplicon/16S "
+            "(library_strategy=AMPLICON or library_selection=PCR), not shotgun metagenomics"
+        )
+    return {
+        "library_strategy": strat,
+        "library_selection": sel,
+        "library_source": tally("library_source"),
+        "instrument_platform": tally("instrument_platform"),
+        "warnings": warnings,
+    }
 
 
 def classify_source(accession: str) -> str:
@@ -112,6 +145,8 @@ class SubmissionService:
             samples = _group_samples(rows, collection_id)
             if not samples:
                 raise AccessionError(f"no runs found for '{accession}'")
+            composition = _library_composition(rows)
+            warnings = composition.pop("warnings")
             if dry_run:
                 counts = await self._count_new(samples)
                 status = "dry_run"
@@ -139,6 +174,8 @@ class SubmissionService:
             "source": source,
             "type": "project",
             "status": status,
+            "library_composition": composition,
+            "warnings": warnings,
             **counts,
         }
 

--- a/tests/test_study_preview.py
+++ b/tests/test_study_preview.py
@@ -1,0 +1,36 @@
+"""Test the add-study preview comment formatter (scripts/format_study_preview.py)."""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_path = Path(__file__).resolve().parent.parent / "scripts" / "format_study_preview.py"
+_spec = importlib.util.spec_from_file_location("format_study_preview", _path)
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+
+def test_render_includes_composition_and_warning():
+    receipt = {
+        "samples_found": 4, "samples_added": 3, "samples_existing": 1,
+        "library_composition": {
+            "library_strategy": {"WGS": 3, "AMPLICON": 1},
+            "library_selection": {"RANDOM": 3, "PCR": 1},
+            "library_source": {"METAGENOMIC": 4},
+            "instrument_platform": {"ILLUMINA": 4},
+        },
+        "warnings": ["1 of 4 run(s) look like amplicon/16S (…)"],
+    }
+    out = mod.render("PRJEB1", receipt)
+    assert "PRJEB1" in out
+    assert "found **4** samples" in out
+    assert "WGS (3), AMPLICON (1)" in out
+    assert "⚠️" in out and "amplicon" in out.lower()
+    assert "approved" in out
+
+
+def test_render_no_composition_no_warnings():
+    out = mod.render("PRJEB2", {"samples_found": 2, "samples_added": 2, "samples_existing": 0})
+    assert "found **2** samples" in out
+    assert "⚠️" not in out
+    assert "Library composition" not in out

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -89,6 +89,44 @@ def test_submission_registers_and_is_idempotent(db_url, monkeypatch):
         submissions_tbl.c.samples_added == 0))) == 1
 
 
+def test_library_composition_flags_amplicon():
+    wgs = [{"library_strategy": "WGS", "library_selection": "RANDOM",
+            "library_source": "METAGENOMIC", "instrument_platform": "ILLUMINA"}] * 3
+    comp = sub_mod._library_composition(wgs)
+    assert comp["library_strategy"] == {"WGS": 3}
+    assert comp["library_selection"] == {"RANDOM": 3}
+    assert comp["warnings"] == []
+
+    mixed = wgs + [{"library_strategy": "AMPLICON", "library_selection": "PCR"}]
+    comp2 = sub_mod._library_composition(mixed)
+    assert comp2["library_strategy"] == {"WGS": 3, "AMPLICON": 1}
+    assert comp2["warnings"] and "amplicon" in comp2["warnings"][0].lower()
+
+
+def test_composition_in_receipt(db_url, monkeypatch):
+    rows = [dict(r, library_strategy="WGS", library_selection="RANDOM",
+                 library_source="METAGENOMIC", instrument_platform="ILLUMINA")
+            for r in _ENA_ROWS]
+
+    async def fake_fetch(accession):
+        return rows
+
+    monkeypatch.setattr(sub_mod, "_fetch_runs", fake_fetch)
+
+    async def scenario():
+        engine = create_async_engine(db_url)
+        try:
+            svc = SubmissionService(engine=engine)
+            r = await svc.register_from_accession("PRJNA1", submitted_by="a@b.c", dry_run=True)
+            assert r["library_composition"]["library_strategy"] == {"WGS": 3}
+            assert r["library_composition"]["library_selection"] == {"RANDOM": 3}
+            assert r["warnings"] == []
+        finally:
+            await engine.dispose()
+
+    _run(scenario())
+
+
 def test_dry_run_previews_without_writing(db_url, monkeypatch):
     async def fake_fetch(accession):
         return _ENA_ROWS


### PR DESCRIPTION
## What
The add-study **dry-run** now aggregates per-run ENA library metadata so an approver can sanity-check the study type before approving:
- `library_strategy` (WGS vs AMPLICON), `library_selection` (RANDOM vs PCR), `library_source`, `instrument_platform` — counts per value.
- An advisory `warnings` entry when amplicon/PCR runs are present (16S signal). **Never blocks** a submission.

The dry-run receipt gains `library_composition` + `warnings`, and the add-study GitHub workflow renders them into the issue comment (via `scripts/format_study_preview.py`, kept out of YAML heredocs and unit-tested). `nf-client --json` already passes the full receipt through, so no client change was needed.

## Scope
Deliberately **excludes DOI / display_name** — metadata enrichment is a separate concern from technical accession validation + pipeline work, to be tackled later and more thoroughly. Boundary here: technical validation of the accession → pipeline work.

## Tests
Full suite **150 passed** locally (typecheck clean). New: composition-in-receipt + amplicon-warning + the preview formatter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)