### PR TITLE
docs: consolidate output-catalog ETL design + execution plan (#57)

### DIFF
--- a/docs/output-catalog-etl-design.md
+++ b/docs/output-catalog-etl-design.md
@@ -149,4 +149,3 @@ For GG2 specifically, GG2's genome-side taxonomy is **GTDB-aligned**, so the tra
 - **Confirm a GG2 crosswalk** (GTDB↔GG2 or genome→GG2) exists in usable, version-matched form.
 - **Marker store decision:** given markers are ~89% of rows and rarely queried by microbe, decide whether they live in the main lake, a separate coarse store, or are built lazily.
 - **Reconcile with target storage:** outputs are currently in `gs://cmgd-data`; `storage-layout.md` targets R2 `cmgd-raw`. This ETL feeds a **dedicated cmgd DuckLake** — its own catalog, for independent full time travel, *not* a shared multi-tenant schema (see [`publish-and-catalog-design.md`](./publish-and-catalog-design.md) → Location; the published artifact is a periodic frozen snapshot of it with a DuckDB-file catalog) — regardless of source bucket. (This supersedes any "shared `cdsci-lake` schema-per-project" framing for cmgd outputs.)
-```

--- a/docs/output-catalog-etl-design.md
+++ b/docs/output-catalog-etl-design.md
@@ -1,0 +1,152 @@
+# Output catalog ETL & taxonomy harmonization
+
+> Status: **draft / exploration** — companion to [`publish-and-catalog-design.md`](./publish-and-catalog-design.md) and [`storage-layout.md`](./storage-layout.md). Those cover the publish-path contract, event-driven registration, buckets, and the DuckLake decision. This doc covers the layer they defer: **how a sample's published files become catalog tables**, the **analytical table schema**, and **taxonomy harmonization** across profilers. Grounded in forensics on real `cmgd_nextflow` 2.0.7 output in `gs://cmgd-data/...` (July 2026). No code committed yet — this records possibilities and details.
+
+## Why a transform layer is required
+
+An earlier framing had DuckLake reading pipeline outputs (TSV.gz) directly, with no transform. Forensics on real 2.0.7 output showed that's too optimistic (and `publish-and-catalog-design.md` now defers to this doc on the point). A **light transform layer is required**, for reasons that are all in the data:
+
+- Output TSVs carry **multi-line `#` comment headers** (mpa DB version, command line, read counts) before the real table; the header row itself is often a `#` line. A raw `read_csv` doesn't get clean columns.
+- **Units differ by tool.** metaphlan/gtdb relative abundance is a percent; bracken's `fraction_total_reads` is a 0–1 fraction. Same logical column, different scale.
+- **Grain and datatype differ by file** (clade-level float profiles vs marker-level bool/float tables) — they can't share one table.
+- **Taxon identifiers are not comparable across tools** without a crosswalk (see harmonization below).
+
+So the catalog is fed by a small, deterministic ETL, not a zero-transform view. The transform is thin and table-driven (below), but it is not nothing.
+
+## Ground truth: what 2.0.7 publishes
+
+Publish path (matches the contract in the catalog doc):
+
+```
+${publish_base_dir}/${manifest.name}/${manifest.version}/${meta.sample}/[full_data|rarefied_data/]<step>/<files>
+# e.g. cMDv4/cmgd_nextflow/2.0.7/02ce1bab.../full_data/metaphlan_markers/marker_rel_ab_w_read_stats.tsv.gz
+```
+
+- `meta.sample` is `md5(sorted(SRR accessions))`, **computed at insert time** and stored as the telemetry sample key — so it is both the folder name and the DB join key. No hashing or `sampleinfo.txt` parsing in the ETL.
+- Two computation branches per sample: **`full_data/` and `rarefied_data/`** (rarefied = recomputed on a 1M-read subsample, seed 42).
+- **`MARK_COMPLETE`** at the sample root (`<sample_id> <UTC timestamp>`) is the **authoritative completion sentinel** — present iff the full output set (manifest + all branch files) is durably written.
+- **`manifest.json`** at the sample root is already emitted and is rich — it is the ETL's backbone:
+  - `provenance.input_ids` (the SRRs), `pipeline_name`, `pipeline_version`, `git_commit`, `run_name`, `command_line`
+  - `parameters.metaphlan_index` (the reference DB version, e.g. `mpa_vJan25_CHOCOPhlAnSGB_202503`), `skip_humann/skip_gtdb/skip_rarefied` flags
+  - `read_accounting` (raw + decontaminated read/base counts, surviving fractions) — a pre-structured QC record
+  - `software_versions` for every tool
+
+Output inventory (per branch unless noted): metaphlan (`marker_rel_ab_w_read_stats`, `metaphlan_unknown_list`, `metaphlan_viruses_list`, `marker_abundance`, `marker_presence`, strainphlan `metaphlan.json`), kraken/**bracken** (`bracken.species/genus`, `kraken2.report`), **gtdb** (`gtdb_profile`), **resistome** (`rgi_bwt.*`), `fastqc`. Every step dir also dumps Nextflow control files (`.command.*`) — noise the ETL must not ingest.
+
+File-format specifics that shaped the parsers:
+| file | header | key columns | notes |
+|---|---|---|---|
+| `marker_rel_ab_w_read_stats.tsv.gz` | `#`-commented | clade_name, clade_taxid (NCBI taxid **lineage**), relative_abundance (%), coverage, est_reads | rows at every rank incl. `t__SGB` leaves |
+| `bracken.species.txt.gz` | normal header row | name (bare binomial), taxonomy_id (NCBI), fraction_total_reads | fraction 0–1, **not** percent; far more taxa reported |
+| `gtdb_profile.tsv.gz` | `#`-commented | clade_name (`;`/`d__` lineage), relative_abundance (%) | **no taxid**; GTDB renames (Firmicutes→Bacillota, etc.) |
+| `marker_abundance.tsv.gz` | `#`-commented | marker_name, value (float) | marker grain, tens of thousands/sample |
+| `marker_presence.tsv.gz` | `#`-commented | marker_name, value | **always present=true** — a membership list, see below |
+| `manifest.json` | JSON | — | source of qc_metrics + provenance |
+
+## The mapping mechanism: spec + parsers + engine
+
+The part that varies per workflow version is small and declarative; the machinery (fetch, parse, attach columns, write, watermark) is identical across every file and version. Keep them apart.
+
+- **`OutputSpec`** — a **frozen dataclass** (`path, table, parser, tags`). Data + a parser reference, not logic. The registry `SPECS[(name, version)] = [OutputSpec, ...]` is the *only* thing that changes when a version adds/renames/moves a file. Dataclass, **not pydantic**: this is developer-authored config, not untrusted input at a trust boundary, so validation buys nothing (pydantic stays reserved for request/response models per repo convention).
+- **Parsers** — plain functions `bytes -> Iterable[dict]` of file-native fields. A shared `commented_tsv(raw, columns, coerce, comment, skip_header)` helper does the work; each tool's parser is a thin wrapper calling it with different columns. **Composition, not inheritance** — no `BaseParser`; the engine's uniform `out.parser(...)` call *is* the polymorphism, dispatched through a function reference. A genuinely new file shape is one new function.
+- **Engine** — one generic `process(sample_ids)`, written once:
+  1. `MARK_COMPLETE` existence gate (HEAD on a known path, never LIST); absent → not ready, requeue.
+  2. Look up `(workflow, version)` → spec; unknown version → dead-letter, never guess.
+  3. For each `OutputSpec`: fetch the file (missing → skipped branch, e.g. `skip_gtdb`, tolerated); run the parser; the engine attaches the **common columns** (`sample_id, workflow, version` + the spec's `tags`, e.g. `method`, `data_type`); route rows to `out.table`.
+  4. One transaction per sample (or per batch); mark ingested in the watermark.
+
+**Convergence with the manifest:** if the pipeline adds an `outputs: [{logical_type, path, row_count}]` array to `manifest.json`, the *path* half of each spec comes from the manifest, the spec collapses to a tiny `logical_type → (table, parser)` map, new tools are picked up with no spec edit, and row counts reconcile for free. This is the single highest-leverage pipeline change; everything works without it, so it's optional.
+
+## Table design: split by `(grain, datatype)`, not by tool
+
+**Rule: a table's identity is its `(grain, datatype)`, not the tool that produced it.** Same shape → one table with a discriminator column; different grain or datatype → separate table.
+
+| table | grain | populated from | discriminators | notes |
+|---|---|---|---|---|
+| `taxonomic_profile` | clade | metaphlan + bracken + gtdb | `method`, `data_type` | unified; keep it **narrow** (see below) |
+| `marker_abundance` | marker | metaphlan marker_abundance | `data_type` | float value |
+| `marker_presence` | marker | metaphlan marker_presence | `data_type` | **degenerate** — see below |
+| `resistome` | AMR gene | rgi_bwt | `data_type` | wide, own shape |
+| `qc_metrics` | sample | `manifest.read_accounting` | — | one row/sample (dimension) |
+
+- **`taxonomic_profile` stays a single table**, with a `method` column, because metaphlan/gtdb/bracken share grain and core datatype (float relative abundance). Splitting into three buys nothing and loses cross-method ergonomics. Keep it **narrow**: `keys + method + data_type + taxon key(s) + rank + relative_abundance`. `coverage`/`est_reads` are metaphlan-only and mostly null — move them to a metaphlan sidecar or accept nullable; partitioning by `method` (below) means a gtdb partition simply has no such columns, so the null sprawl compresses away.
+- **Do NOT denormalize provenance onto every clade row.** At 270–1,200 clade rows/sample × 500k samples, repeating `accessions`/`db_version`/read counts is enormous waste. Per-sample provenance lives once in `qc_metrics` (the dimension), joined on `sample_id`.
+- **`marker_presence` is degenerate as published** — every row is `present=true` (the metaphlan presence table only emits present markers). Presence is encoded by *row existence*; the boolean column carries no information. Store it as `(sample_id, marker_name, data_type)` membership and drop the boolean. (Lesson: can't pick the column — or know you don't need it — until you've seen the values.)
+- **full/rarefied is a column (`data_type`), not a table.** Same grain, same datatype — just computed on all reads vs a subsample. It's a discriminator, and an excellent partition key (below).
+
+### Scale reality (empirical, 12 samples)
+
+| table | rows (12 samples) | extrapolated @ 500k |
+|---|---|---|
+| marker_abundance | 197,482 | ~8B |
+| marker_presence | 184,065 | ~8B |
+| taxonomic_profile | 47,560 | ~2B |
+| resistome | 1,643 | ~70M |
+| qc_metrics | 12 | 500k |
+
+**Markers are ~89% of all rows.** They are strain-analysis inputs, not "by-microbe" query fodder, so they belong in their own tables and probably **off the low-latency path** — a separate, coarser, or lazily-built store. This is the dominant capacity-planning fact.
+
+## Physical layout: partitioning
+
+Partition `taxonomic_profile` (and siblings) by **`workflow / version / method / data_type`** — all low-cardinality, all commonly filtered: `1 × few × 3 × 2` ≈ a dozen partitions per version. Coarse and healthy.
+
+- **Never partition by `sample_id` or `clade_name`.** High cardinality → 500k partitions → the small-files catastrophe this whole effort exists to avoid. `sample_id` is a **sort/clustering key within** partitions, so min-max stats prune files by sample without a directory explosion.
+- Order the hierarchy to match query patterns and the bucket layout; partition coarse, sort fine, **compact many files per partition** (DuckLake handles this).
+- Physically this means near-method-separated files under a logical single table — the reason keeping it one table is free.
+
+## Trigger: event-driven, never list
+
+**Listing 500k directories is a non-starter** (GCS LIST pages ~1k objects; the deep prefix tree is millions of objects). But listing is never needed, because **telemetry already holds the keys** — `(name, version, sample_id)` reconstructs every path.
+
+- **Primary: DB-driven pull.** Telemetry is already the completion event log (weblog → `completed` on `MARK_COMPLETE`). The ETL queries "completed since watermark, not yet ingested" (indexed) and GETs known paths. Zero new infra, reuses the captured event. A watermark / `pending_ingest` marker lives in telemetry Postgres.
+- **Escape hatch: GCS object-finalize → Pub/Sub** on the `MARK_COMPLETE` write. Genuinely loose-coupled, but new infra to learn what the DB already knows. Justified only if the ETL must be owned/deployed separately, needs per-sample push latency, or full producer/consumer decoupling. **We own the emit point**, so the telemetry app can publish to Pub/Sub later without burning the bridge.
+- **Durability race:** telemetry `completed` fires when pipeline *logic* finishes, possibly before `publishDir` has flushed to object storage. The `MARK_COMPLETE` *object* is the last thing written = the true "files are here" marker. Gate ingestion on a cheap existence check of that object (HEAD, not LIST); requeue with backoff if absent.
+- Keep the trigger behind an `ingest(sample_id)` seam so the source is swappable. **Start as a scheduled docker job** (`nf-etl process`, cron/compose on onclappc02, restart-safe via watermark); promote to a polling daemon (mirroring the nf-client pull-mode daemon) only if latency demands it. The ETL is an **in-repo module** (`src/nextflow_telemetry/etl/`, reusing `db.py`/`config.py`), **not** an API endpoint; keep DuckDB/GCS deps in an optional dependency group so the API image stays lean.
+
+## Taxonomy harmonization
+
+The profilers speak different nomenclatures. There is not one crosswalk — there are two problems with different difficulty.
+
+**1. metaphlan ↔ gtdb — same underlying calls, join on the SGB.** gtdb_profile is the metaphlan run *relabeled* to GTDB via MetaPhlAn's shipped **SGB→GTDB** map, then abundances of SGBs collapsing to one GTDB taxon are summed. Deterministic, 1:1 at the SGB (species-level genome bin) level. Join key is the **SGB id** (metaphlan's `t__SGB####` level), not any name (gtdb output has no taxid and GTDB renames taxa). Empirical: for one sample, 77 metaphlan SGB leaves (Σ 32.14) ↔ 77 gtdb species (Σ 32.14) — identical count and total.
+
+**2. bracken ↔ everything — independent classifier, join on NCBI taxid.** bracken is kraken2/NCBI; both bracken (`taxonomy_id`) and metaphlan (terminal element of `clade_taxid` lineage) carry NCBI taxid. But coverage is partial: of 433 metaphlan species taxids, only **232 (53%)** exact-join bracken's — metaphlan SGBs often have no species-level NCBI taxid (uncharacterized bins). Handle at species taxid where present, **fall back to genus**, mark the rest unmatched. Unmatched SGBs are biology, not a bug.
+
+**What we use:**
+- **NCBI taxonomy backbone** (`taxdump` nodes.dmp/names.dmp) — the lingua franca both metaphlan and bracken speak; resolves any taxid → canonical name, rank, lineage.
+- **MetaPhlAn's SGB↔GTDB↔NCBI mapping** (ships with the mpa DB) — authoritative metaphlan↔gtdb bridge, and it assigns each SGB its NCBI taxid (filling some bracken gaps).
+- Optionally **GTDB's own taxonomy** for GTDB-native genus/family rollups.
+
+**Form: a `taxon` dimension table**, star-schema.
+- One row per taxon node, **versioned by `db_version`** (`mpa_vJan25_CHOCOPhlAnSGB_202503` — exactly why the ETL captures it; a new mpa release redefines SGBs, so the crosswalk is version-scoped).
+- Columns: surrogate `taxon_key` + native ids per system (`sgb_id, ncbi_taxid, ncbi_species, ncbi_lineage, gtdb_species, gtdb_lineage`) + `rank` + rollups (`genus, family, phylum`).
+- Fact tables store only the **method-native key they have** (metaphlan/bracken → `ncbi_taxid`, metaphlan also `sgb_id`; gtdb → `gtdb_lineage`/`sgb_id`). Queries join `taxonomic_profile ⋈ taxon ON (db_version, native_key)`.
+- Built **once per db_version** as its own small step (parse mpa metadata + taxdump), never per sample. Tiny next to the facts.
+
+**Two caveats to state up front:**
+1. **Identity harmonization ≠ abundance harmonization.** Matching a taxon across methods does not make the *numbers* comparable — metaphlan rel_ab is marker/genome-size-normalized, bracken is read-count fraction. The crosswalk unifies *who*, not *how much*.
+2. **Coverage is partial** (the 53% above); the dimension enables graceful species→genus fallback, not a perfect equijoin.
+
+## Possibility: drop the gtdb pipeline step, derive it by join
+
+Because gtdb_profile is a deterministic relabel of the metaphlan SGB leaves (evidence above), the `gtdb` process can be **removed from the pipeline** and GTDB materialized as `SGB → gtdb_lineage` join + `SUM(relative_abundance)` rollup against the `taxon` dimension. Saves per-sample compute; gtdb becomes a view/derived table rather than a stored, separately-ingested one (though gtdb is small — ~2.8k rows/sample — so the storage saving is minor; the real win is dropping the pipeline step and the second ingest path).
+
+**Guardrail — validate before deleting.** We still have the stored `gtdb_profile` files, so validation is free: reproduce GTDB from the `t__` rows + the SGB→GTDB map and **diff against the stored files** to N decimals on a few dozen samples. Only then remove the step. Edge cases where a reimplementation drifts: `UNCLASSIFIED` handling, renormalization, and SGBs with no GTDB assignment.
+
+## Possibility: Greengenes2 (and any other target taxonomy)
+
+The pattern generalizes: **any target taxonomy reachable by a crosswalk from a key we already hold (SGB, NCBI taxid, or GTDB lineage) becomes a dimension column + post-hoc join, not a pipeline step.**
+
+For GG2 specifically, GG2's genome-side taxonomy is **GTDB-aligned**, so the tractable route is a **second hop: SGB → GTDB → GG2** (a GTDB↔GG2 label crosswalk), or more robustly `SGB → representative-genome-accession → GG2 feature` (GG2 is built on genomes with accessions; SGBs have representative-genome accessions).
+
+**Two honest limits:**
+1. **The crosswalk artifact must exist and be version-matched.** GTDB↔GG2 / genome→GG2 mapping is very likely reachable but is **unverified** — hold it to the same standard as gtdb (confirm the file, then validate) before promising a clean join.
+2. **A label join gives GG2 names, not GG2 phylogeny.** If the goal is GG2's *tree* (UniFrac, Faith's PD, phylogenetic placement), a taxonomy-string crosswalk does not deliver it — that needs real GG2 feature IDs on the GG2 reference tree, which is genuine new work, not a free dimension column. Pin down which is wanted before scoping.
+
+## Open questions / next steps
+
+- **Add `outputs[]` to `manifest.json`?** Highest-leverage pipeline tweak — makes the ETL fully manifest-driven and self-verifying.
+- **Validate gtdb derivation:** locate the MetaPhlAn SGB metadata (in the `metaphlan4.2.2` container / `store_dir`), build the `taxon` dimension for `mpa_vJan25_CHOCOPhlAnSGB_202503`, reproduce & diff gtdb_profile, and re-measure metaphlan↔bracken overlap *with* genus fallback.
+- **Confirm a GG2 crosswalk** (GTDB↔GG2 or genome→GG2) exists in usable, version-matched form.
+- **Marker store decision:** given markers are ~89% of rows and rarely queried by microbe, decide whether they live in the main lake, a separate coarse store, or are built lazily.
+- **Reconcile with target storage:** outputs are currently in `gs://cmgd-data`; `storage-layout.md` targets R2 `cmgd-raw`. This ETL feeds a **dedicated cmgd DuckLake** — its own catalog, for independent full time travel, *not* a shared multi-tenant schema (see [`publish-and-catalog-design.md`](./publish-and-catalog-design.md) → Location; the published artifact is a periodic frozen snapshot of it with a DuckDB-file catalog) — regardless of source bucket. (This supersedes any "shared `cdsci-lake` schema-per-project" framing for cmgd outputs.)
+```

--- a/docs/output-catalog-etl-plan.md
+++ b/docs/output-catalog-etl-plan.md
@@ -1,0 +1,175 @@
+# Output-catalog ETL — execution plan (#57)
+
+> Status: **plan** — the *how to build it* companion to [`output-catalog-etl-design.md`](./output-catalog-etl-design.md)
+> (file→table mechanism, analytical schema, taxonomy) and [`publish-and-catalog-design.md`](./publish-and-catalog-design.md)
+> (telemetry plumbing, dedicated + frozen DuckLake, no orchestrator). This doc is the staged build with a
+> **concrete acceptance check per phase** — each phase is independently shippable and "done" means the check passes.
+> Target pipeline version: **`cmgd_nextflow` 2.2.1** (the active version). Runs on **onclappc02** (same host as the API + Postgres).
+
+## Target picture
+
+Publish to the DuckLake on a **regular cadence as samples complete**, in two tiers:
+
+1. **Internal working lake** — DuckLake catalog in Postgres (separate DB on the same instance), data (parquet) on **R2**.
+   Writable; ingested in batches. This is what group-internal users query.
+2. **Frozen public lake** — the **same R2 bucket and the same parquet files** as (1); only the catalog and access
+   protocol differ. External users get a **frozen DuckDB-file catalog** (`cmgd.duckdb`) whose data references resolve
+   over **public HTTPS** (R2 GET, no credentials). No data duplication — the freeze snapshots the *catalog*, not the data.
+
+Internal reads/writes over **S3 (R2)** with keys; external reads over **HTTPS**. One file set, two catalogs.
+
+### One file set, two catalogs — the constraints
+
+Sharing files (vs. a separate export copy) is cheaper and matches the R2 public model (GET-only, no anonymous LIST —
+fine, because the catalog enumerates every file by exact key; browsing is never needed). It costs three things:
+
+- **Relative / overridable data paths** are required, so the one file set resolves under both `s3://…` (internal) and
+  `https://…` (external). If DuckLake pins absolute `s3://` URIs, the HTTPS client can't read them. **Verify first (Phase 0).**
+- **Retention couples to publishing.** Internal compaction / `expire_snapshots` must not delete parquet a published
+  frozen catalog still references, or external reads 404. Default rule: **don't expire published snapshots** (parquet is
+  cheap, the lake is append-mostly).
+- **No hiding by omission.** If a table is internal-only (plausibly the marker tables — ~89% of rows, off the
+  low-latency path), you can't exclude it by not-copying. Split public/private **prefixes** in the same bucket and expose
+  only the public prefix over HTTPS; the frozen public catalog references only public-prefix files.
+
+DuckDB runs in-process on onclappc02. **No orchestrator** — a systemd timer (or cron) runs a plain `nf-etl` CLI.
+
+### Trigger
+
+A timer runs `nf-etl tick` frequently (default **every 15 min**). Each tick:
+
+1. Computes **backlog** = completed 2.2.1 samples not yet in the lake (watermark query below).
+2. Runs an **ingest batch** iff `backlog ≥ INGEST_THRESHOLD` (default **500**) **or** the oldest un-ingested completion
+   is older than `MAX_AGE` (default **24 h** — a fallback so a trailing <500 tail still publishes).
+3. After a successful ingest, runs **`freeze`** iff it's past the freeze cadence (default **daily**) or a manual flag is set.
+
+Polling, not push: telemetry already *is* the completion event log, so the tick just reads it. (Pub/Sub is the documented
+escape hatch if per-sample latency ever matters; not now.)
+
+### Layout the ETL relies on (from the design doc — confirm in Phase 0, do not re-derive)
+
+```
+<publish_base>/cmgd_nextflow/2.2.1/<sample_id>/MARK_COMPLETE          # completion sentinel (HEAD gate)
+<publish_base>/cmgd_nextflow/2.2.1/<sample_id>/manifest.json         # provenance + read_accounting + db_version
+<publish_base>/cmgd_nextflow/2.2.1/<sample_id>/<full_data|rarefied_data>/<step>/<file>.tsv.gz
+```
+
+`<sample_id>` is `md5(sorted(SRR))`, already the telemetry sample key — so **every path is reconstructable from
+`(workflow_id, version, sample_id)`; the ETL never LISTs GCS.**
+
+## Component
+
+One in-repo module: `src/nextflow_telemetry/etl/` (reuses `db.py` / `config.py`). CLI `nf-etl` with subcommands
+`parse` · `ingest` · `tick` · `freeze` · `status`. DuckDB / fsspec deps go in an **optional dependency group**
+(`etl`) so the API image stays lean. Fetch file bytes via the already-working `gs1:` remote (`rclone cat`) or `gcsfs` —
+decided in Phase 1; both reuse existing creds.
+
+### Watermark (idempotency)
+
+New table in telemetry Postgres:
+
+```
+etl_ingested(sample_id, workflow_id, workflow_version,
+             ingested_at timestamptz, row_counts jsonb, lake_snapshot bigint,
+             PRIMARY KEY (sample_id, workflow_id, workflow_version))
+```
+
+`pending` = completed jobs `LEFT JOIN etl_ingested` where the join is NULL:
+
+```sql
+SELECT j.sample_id
+FROM jobs j
+WHERE j.status = 'completed' AND j.workflow_id = 'cmgd_nextflow' AND j.workflow_version = '2.2.1'
+  AND NOT EXISTS (SELECT 1 FROM etl_ingested e
+                  WHERE e.sample_id = j.sample_id
+                    AND e.workflow_id = j.workflow_id AND e.workflow_version = j.workflow_version)
+ORDER BY j.completed_at;
+```
+
+Restart-safe, re-run-safe, and the source of the backlog count. Mirrors the existing `sweep_run_incomplete` reconcile pattern.
+
+---
+
+## Phases (each with its completion check)
+
+### Phase 0 — Ground truth & credentials
+Prove the environment before writing engine code.
+- Confirm the exact `<publish_base>` for 2.2.1 from the **deployed client config** (not a guess).
+- Pull one *known-completed* 2.2.1 sample (from the watermark query) and diff its `rclone lsf -R` against the expected
+  spec inventory: `manifest.json`, `MARK_COMPLETE`, `full_data/` + `rarefied_data/`, the metaphlan/bracken/gtdb/resistome step files.
+- Prove creds from onclappc02: `rclone lsd r2:` and `rclone lsd gs1:` succeed; psql `SELECT 1`; DuckDB `httpfs` reads a test
+  parquet from R2 via an R2 `CREATE SECRET`.
+
+**✅ Done when:** a captured listing of a real 2.2.1 sample matches the spec inventory; `nf-etl status` (stub) prints the
+count of completed 2.2.1 samples from Postgres; a one-liner has DuckDB list an R2 bucket and read a probe parquet back.
+
+### Phase 1 — 2.2.1 `OutputSpec` + parsers (offline)
+Implement `SPECS[('cmgd_nextflow','2.2.1')]` + parser functions + the `commented_tsv` helper + the manifest parser
+(per the ETL doc). No DB, no lake.
+
+**✅ Done when:** `nf-etl parse --sample <id> --dry-run` prints per-logical-table row counts and columns that match
+hand-inspection of the raw files; `tests/test_etl_parsers.py` passes on a committed tiny fixture and asserts the three
+transforms that forced code over YAML — percent→fraction unit normalization, degenerate-presence collapse, and taxid
+extraction from the clade lineage.
+
+### Phase 2 — Internal DuckLake, one sample end-to-end
+Stand up the internal lake (Postgres catalog DB + R2 data path), create tables with the design's partitioning
+(`workflow / version / method / data_type`), ingest **one** sample, write its `etl_ingested` row.
+
+**✅ Done when:** `SELECT count(*) FROM cmgd_lake.taxonomic_profile WHERE sample_id=<id>` equals the Phase-1 count;
+the R2 lake prefix contains parquet; **re-running the same sample is a no-op** (counts unchanged, no duplicate rows);
+`ducklake_snapshots()` shows the new snapshot.
+
+### Phase 3 — Batch engine + MARK_COMPLETE gate + reconcile
+`nf-etl ingest` processes the whole pending set in a batch: HEAD-gate each sample on `MARK_COMPLETE`, parse, write,
+one transaction, then insert `etl_ingested`.
+
+**✅ Done when:** seeding a backlog of K completed samples and running `ingest` writes K `etl_ingested` rows and lake
+counts = Σ per-sample; a sample **missing MARK_COMPLETE** is left pending and gets picked up on the next run once the
+object appears; an induced mid-batch failure leaves **no half-ingested sample** (watermark and lake agree).
+
+### Phase 4 — Trigger + cadence (the 500 gate)
+`nf-etl tick` implements the backlog/threshold/age logic and the conditional freeze; install a **systemd timer**
+(or cron) on onclappc02.
+
+**✅ Done when:** with backlog < 500 a tick is a logged no-op (`backlog 137 < 500, skipping`); when backlog crosses 500
+the tick ingests and advances the watermark; `systemctl list-timers` shows the unit firing on schedule; `nf-etl status`
+prints last-tick, backlog, last-ingest, last-freeze.
+
+### Phase 5 — Frozen public catalog (same files, HTTPS)
+`nf-etl freeze`: snapshot the internal lake's **catalog** into a frozen **DuckDB file** (`cmgd.duckdb`) whose data-file
+references point at the **same R2 parquet over public HTTPS** — not a data copy. Publish the DuckDB file at the existing
+public entry point; the data files are already in place from ingest. Requires the relative/overridable data paths and
+the retention rule from [the constraints above](#one-file-set-two-catalogs--the-constraints).
+
+**✅ Done when:** from a **clean client with no Postgres and no R2 keys**, `ATTACH`ing the published `cmgd.duckdb` and
+querying returns the same row counts as the internal lake, with every data read served over **HTTPS GET**; a re-freeze
+produces a new immutable catalog snapshot while the prior one stays readable (time travel preserved).
+
+### Phase 6 — Observability & staleness alert (thin)
+Log every tick; a deliberately-stuck ingest (backlog growing for > T hours with no successful ingest) surfaces via
+`nf-etl status` and a log-level alert — same shape as the `heartbeat-watchdog`. Update the design docs' "next steps".
+
+**✅ Done when:** a forced stall shows up in `status` and emits the alert line; docs updated; the timer has run
+unattended for a full cadence cycle (samples complete → appear in the internal lake within one tick → daily freeze
+updates the public artifact).
+
+---
+
+## Credentials & config (all present on onclappc02)
+- **Postgres** — reuse `SQLALCHEMY_URI` from the app env; the catalog DB is a separate database on the same instance.
+- **R2 internal (S3)** — DuckDB `CREATE SECRET (TYPE s3, ENDPOINT <r2>, KEY/SECRET …)` for ingest + internal reads; keys
+  already available (rclone `r2:`).
+- **R2 external (HTTPS)** — the same bucket's public HTTPS base for the frozen catalog's data reads; **GET-only, no LIST**
+  (fine — the catalog enumerates every file). Matches the R2 public-access model.
+- **GCS read** — reuse the working `gs1:` rclone remote (or `gcsfs`) to fetch source files; no new cred wiring.
+- Tunables in `config.py`: `INGEST_THRESHOLD=500`, `MAX_AGE=24h`, `TICK=15m`, `FREEZE_CADENCE=daily`,
+  `ETL_CATALOG_URI`, `ETL_LAKE_DATA_PATH` (one R2 bucket/prefix), `ETL_PUBLIC_HTTPS_BASE`, `ETL_PUBLISH_BASE`.
+
+## Open confirmations (close in Phase 0)
+- Exact `<publish_base>` for 2.2.1 (from deployed client config).
+- **Relative / overridable data paths** in DuckLake — the load-bearing assumption of the shared-file model (one parquet
+  set served over both `s3://` and `https://`). Verify before anything else.
+- Whether any table is **internal-only** (e.g. the ~89% marker rows) → public/private prefix split within the bucket.
+- Retention: internal compaction / `expire_snapshots` must not delete parquet a published frozen catalog references.
+- The single R2 bucket/prefix for the shared lake data (per `storage-layout.md`; dedicated cmgd lake, not a shared schema).

--- a/docs/publish-and-catalog-design.md
+++ b/docs/publish-and-catalog-design.md
@@ -55,7 +55,7 @@ What stays in scope:
                    ▼
 ┌─────────────────────────────────────────────────────────────┐
 │  Frozen published DuckLake                                     │
-│  - DuckDB-file catalog: self-contained ATTACH           │
+│  - DuckDB-file catalog, ATTACH-able (no keys)           │
 │  - same R2 parquet, over public HTTPS (no keys)  │
 │  - frozen cmgd.duckdb IS the catalog now                     │
 └─────────────────────────────────────────────────────────────┘

--- a/docs/publish-and-catalog-design.md
+++ b/docs/publish-and-catalog-design.md
@@ -1,6 +1,6 @@
 # Publish & catalog design
 
-> Status: **draft** — supersedes the experimental [`curatedMetagenomicDataETL`](https://github.com/seandavi/curatedMetagenomicDataETL) approach. Read alongside [`sample-metadata-design.md`](./sample-metadata-design.md): that doc is about sample *inputs* and harmonization; this one is about pipeline *outputs* and the analytical catalog.
+> Status: **draft** — supersedes the experimental [`curatedMetagenomicDataETL`](https://github.com/seandavi/curatedMetagenomicDataETL) approach. Read alongside [`sample-metadata-design.md`](./sample-metadata-design.md): that doc is about sample *inputs* and harmonization; this one is about pipeline *outputs* and the analytical catalog. For how published files become catalog *tables* (the file→table ETL, analytical schema, and taxonomy harmonization), see [`output-catalog-etl-design.md`](./output-catalog-etl-design.md).
 
 ## Framing
 
@@ -14,18 +14,18 @@ Three observations the design rests on:
 
 2. **Telemetry is the operational source of truth.** It knows what samples exist, which jobs have completed, and (with one new column) where each job published its output. It can be the SoT for pipeline outputs in the catalog too — no separate ETL needs to discover them by globbing S3.
 
-3. **The group's analytical surface is moving toward DuckLake (DuckDB v1.0).** Postgres-backed catalog over parquet (and other) files in object storage. Multiple producers will share it: omicidx, bugsigdb, PMC fulltext (Dagster-managed); pipeline outputs (this design).
+3. **The group's analytical surface is moving toward DuckLake (DuckDB v1.0).** Postgres-backed catalog over parquet (and other) files in object storage. Several sibling lakes live on it — omicidx, bugsigdb, PMC fulltext each publish their own; pipeline outputs (this design) get a **dedicated cmgd lake** (see [Location](#location)).
 
 What this rules out:
 - A separate ETL pipeline that globs S3 to discover what got produced (today's `curatedMetagenomicDataETL`).
 - A `sample_id_map.csv` artifact carried independently of telemetry.
 - Promoting taxonomic/marker counts into telemetry's Postgres schema. They live in object storage; the catalog points at them.
-- Routing pipeline-output cataloging through Dagster. The dependency graph is one edge (completion → register); telemetry already sits on the source side of that edge.
+- Routing pipeline-output cataloging through a workflow orchestrator (Dagster / Prefect / Airflow). The dependency graph is one edge (completion → register); telemetry already sits on the source side of it, so scheduling is plain scripts, not an orchestrator.
 
 What stays in scope:
 - A clear contract for the publish path.
 - A small change to telemetry's schema and HTTP surface so the catalog can be populated event-driven from completion.
-- A stable public parquet artifact at known URLs for external consumers.
+- A stable public artifact at known URLs for external consumers (a frozen DuckDB-catalog snapshot over the shared parquet, read via HTTPS).
 
 ## Two layers
 
@@ -42,22 +42,22 @@ What stays in scope:
                    │ catalog write
                    ▼
 ┌─────────────────────────────────────────────────────────────┐
-│  DuckLake catalog (DuckDB v1.0)                             │
-│  - same Postgres instance, separate database                 │
+│  DuckLake — dedicated cmgd lake                             │
+│  - Postgres catalog; full snapshot history                 │
 │  - manifest + table metadata managed by DuckDB               │
-│  - reads pipeline outputs (TSV.gz) directly — no transform   │
-│  Other tenants (Dagster-published):                          │
+│  - fed by a thin file→table ETL (see output-catalog doc)    │
+│  sibling lakes (separate, ATTACHed):                          │
 │  - omicidx (BioSample/BioProject/SRA)                        │
 │  - bugsigdb                                                  │
 │  - PMC fulltext                                              │
 └──────────────────┬──────────────────────────────────────────┘
-                   │ read access (group internal, ATTACH)
+                   │ periodic freeze (script)
                    ▼
 ┌─────────────────────────────────────────────────────────────┐
-│  Public parquet artifact                                     │
-│  - periodic COPY from DuckLake views, full replace           │
-│  - stable URLs at s3://cmgd-export/<dataset>/study_name=…/  │
-│  - optional ATTACH-able cmgd.duckdb shim                     │
+│  Frozen published DuckLake                                     │
+│  - DuckDB-file catalog: self-contained ATTACH           │
+│  - same R2 parquet, over public HTTPS (no keys)  │
+│  - frozen cmgd.duckdb IS the catalog now                     │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -114,23 +114,23 @@ Reconcile path: a periodic sweep finds completed jobs whose catalog rows are mis
 
 ### Location
 
-Same Postgres instance as telemetry, separate database. Avoids cross-cluster joins; keeps the operational and analytical schemas from contaminating each other (different consumers, different uptime profiles, different schema-evolution cadences).
+**A dedicated cmgd DuckLake — not co-tenanted.** The working catalog DB is Postgres (same instance as telemetry, separate database), which keeps operational and analytical schemas from contaminating each other and avoids cross-cluster joins. But the *lake* is cmgd-only: pipeline outputs get their **own** DuckLake catalog, separate from omicidx/bugsigdb/PMC, **specifically so its snapshot history supports full time travel** without being churned by other tenants' publish cadences. DuckLake's time travel is a property of the catalog — a shared catalog interleaves every tenant's snapshots into cmgd's history; a dedicated one keeps "the catalog as of date X" meaningful for cmgd alone.
 
 ### Source format
 
-TSV.gz, read directly via DuckDB. **No conversion step.** The Nextflow pipeline's `publishDir` output is the on-disk SoT.
+TSV.gz is the on-disk SoT (the Nextflow pipeline's `publishDir` output). **Correction:** these are not loaded zero-transform — a thin, deterministic file→table ETL is required (comment headers, per-tool unit differences, differing grain). See [`output-catalog-etl-design.md`](./output-catalog-etl-design.md), which owns the file→table mechanism.
 
 ### Logical tables
 
-DuckLake exposes one logical table per dataset (`marker_abundance`, `marker_presence`, `marker_rel_ab_w_read_stats`, `metaphlan_unknown_list`, `metaphlan_viruses_list`, future: `humann_genefamilies`, `humann_pathabundance`). Each is a DuckDB read over the union of TSV.gz files at the registered prefixes, joined to the catalog's identity columns (`sample_id`, `study_name`, `run_ids`). The mapping from "files on disk" to "logical table" lives in the [output spec layer](#output-spec-layer).
+**The analytical schema is owned by [`output-catalog-etl-design.md`](./output-catalog-etl-design.md).** In brief: tables split by `(grain, datatype)`, **not** one-per-file — e.g. a single `taxonomic_profile` unifies metaphlan/bracken/gtdb (with a `method` discriminator) rather than three separate tables, marker tables are their own grain (and dominate row count ~89%), and per-sample provenance/QC lives once in a `qc_metrics` dimension. Each fact table joins to the catalog's identity columns (`sample_id`, `study_name`, `run_ids`). The file→table mapping mechanism lives in the [spec layer](#output-spec-layer), whose format that doc defines.
 
-### Other tenants
+### Sibling lakes
 
-- **omicidx** — BioSample / BioProject / SRA metadata. Already used by `scripts/load_bioproject.py` (read from a parquet file). Dagster-published.
+- **omicidx** — BioSample / BioProject / SRA metadata. Already used by `scripts/load_bioproject.py` (read from a parquet file). Its own lake, separately published.
 - **bugsigdb** — curated microbial signatures.
 - **PMC fulltext** — pulled for harmonization downstream (see [`sample-metadata-design.md`](./sample-metadata-design.md)).
 
-All share the same DuckLake. Joins on accession (`run_id`, `study_id`, etc.) are first-class because every tenant publishes into the same catalog.
+Each is its **own** lake, not co-tenanted with cmgd (see [Location](#location)). Cross-lake joins on accession (`run_id`, `study_id`, etc.) stay first-class via DuckDB `ATTACH` — one query spanning several lakes — without interleaving their snapshot histories into cmgd's time travel.
 
 ## Output spec layer
 
@@ -138,71 +138,31 @@ Telemetry stores `(workflow_id, version, sample_id)` and a deterministic publish
 
 ### Shape
 
-A YAML spec per `(workflow_id, version)` lives in this repo at:
-
-```
-packages/cmgd_publish/specs/<workflow_id>/<version>.yaml
-```
-
-Each spec maps step outputs to logical tables and DuckDB `read_csv` config:
-
-```yaml
-workflow_id: cmgd_nextflow
-version: 1.6.0
-steps:
-  - name: marker_abundance
-    file_glob: "*_marker_abundance.tsv.gz"
-    branches: [full_data, rarefied_data]
-    read_csv:
-      delim: "\t"
-      header: true
-      compression: gzip
-      comment: "#"
-      types: {clade_name: VARCHAR, relative_abundance: DOUBLE}
-    logical_table: marker_abundance
-```
-
-Adding a new workflow = adding a YAML file. Adding a step = ~10 lines. Same pattern as Singer taps and Frictionless Data Resources. The spec is consumed by the publisher when registering a sample's outputs into DuckLake — it does not infer anything from the file itself at register-time.
+**The spec format and the file→table engine are defined in [`output-catalog-etl-design.md`](./output-catalog-etl-design.md)** — do not duplicate them here. In brief: a per-`(workflow_id, version)` registry of Python `OutputSpec` dataclasses (`path, table, parser, tags`) in `src/nextflow_telemetry/etl/`, not YAML. The reason it's code and not declarative config: the transforms the forensics turned up (normalizing percent↔fraction, parsing a taxid out of a lineage string, collapsing degenerate presence rows) can't be expressed as `read_csv` options — parsers are plain `bytes -> Iterable[dict]` functions. Adding a workflow version = one registry entry (+ a parser only for a genuinely new file shape).
 
 ### File discovery
 
-Two ways to bridge "we have a publish prefix" → "we have a list of files":
+Never LIST — the trigger reconstructs every publish path from telemetry's `(workflow_id, version, sample_id)` keys and gates ingestion on a HEAD of the `MARK_COMPLETE` object. The [ETL doc's "Trigger" section](./output-catalog-etl-design.md) owns this; the `/api/published` endpoint below is the same event-driven primitive exposed over HTTP. (Globbing 500k publish prefixes is a non-starter, which is why it isn't done.)
 
-(a) **Glob the publish prefix** at register-time. Works against S3 LIST or POSIX; no pipeline change. One LIST per sample.
-(b) **Pipeline-emitted manifest** — a small `outputs.json` published alongside each sample's data, listing what was written. Authoritative, cheaper, but requires a pipeline change.
+### Spec authoring & drift
 
-Start with (a). Fall back to (b) if spec globs drift from reality enough to cause register-time errors.
-
-### Authoring the first spec
-
-Bootstrap: pull 5–10 completed samples' publish prefixes locally, inspect interactively, draft the YAML. Validate against a *different* held-out batch of 10; any `read_csv` failure means the spec was wrong. Don't ship on the first pass.
-
-Interactive authoring is the right form for the first workflow because conventions (delim, comment chars, which columns get explicit types vs. inferred) are being established. Once one spec exists as ground truth, the spec-discovery step is worth scripting:
-
-- **New-workflow onboarding**: an agentic sniffer reads a publish prefix, proposes YAML by structural similarity to existing specs, opens a draft PR for human review.
-- **Drift detection**: a scheduled job re-parses a held-out batch from the latest run and flags any `read_csv` failure or schema mismatch against the current spec.
-
-Both are HITL-on-output, not HITL-on-every-decision — which is what makes them worth scripting. The recurring scripted form would use the Claude Agent SDK with API credentials (separate from this repo's runtime), not the Max subscription.
+Bootstrap the first spec by pulling a handful of completed samples and inspecting interactively; validate the parsers against a held-out batch before shipping. Once one spec exists as ground truth, two agent-assisted, HITL-on-output steps are worth scripting: **onboarding** (a sniffer proposes a new version's specs by structural similarity, opens a draft PR) and **drift detection** (a scheduled job re-parses a held-out batch and flags parser/schema failures). Both would run as a separate Agent-SDK job with API credentials, not this repo's runtime.
 
 ### Schema evolution
 
-When MetaPhlAn versions bump and column shapes change, **version is the dimension we use**: a new `1.7.0.yaml`, not a mutation of `1.6.0.yaml`. Logical tables become version-tagged (`marker_abundance_v4`, `marker_abundance_v5`) with a union view that consumers opt into. This is the concrete mechanism that resolves open question #3 in favor of partitioned-per-version tables.
+When MetaPhlAn versions bump and column shapes change, **version is the dimension we use**: a new registry entry for the new `(workflow_id, version)`, never a mutation of the old one. `version` is a partition key on the fact tables (see the ETL doc's partitioning: `workflow / version / method / data_type`), so historical rows keep their shape and consumers filter — or opt into a latest-version view — rather than silently reading column-drifted data. This resolves open question #3.
 
-## Public parquet artifact
+## Published artifact: frozen DuckLake
 
-Group-internal users hit DuckLake. External consumers want stable parquet URLs without DuckLake / DuckDB-version dependencies. We keep that surface:
+The **working** cmgd lake is live and writable (Postgres catalog, ingesting on every completion). The **published** artifact is a periodic **frozen snapshot** of it that uses a **DuckDB file as the metadata catalog** instead of Postgres. Crucially, the freeze **does not copy the data** — internal and external share the **same R2 bucket and the same parquet files**; only the catalog and access protocol differ (internal reads/writes over **S3 (R2)** with keys; external reads over **public HTTPS**, no credentials). The freeze snapshots the *catalog*, rewriting its data references to the public HTTPS base, and publishes the resulting `cmgd.duckdb`. See the execution plan's [shared-file constraints](./output-catalog-etl-plan.md) for what this couples.
 
-- A periodic job (cron / Dagster sensor / cron-equivalent) runs:
-  ```sql
-  COPY (SELECT * FROM ducklake.marker_abundance)
-  TO 's3://cmgd-export/marker_abundance/'
-  (FORMAT PARQUET, PARTITION_BY 'study_name', COMPRESSION 'zstd');
-  ```
-  Full replace per dataset. No incremental machinery — at our scale a periodic full rewrite is simple and the right tradeoff vs. the operational complexity of incremental.
-- Stable URLs preserved: `s3://cmgd-export/<dataset>/study_name=…/` continues to be the public address (same shape `curatedMetagenomicDataETL` already publishes).
-- Optional `cmgd.duckdb` ATTACH-able shim at `https://minio.cancerdatasci.org/cmgd-export/cmgd.duckdb`, kept for backward compatibility with the existing public consumer entry point.
+Why frozen-DuckDB-catalog over the old "just parquet" plan:
+- **Self-contained catalog + versioned.** Consumers get the whole schema and every table in one `ATTACH` at a known point in time — not a bag of parquet prefixes they must know the layout of. (Data is read from the shared bucket over HTTPS; no Postgres, no keys.)
+- **No live-catalog dependency.** External users never touch the Postgres catalog or need it up.
+- **Reproducible.** "The published lake as of 2026-07-01" is a concrete, immutable snapshot — re-runnable analyses cite it, not a moving target.
+- **No data duplication.** The published parquet *is* the lake parquet, at its public HTTPS address — there's no separate `cmgd-export` COPY to keep in sync.
 
-This is the only surviving "ETL"-shaped step in the design, and it's a single `COPY` per dataset on a schedule.
+The `cmgd.duckdb` lands at the existing public entry point (`https://minio.cancerdatasci.org/cmgd-export/cmgd.duckdb` or the R2 public base) — now the frozen catalog itself, not a hand-built shim. Requires DuckLake's data paths to be relative / data_path-overridable so one file set resolves under both `s3://` and `https://` (verify first), and internal compaction must not delete parquet a published snapshot references.
 
 ## What replaces `curatedMetagenomicDataETL`
 
@@ -211,24 +171,24 @@ The repo's three jobs all become obsolete:
 | Today | Target |
 |---|---|
 | Glob `s3://gs-cmgd-mirror/**` + parse `split(file, '/')[7]` for `sample_id` | Telemetry catalog write at completion; `/api/published` for on-demand discovery |
-| Convert TSV.gz to partitioned parquet | DuckLake reads TSV.gz directly; public parquet is a periodic full-replace `COPY` |
+| Convert TSV.gz to partitioned parquet | Thin file→table ETL parses TSV.gz into DuckLake catalog tables (ETL doc); the public artifact is a periodic frozen-DuckLake snapshot |
 | Maintain `sample_id_map.csv` (4.6 MB checked in) | DuckLake view over `samples ⨝ curated_sample_annotations` |
 
 Migration:
 
 1. This repo gains `workflows.publish_base_uri` + `/api/published` + the catalog-write hook.
 2. DuckLake catalog stood up with one tenant (pipeline outputs).
-3. Public parquet generator runs alongside the existing ETL output for a transition window.
+3. Frozen-catalog publish runs alongside the existing ETL output for a transition window (the shared parquet also carries the legacy public URLs).
 4. Cross-check generated parquet against the existing public artifact; once verified equivalent, deprecate `curatedMetagenomicDataETL` and archive the repo. The public URL doesn't change.
 
 ## Open questions
 
-1. **DuckLake's representation of TSV.gz as a logical table**: needs verification. DuckLake v1.0 is parquet-native; non-parquet inputs may need wrapping (a DuckDB view that reads via `read_csv`, registered as a logical table). Worst case we shim TSV.gz → parquet at registration time; that's a per-sample one-time cost, still no global ETL pass. The [output spec layer](#output-spec-layer) carries the `read_csv` config either way, so this is a question about *where* the wrapping happens, not whether the spec itself changes.
+1. ~~**DuckLake's representation of TSV.gz as a logical table**~~ Resolved by the file→table ETL: TSV.gz is **parsed** to rows and **written** to catalog tables (the ETL doc), not read in place — so DuckLake's non-parquet-input question is moot. The remaining detail (parquet write target, partition layout) is owned by the ETL doc.
 2. **Catalog-write idempotency key**: probably `(workflow_id, workflow_version, sample_id)` — the same composite as `jobs_tbl`.
-3. **Schema evolution on MetaPhlAn version bumps**: ~~if `marker_abundance` columns change, do we tag rows with the producing version, or partition logical tables per version so consumers opt in?~~ Resolved: partition logical tables per version (`marker_abundance_v4`, `marker_abundance_v5`) with a union view, mechanized via spec-per-`(workflow_id, version)` in the [output spec layer](#schema-evolution). Avoids silent column drift across years of data.
-4. **Branch dimension**: the `full_data` / `rarefied_data` path component currently splits each step's output. Expose as a partition column on the logical table, or as separate logical tables (`marker_abundance` vs `marker_abundance_rarefied`)? Lean partition column — it's a small dimension and consumers will want both reachable.
+3. ~~**Schema evolution on MetaPhlAn version bumps**~~ Resolved: `version` is a **partition key** on one logical table (not version-suffixed tables) — a new registry entry per `(workflow_id, version)`, historical rows keep their shape, consumers filter or opt into a latest-version view. See [Schema evolution](#schema-evolution). Avoids silent column drift across years of data.
+4. ~~**Branch dimension**~~ Resolved: `full_data` / `rarefied_data` is a `data_type` discriminator **column** (and a partition key), not a separate table — same grain and datatype, just all-reads vs subsample. See the ETL doc.
 5. **Catalog-write failure mode**: synchronous (blocks completion-write but logged) vs. async (fire-and-forget with reconcile). Position above is async. Worth pushback if there's a reason completion shouldn't be observable until cataloged.
-6. **Public parquet generator location**: in this repo (sibling to `nf_client`), in a separate package, or as a Dagster asset on the existing instance? Lean in this repo for now (`packages/cmgd_publish/`?) — small enough that a separate repo is overhead. Migrating to Dagster later is mechanical if the catalog grows complex enough.
+6. **Publisher location**: the file→table ETL lives in-repo at `src/nextflow_telemetry/etl/` (per the ETL doc), with DuckDB/GCS deps in an optional dependency group so the API image stays lean. The frozen-DuckLake export job (below) is a small piece of that module (or a sibling script), not a separate package. Scheduling stays plain scripts (cron / docker-compose); no orchestrator.
 7. **HUMAnN outputs**: not yet emitted by the pipeline (`skip_humann=true`). When that flips, the catalog gains gene-family / pathway tables. Reach-ready under this design — same publish-prefix → register pattern, just new step names.
 8. **Per-execution-site publish locations**: anvil → S3, google profile → GCS. Today's design assumes one location per (workflow, version). If multi-site execution is real, `publish_base_uri` moves to `workflow_runs`. Defer until it bites.
 
@@ -240,9 +200,9 @@ Smallest first. Each independently shippable.
 2. **`GET /api/published`** (small). Read-only, joins existing tables. Useful pre-DuckLake.
 3. **DuckLake catalog DB scaffolding** (medium). New database, DuckDB-managed schema, connection settings.
 4. **Catalog-write hook on completion + reconcile sweep** (small). Mirrors existing service patterns.
-5. **First output spec** (small). Pull 5–10 samples from `cmgd_nextflow` 1.6.0, draft `packages/cmgd_publish/specs/cmgd_nextflow/1.6.0.yaml` interactively, validate against a held-out 10-sample batch.
+5. **First output spec** (small). Pull 5–10 completed samples from the active `cmgd_nextflow` version, author its `OutputSpec` registry entry + parsers in `src/nextflow_telemetry/etl/` interactively, validate against a held-out 10-sample batch. (Spec format & engine: the ETL doc.)
 6. **Logical tables / views over pipeline outputs** (small per dataset, driven by #5).
-7. **Public parquet generator** (small). One `COPY` per dataset, scheduled.
+7. **Frozen-catalog publish** (small). Snapshot the catalog to `cmgd.duckdb` with HTTPS data paths, scheduled — no data copy (same shared parquet).
 8. **Deprecate `curatedMetagenomicDataETL`** (after #7 is verified against the existing public artifact).
 
 That's the full telemetry-side roadmap for catalog publishing.
@@ -251,10 +211,10 @@ That's the full telemetry-side roadmap for catalog publishing.
 
 - No `analyses_tbl` in telemetry. The implicit `(jobs.completed × samples × workflows)` is sufficient.
 - No taxonomic / marker / functional tables in telemetry's Postgres.
-- No transform step in the ingestion path. TSV.gz stays as-is; the only conversion is the periodic public-parquet rewrite.
-- No Dagster integration in this repo. The existing group Dagster owns SRA/biosample metadata; pipeline outputs are catalog-side via telemetry directly.
+- The ingestion path has a thin, deterministic file→table transform (superseding the earlier "no transform" framing — see [`output-catalog-etl-design.md`](./output-catalog-etl-design.md)); the periodic public freeze is a catalog snapshot (no data rewrite — same shared parquet, over HTTPS), a separate, later step.
+- No workflow orchestrator (Dagster / Prefect / Airflow) anywhere in this design. Scheduling is plain scripts (cron / docker-compose), restart-safe via the ETL watermark. The dependency graph is a single edge (completion → register); an orchestrator would be pure overhead.
 - No coupling between telemetry uptime and catalog availability. Catalog write failure is async and recoverable.
-- No incremental public-parquet machinery. Full replace is simple and cheap at our scale.
+- No incremental machinery. The public freeze is a full catalog snapshot (no data copy) — simple and cheap at our scale.
 - No Iceberg. DuckDB writes to Iceberg are not yet first-class; DuckLake is the chosen format.
 - No per-file telemetry. Nextflow's weblog doesn't carry publishDir info and we don't add a side-channel to capture it; the spec layer is how we know what files exist.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -114,8 +114,10 @@ Tracker: **#57**; design doc `docs/publish-and-catalog-design.md`. This is the
   `universal_pathlib` (credentials once in the server, not per-cluster) →
   `artifacts_tbl`. Feeds #57.
 - **#57** DuckLake catalog (7 shippable steps: `publish_base_uri` migration →
-  `GET /api/published` → catalog DB → completion-hook write → logical views →
-  public-parquet generator → deprecate `curatedMetagenomicDataETL`).
+  `GET /api/published` → **dedicated cmgd** catalog DB → completion-hook write →
+  file→table ETL + logical tables → **frozen-DuckLake** export → deprecate
+  `curatedMetagenomicDataETL`). Design: `publish-and-catalog-design.md` (plumbing) +
+  `output-catalog-etl-design.md` (file→table, schema, taxonomy).
 - **#83** `pg_duckdb` for analytical queries (process_metrics, cohort) once volume
   warrants.
 
@@ -165,5 +167,6 @@ metadata (#55), and catalog keying (#57/#93) simultaneously.
   silent-death gap → **#115**. Retired-workflow orphan-jobs confusion → **#114**.
 - 100k-scale UI eval (reusable agent `.claude/agents/ui-observability-evaluator.md` +
   `scripts/ui_eval_capture.py`, merged in #123) → **#116–#122**.
-- A full 69-sample re-run of `cmgd_nextflow` 2.0.6 was kicked off 2026-07-02 to
-  stress the telemetry (see memory `project_timeout_zombie_run`, `reference_alpine_ssh_access`).
+- A full 69-sample re-run of `cmgd_nextflow` 2.0.6 (2026-07-02) stress-tested the
+  telemetry and surfaced the walltime-TIMEOUT zombie-run gap, #115 (see memory
+  `project_timeout_zombie_run`, `reference_alpine_ssh_access`).


### PR DESCRIPTION
Consolidates the downstream pipeline-ETL design into one coherent set and adds the phased build plan for #57.

## What changed
- **`output-catalog-etl-design.md`** (new) owns the file→table mechanism, analytical schema (split by `(grain, datatype)`), and taxonomy harmonization — the forensics-grounded decisions.
- **`publish-and-catalog-design.md`** now defers to it and covers telemetry plumbing + the DuckLake tiers. Resolved four contradictions between the docs (spec format → Python `OutputSpec`; discovery → never-LIST; tables → grain/datatype; module → `src/nextflow_telemetry/etl/`).
- Folded in the confirmed decisions: a **dedicated** cmgd DuckLake (independent time travel); a **frozen public tier that shares one set of R2 parquet** with the internal lake (internal S3 / external HTTPS, no data copy); **no orchestrator** (plain scripts on onclappc02).
- **`output-catalog-etl-plan.md`** (new): 7 phases (0–6), each with a concrete acceptance check; 500-new-sample tick trigger; targets `cmgd_nextflow` 2.2.1.
- `roadmap.md`: Epic E summary updated to match.

Docs-only. Phase tracking: #152–#158 under the #57 epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EyZad3U7YthLPfWq9PN8ZW