### PR TITLE
feat(etl): output-catalog ETL — published files → DuckLake (#57)

### DIFF
--- a/docs/data-access.md
+++ b/docs/data-access.md
@@ -145,7 +145,7 @@ FROM cmgd.qc_metrics GROUP BY study_name ORDER BY n_samples DESC;
 
 ## Two things to know before you compute
 
-1. **Abundances are not directly comparable across methods.** `metaphlan` relative abundance is marker/genome-size-normalized (a percent); `bracken` `relative_abundance` is a read-count fraction. The `method` column tells you which. Matching a *taxon* across methods (via `taxon`) unifies *who*, not *how much*.
+1. **Abundances are not directly comparable across methods.** `relative_abundance` is stored as a **0–1 fraction** for both methods (metaphlan's native percent is normalized ÷100), so the *scale* matches — but the *definitions* differ: metaphlan is marker/genome-size-normalized, `bracken` is a read-count fraction. The `method` column tells you which. Matching a *taxon* across methods (via `taxon`) unifies *who*, not *how much*.
 2. **`data_type` matters.** `full_data` uses all reads; `rarefied_data` is a 1M-read subsample (for depth-controlled comparisons). Pick one — don't mix them in an aggregate. Most analyses want `full_data`.
 
 ## Citing / reproducibility

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,14 @@ dependencies = [
     "httpx>=0.27.0,<0.28.0",      # authlib runtime; pinned to match dev httpx
 ]
 
+# Output-catalog ETL runtime deps — kept optional so the API image stays lean.
+# Install on the ETL host with `uv sync --extra etl` (or `pip install .[etl]`).
+[project.optional-dependencies]
+etl = ["duckdb>=1.0.0,<2.0.0"]
+
+[project.scripts]
+nf-etl = "nextflow_telemetry.etl.cli:main"
+
 [dependency-groups]
 dev = [
     "mypy>=1.8.0,<2.0.0",

--- a/src/nextflow_telemetry/db.py
+++ b/src/nextflow_telemetry/db.py
@@ -346,3 +346,18 @@ daemon_agents_tbl = Table(
     Column("last_seen_at", DateTime(timezone=True), nullable=False),
     Column("started_at", DateTime(timezone=True), nullable=False),
 )
+
+# ---------------------------------------------------------------------------
+# Output-catalog ETL watermark — one row per (sample, workflow, version) whose
+# published outputs have been ingested into the DuckLake. "pending" = completed
+# jobs anti-joined against this. See src/nextflow_telemetry/etl/.
+# ---------------------------------------------------------------------------
+etl_ingested_tbl = Table(
+    "etl_ingested",
+    metadata,
+    Column("sample_id", String, primary_key=True),
+    Column("workflow_id", String, primary_key=True),
+    Column("workflow_version", String, primary_key=True),
+    Column("ingested_at", DateTime(timezone=True), nullable=False, server_default=text("now()")),
+    Column("row_counts", JSONB, nullable=True),
+)

--- a/src/nextflow_telemetry/etl/__init__.py
+++ b/src/nextflow_telemetry/etl/__init__.py
@@ -1,0 +1,1 @@
+"""Output-catalog ETL: published pipeline files -> DuckLake tables."""

--- a/src/nextflow_telemetry/etl/cli.py
+++ b/src/nextflow_telemetry/etl/cli.py
@@ -1,0 +1,161 @@
+"""nf-etl — the ETL command line. Plain scripts, no orchestrator.
+
+  nf-etl status                     backlog + ingested counts
+  nf-etl parse   --sample <id>      dry-run: per-table row counts (no DB/lake)
+  nf-etl ingest  [--limit N]        ingest pending completed samples
+  nf-etl tick    [--threshold 500]  ingest iff backlog >= threshold or age fallback
+  nf-etl freeze  --out cmgd.duckdb  publish a frozen DuckDB-catalog snapshot
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import shutil
+from collections import defaultdict
+
+import duckdb
+
+from . import engine, lake, source, watermark
+from .parsers import parse_qc
+from .specs import BRANCHES, SPECS
+
+WORKFLOW = "cmgd_nextflow"
+
+
+async def _version(pg, workflow: str, version: str | None) -> str:
+    if version:
+        return version
+    v = await pg.fetchval(
+        "SELECT version FROM workflows WHERE workflow_id = $1 AND status = 'active'", workflow)
+    if not v:
+        raise SystemExit(f"no active version for {workflow}; pass --version")
+    return v
+
+
+async def cmd_status(a) -> None:
+    pg = await watermark.connect()
+    await watermark.ensure_table(pg)
+    version = await _version(pg, a.workflow, a.version)
+    backlog = await watermark.backlog_count(pg, a.workflow, version)
+    ingested = await pg.fetchval(
+        "SELECT count(*) FROM etl_ingested WHERE workflow_id = $1 AND workflow_version = $2",
+        a.workflow, version)
+    print(f"workflow={a.workflow} version={version}")
+    print(f"  ingested samples : {ingested}")
+    print(f"  backlog          : {backlog}  (completed, not yet ingested)")
+    await pg.close()
+
+
+async def cmd_ingest(a) -> None:
+    pg = await watermark.connect()
+    await watermark.ensure_table(pg)
+    version = await _version(pg, a.workflow, a.version)
+    sids = await watermark.pending(pg, a.workflow, version, limit=a.limit)
+    if not sids:
+        print("nothing to ingest")
+        await pg.close()
+        return
+    con = lake.connect()
+    lake.ensure_schema(con)
+    summary = await engine.process(pg, con, sids, a.workflow, version, include_markers=a.include_markers)
+    con.close()
+    await pg.close()
+    print(json.dumps(summary))
+
+
+async def cmd_tick(a) -> None:
+    pg = await watermark.connect()
+    await watermark.ensure_table(pg)
+    version = await _version(pg, a.workflow, a.version)
+    backlog = await watermark.backlog_count(pg, a.workflow, version)
+    oldest_h = await pg.fetchval(
+        """
+        SELECT extract(epoch FROM (now() - min(j.completed_at))) / 3600 FROM jobs j
+        WHERE j.status = 'completed' AND j.workflow_id = $1 AND j.workflow_version = $2
+          AND NOT EXISTS (SELECT 1 FROM etl_ingested e WHERE e.sample_id = j.sample_id
+              AND e.workflow_id = j.workflow_id AND e.workflow_version = j.workflow_version)
+        """, a.workflow, version)
+    trigger = backlog >= a.threshold or (backlog > 0 and oldest_h and oldest_h >= a.max_age_hours)
+    if not trigger:
+        age = f"{oldest_h:.1f}h" if oldest_h else "-"
+        print(f"backlog {backlog} < {a.threshold} (oldest {age} < {a.max_age_hours}h) — skipping")
+        await pg.close()
+        return
+    sids = await watermark.pending(pg, a.workflow, version, limit=a.batch)
+    con = lake.connect()
+    lake.ensure_schema(con)
+    summary = await engine.process(pg, con, sids, a.workflow, version, include_markers=a.include_markers)
+    con.close()
+    await pg.close()
+    print(json.dumps(summary))
+
+
+def cmd_parse(a) -> None:
+    """Dry-run: fetch + parse one sample, print per-table row counts. No DB, no lake."""
+    specs = SPECS.get((a.workflow, a.version))
+    if specs is None:
+        raise SystemExit(f"no spec for {a.workflow} {a.version}")
+    prefix = source.sample_prefix(a.workflow, a.version, a.sample)
+    counts: dict[str, int] = defaultdict(int)
+    for spec in specs:
+        if spec.defer and not a.include_markers:
+            continue
+        if not spec.branched:
+            data = source.fetch(prefix, spec.subpath)
+            if data:
+                counts[spec.table] += sum(1 for _ in spec.parser(data))
+            continue
+        for branch in BRANCHES:
+            data = source.fetch(f"{prefix}/{branch}", spec.subpath)
+            if data:
+                counts[spec.table] += sum(1 for _ in spec.parser(data))
+    print(json.dumps(dict(counts)))
+
+
+def cmd_freeze(a) -> None:
+    """Snapshot the working catalog into a frozen DuckDB-catalog file whose data
+    references resolve over public HTTPS. DuckLake stores relative file paths but
+    pins data_path in the catalog, so we copy the catalog and rewrite data_path to
+    the public base (the parquet is the same shared R2 objects, read over https)."""
+    shutil.copy(lake.CATALOG, a.out)
+    con = duckdb.connect(a.out)
+    con.execute("INSTALL ducklake; LOAD ducklake;")
+    con.execute("UPDATE ducklake_metadata SET value = ? WHERE key = 'data_path'", [a.https_base])
+    con.close()
+    print(f"frozen catalog -> {a.out} (data_path={a.https_base})")
+
+
+def main(argv: list[str] | None = None) -> None:
+    p = argparse.ArgumentParser(prog="nf-etl", description="cMD output-catalog ETL")
+    p.add_argument("--workflow", default=WORKFLOW)
+    p.add_argument("--version", default=None, help="pipeline version (default: active)")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("status")
+    ing = sub.add_parser("ingest")
+    ing.add_argument("--limit", type=int, default=None)
+    ing.add_argument("--include-markers", action="store_true")
+    tick = sub.add_parser("tick")
+    tick.add_argument("--threshold", type=int, default=500)
+    tick.add_argument("--max-age-hours", type=float, default=24.0)
+    tick.add_argument("--batch", type=int, default=1000)
+    tick.add_argument("--include-markers", action="store_true")
+    pr = sub.add_parser("parse")
+    pr.add_argument("--sample", required=True)
+    pr.add_argument("--include-markers", action="store_true")
+    fr = sub.add_parser("freeze")
+    fr.add_argument("--out", required=True)
+    fr.add_argument("--https-base", required=True, help="public HTTPS base for the parquet data")
+
+    a = p.parse_args(argv)
+    if a.cmd == "parse":
+        cmd_parse(a)
+    elif a.cmd == "freeze":
+        cmd_freeze(a)
+    else:
+        asyncio.run({"status": cmd_status, "ingest": cmd_ingest, "tick": cmd_tick}[a.cmd](a))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nextflow_telemetry/etl/engine.py
+++ b/src/nextflow_telemetry/etl/engine.py
@@ -66,7 +66,8 @@ async def process(pg: asyncpg.Connection, con: duckdb.DuckDBPyConnection,
 
         con.execute("BEGIN TRANSACTION")
         try:
-            counts = {t: lake.replace_sample(con, t, sid, rows) for t, rows in rows_by_table.items()}
+            counts = {t: lake.replace_sample(con, t, sid, workflow, version, rows)
+                      for t, rows in rows_by_table.items()}
             con.execute("COMMIT")
         except Exception:
             con.execute("ROLLBACK")

--- a/src/nextflow_telemetry/etl/engine.py
+++ b/src/nextflow_telemetry/etl/engine.py
@@ -1,0 +1,82 @@
+"""The generic ingest engine: fetch → gate → parse → attach common columns →
+write → watermark. Written once; the per-version variation lives entirely in the
+spec registry.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+
+import asyncpg  # type: ignore[import-untyped]
+import duckdb
+
+from . import lake, source, watermark
+from .parsers import parse_qc
+from .specs import BRANCHES, SPECS
+
+
+async def process(pg: asyncpg.Connection, con: duckdb.DuckDBPyConnection,
+                  sample_ids: list[str], workflow: str, version: str,
+                  include_markers: bool = False) -> dict:
+    specs = SPECS.get((workflow, version))
+    if specs is None:
+        raise ValueError(f"no OutputSpec registered for {workflow} {version}")
+
+    studies = await watermark.study_map(pg, sample_ids)
+    summary: dict = {"ingested": 0, "skipped_unpublished": 0, "tables": defaultdict(int)}
+
+    for sid in sample_ids:
+        if not source.is_published(workflow, version, sid):
+            summary["skipped_unpublished"] += 1
+            continue
+        prefix = source.sample_prefix(workflow, version, sid)
+        manifest = source.fetch(prefix, "manifest.json")
+        if manifest is None:
+            summary["skipped_unpublished"] += 1
+            continue
+
+        qc_row = next(parse_qc(manifest), {})
+        common = {
+            "sample_id": sid,
+            "study_name": studies.get(sid),
+            "run_ids": qc_row.get("run_ids"),
+            "workflow": workflow,
+            "version": version,
+        }
+
+        rows_by_table: dict[str, list[dict]] = defaultdict(list)
+        for spec in specs:
+            if spec.defer and not include_markers:
+                continue
+            if not spec.branched:
+                if spec.table == "qc_metrics":
+                    rows_by_table["qc_metrics"].append({**common, **qc_row})
+                    continue
+                data = source.fetch(prefix, spec.subpath)
+                if data:
+                    for r in spec.parser(data):
+                        rows_by_table[spec.table].append({**common, **spec.tags, **r})
+                continue
+            for branch in BRANCHES:
+                data = source.fetch(f"{prefix}/{branch}", spec.subpath)
+                if not data:
+                    continue
+                for r in spec.parser(data):
+                    rows_by_table[spec.table].append(
+                        {**common, "data_type": branch, **spec.tags, **r})
+
+        con.execute("BEGIN TRANSACTION")
+        try:
+            counts = {t: lake.replace_sample(con, t, sid, rows) for t, rows in rows_by_table.items()}
+            con.execute("COMMIT")
+        except Exception:
+            con.execute("ROLLBACK")
+            raise
+        # lake is committed before the watermark: a crash here re-ingests next
+        # run, and replace_sample makes that a no-op-equivalent replace.
+        await watermark.mark_ingested(pg, sid, workflow, version, counts)
+        summary["ingested"] += 1
+        for t, n in counts.items():
+            summary["tables"][t] += n
+
+    summary["tables"] = dict(summary["tables"])
+    return summary

--- a/src/nextflow_telemetry/etl/lake.py
+++ b/src/nextflow_telemetry/etl/lake.py
@@ -1,0 +1,93 @@
+"""DuckLake catalog: connection, schema, and writes.
+
+Runs DuckDB in-process (on onclappc02). The catalog is a DuckDB file
+(``ETL_LAKE_CATALOG``); data (parquet) lands at ``ETL_LAKE_DATA_PATH`` — a local
+dir for dev/tests, or ``s3://cmgd-data/lake/`` (Cloudflare R2) in prod. When the
+data path is ``s3://``, R2 credentials are read from the rclone ``[r2]`` config
+(never printed) and installed as a DuckDB secret.
+
+ponytail: DuckDB-file catalog (single-writer ETL). Upgrade path — a Postgres
+catalog — is what enables concurrent internal readers; swap the ATTACH target
+when that's needed. Partitioning (workflow/version/method/data_type) is a
+follow-up; correctness of ingest doesn't depend on it.
+"""
+from __future__ import annotations
+
+import configparser
+import os
+import pathlib
+
+import duckdb
+
+CATALOG = os.environ.get("ETL_LAKE_CATALOG", "/data/cmgd/lake/cmgd_lake.ducklake")
+DATA_PATH = os.environ.get("ETL_LAKE_DATA_PATH", "/data/cmgd/lake/data")
+
+_ID = {"sample_id": "VARCHAR", "study_name": "VARCHAR", "run_ids": "VARCHAR",
+       "workflow": "VARCHAR", "version": "VARCHAR"}
+_BRANCH = {"data_type": "VARCHAR"}
+
+SCHEMAS: dict[str, dict[str, str]] = {
+    "taxonomic_profile": {**_ID, **_BRANCH, "method": "VARCHAR", "clade_name": "VARCHAR",
+                          "rank": "VARCHAR", "ncbi_taxid": "INTEGER", "sgb_id": "VARCHAR",
+                          "relative_abundance": "DOUBLE"},
+    "resistome": {**_ID, **_BRANCH, "gene": "VARCHAR", "template_coverage": "DOUBLE",
+                  "template_identity": "DOUBLE", "depth": "DOUBLE", "score": "DOUBLE"},
+    "qc_metrics": {**_ID, "reads_raw": "BIGINT", "reads_decontaminated": "BIGINT",
+                   "bases_raw": "BIGINT", "bases_decontaminated": "BIGINT",
+                   "reads_surviving_fraction": "DOUBLE", "bases_surviving_fraction": "DOUBLE",
+                   "metaphlan_index": "VARCHAR", "pipeline_version": "VARCHAR", "git_commit": "VARCHAR"},
+    "marker_abundance": {**_ID, **_BRANCH, "marker_name": "VARCHAR", "value": "DOUBLE"},
+    "marker_presence": {**_ID, **_BRANCH, "marker_name": "VARCHAR"},
+}
+
+
+def _r2_secret_sql() -> str | None:
+    cfg = configparser.ConfigParser()
+    cfg.read(os.path.expanduser("~/.config/rclone/rclone.conf"))
+    if "r2" not in cfg:
+        return None
+    r = cfg["r2"]
+    key, secret, endpoint = r.get("access_key_id"), r.get("secret_access_key"), r.get("endpoint")
+    if not (key and secret and endpoint):
+        return None
+    ep = endpoint.replace("https://", "").replace("http://", "")
+    return (f"CREATE OR REPLACE SECRET r2 (TYPE s3, KEY_ID '{key}', SECRET '{secret}', "
+            f"ENDPOINT '{ep}', URL_STYLE 'path', REGION 'auto')")
+
+
+def connect(read_only: bool = False) -> duckdb.DuckDBPyConnection:
+    con = duckdb.connect()
+    con.execute("INSTALL ducklake; LOAD ducklake; INSTALL httpfs; LOAD httpfs;")
+    if DATA_PATH.startswith("s3://"):
+        sql = _r2_secret_sql()
+        if not sql:
+            raise RuntimeError("ETL_LAKE_DATA_PATH is s3:// but no rclone [r2] credentials found")
+        con.execute(sql)
+    else:
+        pathlib.Path(DATA_PATH).mkdir(parents=True, exist_ok=True)
+        pathlib.Path(CATALOG).parent.mkdir(parents=True, exist_ok=True)
+    ro = ", READ_ONLY" if read_only else ""
+    con.execute(f"ATTACH 'ducklake:{CATALOG}' AS lake (DATA_PATH '{DATA_PATH}'{ro})")
+    return con
+
+
+def ensure_schema(con: duckdb.DuckDBPyConnection) -> None:
+    for table, cols in SCHEMAS.items():
+        coldefs = ", ".join(f"{c} {t}" for c, t in cols.items())
+        con.execute(f"CREATE TABLE IF NOT EXISTS lake.{table} ({coldefs})")
+
+
+def replace_sample(con: duckdb.DuckDBPyConnection, table: str, sample_id: str,
+                   rows: list[dict]) -> int:
+    """Idempotent write: delete this sample's existing rows, then insert. Returns
+    rows written. Caller wraps a whole sample's tables in one transaction."""
+    cols = list(SCHEMAS[table])
+    con.execute(f"DELETE FROM lake.{table} WHERE sample_id = ?", [sample_id])
+    if not rows:
+        return 0
+    placeholders = ", ".join("?" for _ in cols)
+    con.executemany(
+        f"INSERT INTO lake.{table} VALUES ({placeholders})",
+        [[r.get(c) for c in cols] for r in rows],
+    )
+    return len(rows)

--- a/src/nextflow_telemetry/etl/lake.py
+++ b/src/nextflow_telemetry/etl/lake.py
@@ -1,26 +1,45 @@
 """DuckLake catalog: connection, schema, and writes.
 
-Runs DuckDB in-process (on onclappc02). The catalog is a DuckDB file
-(``ETL_LAKE_CATALOG``); data (parquet) lands at ``ETL_LAKE_DATA_PATH`` — a local
-dir for dev/tests, or ``s3://cmgd-data/lake/`` (Cloudflare R2) in prod. When the
-data path is ``s3://``, R2 credentials are read from the rclone ``[r2]`` config
-(never printed) and installed as a DuckDB secret.
+Runs DuckDB in-process (on onclappc02). It's a **DuckLake** — a tracked catalog
+plus DuckLake-managed parquet, not a loose parquet dump. Two catalog backends:
 
-ponytail: DuckDB-file catalog (single-writer ETL). Upgrade path — a Postgres
-catalog — is what enables concurrent internal readers; swap the ATTACH target
-when that's needed. Partitioning (workflow/version/method/data_type) is a
-follow-up; correctness of ingest doesn't depend on it.
+- **Postgres** (design default for the internal working lake) — set
+  ``ETL_LAKE_CATALOG_PG_DB`` (e.g. ``cmgd_lake``); the connection is derived from
+  ``SQLALCHEMY_URI`` (same telemetry instance, separate database), which is what
+  lets internal consumers read concurrently while the ETL writes. Provisioning the
+  ``cmgd_lake`` database is a one-time privileged step (the app role lacks
+  ``CREATEDB``): ``CREATE DATABASE cmgd_lake; GRANT ALL ... TO nf_telemetry;``.
+- **DuckDB file** (``ETL_LAKE_CATALOG``) — single-writer fallback for dev/tests.
+
+Data (parquet) lands at ``ETL_LAKE_DATA_PATH`` — a local dir for dev/tests, or
+``s3://cmgd-data/lake/`` (Cloudflare R2) in prod. When the data path is ``s3://``,
+R2 credentials are read from the rclone ``[r2]`` config (never printed) and
+installed as a DuckDB secret. Partitioning (workflow/version/method/data_type) is
+a follow-up; correctness of ingest doesn't depend on it.
 """
 from __future__ import annotations
 
 import configparser
 import os
 import pathlib
+import re
 
 import duckdb
 
 CATALOG = os.environ.get("ETL_LAKE_CATALOG", "/data/cmgd/lake/cmgd_lake.ducklake")
+CATALOG_PG_DB = os.environ.get("ETL_LAKE_CATALOG_PG_DB")  # set → Postgres catalog
 DATA_PATH = os.environ.get("ETL_LAKE_DATA_PATH", "/data/cmgd/lake/data")
+
+
+def _pg_catalog_dsn(db: str) -> str:
+    """DuckLake Postgres-catalog DSN on the telemetry instance (same host/creds as
+    SQLALCHEMY_URI, different database)."""
+    uri = re.sub(r"\+\w+", "", os.environ["SQLALCHEMY_URI"])
+    m = re.match(r"postgresql://([^:]*):([^@]*)@([^:/]+):(\d+)/", uri)
+    if not m:
+        raise RuntimeError("cannot derive Postgres catalog DSN from SQLALCHEMY_URI")
+    user, pw, host, port = m.groups()
+    return f"postgres:dbname={db} host={host} port={port} user={user} password={pw}"
 
 _ID = {"sample_id": "VARCHAR", "study_name": "VARCHAR", "run_ids": "VARCHAR",
        "workflow": "VARCHAR", "version": "VARCHAR"}
@@ -58,6 +77,12 @@ def _r2_secret_sql() -> str | None:
 def connect(read_only: bool = False) -> duckdb.DuckDBPyConnection:
     con = duckdb.connect()
     con.execute("INSTALL ducklake; LOAD ducklake; INSTALL httpfs; LOAD httpfs;")
+    if CATALOG_PG_DB:
+        con.execute("INSTALL postgres; LOAD postgres;")
+        target = _pg_catalog_dsn(CATALOG_PG_DB)
+    else:
+        pathlib.Path(CATALOG).parent.mkdir(parents=True, exist_ok=True)
+        target = CATALOG
     if DATA_PATH.startswith("s3://"):
         sql = _r2_secret_sql()
         if not sql:
@@ -65,9 +90,8 @@ def connect(read_only: bool = False) -> duckdb.DuckDBPyConnection:
         con.execute(sql)
     else:
         pathlib.Path(DATA_PATH).mkdir(parents=True, exist_ok=True)
-        pathlib.Path(CATALOG).parent.mkdir(parents=True, exist_ok=True)
     ro = ", READ_ONLY" if read_only else ""
-    con.execute(f"ATTACH 'ducklake:{CATALOG}' AS lake (DATA_PATH '{DATA_PATH}'{ro})")
+    con.execute(f"ATTACH 'ducklake:{target}' AS lake (DATA_PATH '{DATA_PATH}'{ro})")
     return con
 
 
@@ -78,16 +102,23 @@ def ensure_schema(con: duckdb.DuckDBPyConnection) -> None:
 
 
 def replace_sample(con: duckdb.DuckDBPyConnection, table: str, sample_id: str,
-                   rows: list[dict]) -> int:
-    """Idempotent write: delete this sample's existing rows, then insert. Returns
-    rows written. Caller wraps a whole sample's tables in one transaction."""
+                   workflow: str, version: str, rows: list[dict]) -> int:
+    """Idempotent write: delete this sample's rows *for this (workflow, version)*,
+    then insert. Scoping the delete by the full key means re-ingesting one version
+    never touches another version's rows for the same sample. Explicit column list
+    so inserts don't depend on physical column order. Returns rows written; caller
+    wraps a whole sample's tables in one transaction."""
     cols = list(SCHEMAS[table])
-    con.execute(f"DELETE FROM lake.{table} WHERE sample_id = ?", [sample_id])
+    con.execute(
+        f"DELETE FROM lake.{table} WHERE sample_id = ? AND workflow = ? AND version = ?",
+        [sample_id, workflow, version],
+    )
     if not rows:
         return 0
+    collist = ", ".join(cols)
     placeholders = ", ".join("?" for _ in cols)
     con.executemany(
-        f"INSERT INTO lake.{table} VALUES ({placeholders})",
+        f"INSERT INTO lake.{table} ({collist}) VALUES ({placeholders})",
         [[r.get(c) for c in cols] for r in rows],
     )
     return len(rows)

--- a/src/nextflow_telemetry/etl/parsers.py
+++ b/src/nextflow_telemetry/etl/parsers.py
@@ -1,0 +1,157 @@
+"""File→row parsers for cmgd_nextflow published outputs.
+
+Each parser is a plain function ``bytes -> Iterator[dict]`` of file-native fields.
+The engine attaches the common columns (sample_id, study_name, ..., data_type,
+and the spec's tags); parsers only know their file's own shape. Composition, not
+inheritance — a genuinely new file shape is one new function.
+
+Grounded in 2.2.1 output (July 2026): metaphlan uses ``|``-delimited clade
+lineages with a matching taxid lineage; bracken is a normal-header TSV whose
+``fraction_total_reads`` is a 0–1 fraction; card_kma.res is a ``#``-header TSV
+with whitespace-padded numerics.
+"""
+from __future__ import annotations
+
+import gzip
+import json
+from typing import Iterator
+
+# metaphlan/bracken single-letter rank prefixes → canonical rank
+_RANK = {
+    "d": "domain", "k": "kingdom", "p": "phylum", "c": "class",
+    "o": "order", "f": "family", "g": "genus", "s": "species", "t": "strain",
+}
+_BRACKEN_LVL = {
+    "D": "domain", "K": "kingdom", "P": "phylum", "C": "class",
+    "O": "order", "F": "family", "G": "genus", "S": "species",
+}
+
+
+def _lines(raw: bytes) -> list[str]:
+    text = (gzip.decompress(raw) if raw[:2] == b"\x1f\x8b" else raw).decode("utf-8", "replace")
+    return text.splitlines()
+
+
+def _rows(raw: bytes, comment: str | None = "#"):
+    """Yield tab-split fields, skipping blank and (optionally) comment lines."""
+    for line in _lines(raw):
+        if not line.strip():
+            continue
+        if comment and line.startswith(comment):
+            continue
+        yield line.split("\t")
+
+
+def _as_int(s: str) -> int | None:
+    s = s.strip()
+    return int(s) if s.lstrip("-").isdigit() and s != "-1" else None
+
+
+def parse_metaphlan_profile(raw: bytes) -> Iterator[dict]:
+    """metaphlan marker_rel_ab_w_read_stats → taxonomic_profile rows.
+
+    Columns (no real header — every leading line is a ``#`` comment):
+    clade_name, clade_taxid (lineage of NCBI taxids), relative_abundance (%),
+    coverage, est_reads. rel_ab is normalized %→fraction so it shares a scale
+    with bracken. The terminal taxid is the row's NCBI taxid; a ``t__SGB`` leaf
+    carries the SGB id.
+    """
+    for f in _rows(raw):
+        if len(f) < 3:
+            continue
+        clade = f[0]
+        last = clade.split("|")[-1]
+        rank = _RANK.get(last[0]) if len(last) > 2 and last[1] == "_" else None
+        try:
+            rel = float(f[2]) / 100.0
+        except ValueError:
+            continue
+        yield {
+            "clade_name": clade,
+            "rank": rank,
+            "ncbi_taxid": _as_int(f[1].split("|")[-1]),
+            "sgb_id": last if last.startswith("t__SGB") else None,
+            "relative_abundance": rel,
+        }
+
+
+def parse_bracken(raw: bytes) -> Iterator[dict]:
+    """bracken.species/genus → taxonomic_profile rows. Normal header row;
+    ``fraction_total_reads`` is already a 0–1 fraction."""
+    rows = _rows(raw, comment=None)
+    header = next(rows, None)
+    if not header:
+        return
+    idx = {h: i for i, h in enumerate(header)}
+    for f in rows:
+        if len(f) < len(header):
+            continue
+        yield {
+            "clade_name": f[idx["name"]],
+            "rank": _BRACKEN_LVL.get(f[idx["taxonomy_lvl"]].strip()),
+            "ncbi_taxid": _as_int(f[idx["taxonomy_id"]]),
+            "sgb_id": None,
+            "relative_abundance": float(f[idx["fraction_total_reads"]]),
+        }
+
+
+def parse_resistome(raw: bytes) -> Iterator[dict]:
+    """card_kma.res → resistome rows. ``#Template``-prefixed header; numeric
+    fields are whitespace-padded (``float`` tolerates the leading spaces)."""
+    rows = _rows(raw, comment=None)
+    header = next(rows, None)
+    if not header:
+        return
+    header = [h.lstrip("#").strip() for h in header]
+    idx = {h: i for i, h in enumerate(header)}
+    for f in rows:
+        if len(f) < len(header):
+            continue
+        yield {
+            "gene": f[idx["Template"]].strip(),
+            "template_coverage": float(f[idx["Template_Coverage"]]),
+            "template_identity": float(f[idx["Template_Identity"]]),
+            "depth": float(f[idx["Depth"]]),
+            "score": float(f[idx["Score"]]),
+        }
+
+
+def parse_marker_abundance(raw: bytes) -> Iterator[dict]:
+    """metaphlan marker_abundance → (marker_name, value). Deferred from the
+    default ingest (markers are ~89% of all rows)."""
+    for f in _rows(raw):
+        if len(f) < 2:
+            continue
+        try:
+            yield {"marker_name": f[0], "value": float(f[1])}
+        except ValueError:
+            continue
+
+
+def parse_marker_presence(raw: bytes) -> Iterator[dict]:
+    """metaphlan marker_presence → membership. Degenerate as published (every
+    listed marker is present), so the boolean value is dropped — presence is
+    encoded by row existence. Deferred from the default ingest."""
+    for f in _rows(raw):
+        if f and f[0]:
+            yield {"marker_name": f[0]}
+
+
+def parse_qc(raw: bytes) -> Iterator[dict]:
+    """manifest.json → one qc_metrics row (per sample, no data_type)."""
+    d = json.loads(raw)
+    ra = d.get("read_accounting", {}) or {}
+    raw_, dec = ra.get("raw", {}) or {}, ra.get("decontaminated", {}) or {}
+    prov, params = d.get("provenance", {}) or {}, d.get("parameters", {}) or {}
+    yield {
+        "reads_raw": raw_.get("number_reads"),
+        "reads_decontaminated": dec.get("number_reads"),
+        "bases_raw": raw_.get("number_bases"),
+        "bases_decontaminated": dec.get("number_bases"),
+        "reads_surviving_fraction": ra.get("reads_surviving_fraction"),
+        "bases_surviving_fraction": ra.get("bases_surviving_fraction"),
+        "metaphlan_index": params.get("metaphlan_index"),
+        "pipeline_version": prov.get("pipeline_version"),
+        "git_commit": prov.get("git_commit"),
+        "run_ids": ";".join(prov.get("input_ids", []) or []),
+    }

--- a/src/nextflow_telemetry/etl/source.py
+++ b/src/nextflow_telemetry/etl/source.py
@@ -1,0 +1,34 @@
+"""Reads published outputs from object storage via rclone.
+
+We never LIST — every path is reconstructed from ``(workflow, version, sample_id)``.
+rclone reuses the already-configured ``gs1:`` remote on onclappc02, so there's no
+new credential wiring. ``ETL_SOURCE_BASE`` overrides the remote+prefix (e.g. for a
+test double); default is the cMDv4 GCS publish base.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+
+# rclone remote + publish_base_dir. The workflow derives <base>/<name>/<version>/<sample>.
+SOURCE_BASE = os.environ.get("ETL_SOURCE_BASE", "gs1:cmgd-data/results/cMDv4")
+
+
+def sample_prefix(workflow: str, version: str, sample_id: str) -> str:
+    return f"{SOURCE_BASE}/{workflow}/{version}/{sample_id}"
+
+
+def is_published(workflow: str, version: str, sample_id: str) -> bool:
+    """MARK_COMPLETE existence gate — the sentinel is the last object written, so
+    its presence means the full output set is durably there. Cheap stat, never LIST."""
+    path = f"{sample_prefix(workflow, version, sample_id)}/MARK_COMPLETE"
+    r = subprocess.run(["rclone", "lsf", path], capture_output=True, text=True)
+    return r.returncode == 0 and bool(r.stdout.strip())
+
+
+def fetch(prefix: str, subpath: str) -> bytes | None:
+    """Fetch one object's bytes; None if it's absent (a tolerated skipped branch/step)."""
+    r = subprocess.run(["rclone", "cat", f"{prefix}/{subpath}"], capture_output=True)
+    if r.returncode != 0 or not r.stdout:
+        return None
+    return r.stdout

--- a/src/nextflow_telemetry/etl/specs.py
+++ b/src/nextflow_telemetry/etl/specs.py
@@ -1,0 +1,63 @@
+"""Declarative per-(workflow, version) output specs.
+
+The only thing that changes when a pipeline version adds/renames/moves a file is
+this registry. Frozen dataclass, not pydantic: developer-authored config, not an
+untrusted trust boundary.
+
+A spec's ``subpath`` is relative to the branch dir (``full_data``/``rarefied_data``)
+when ``branched`` is True, or to the sample root otherwise. ``defer=True`` marks
+the marker tables (~89% of all rows) — spec'd for completeness but skipped by the
+default ingest until the marker-store decision is made.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Iterator
+
+from . import parsers
+
+
+@dataclass(frozen=True)
+class OutputSpec:
+    subpath: str
+    table: str
+    parser: Callable[[bytes], Iterator[dict]]
+    tags: dict = field(default_factory=dict)
+    branched: bool = True
+    defer: bool = False
+
+
+SPECS: dict[tuple[str, str], list[OutputSpec]] = {
+    ("cmgd_nextflow", "2.2.1"): [
+        OutputSpec(
+            "metaphlan_markers/marker_rel_ab_w_read_stats.tsv.gz",
+            "taxonomic_profile", parsers.parse_metaphlan_profile, {"method": "metaphlan"},
+        ),
+        OutputSpec(
+            "kraken/bracken.species.txt.gz",
+            "taxonomic_profile", parsers.parse_bracken, {"method": "bracken"},
+        ),
+        OutputSpec(
+            "kraken/bracken.genus.txt.gz",
+            "taxonomic_profile", parsers.parse_bracken, {"method": "bracken"},
+        ),
+        OutputSpec(
+            "resistome/card_kma.res.gz",
+            "resistome", parsers.parse_resistome,
+        ),
+        OutputSpec(
+            "manifest.json", "qc_metrics", parsers.parse_qc, branched=False,
+        ),
+        # Deferred — markers are ~89% of all rows; not on the low-latency path.
+        OutputSpec(
+            "metaphlan_markers/marker_abundance.tsv.gz",
+            "marker_abundance", parsers.parse_marker_abundance, defer=True,
+        ),
+        OutputSpec(
+            "metaphlan_markers/marker_presence.tsv.gz",
+            "marker_presence", parsers.parse_marker_presence, defer=True,
+        ),
+    ],
+}
+
+BRANCHES = ("full_data", "rarefied_data")

--- a/src/nextflow_telemetry/etl/watermark.py
+++ b/src/nextflow_telemetry/etl/watermark.py
@@ -47,9 +47,11 @@ async def pending(conn: asyncpg.Connection, workflow: str, version: str,
                 AND e.workflow_version = j.workflow_version)
         ORDER BY j.completed_at
     """
-    if limit:
-        q += f" LIMIT {int(limit)}"
-    return [r["sample_id"] for r in await conn.fetch(q, workflow, version)]
+    args: list = [workflow, version]
+    if limit is not None:
+        q += " LIMIT $3"
+        args.append(limit)
+    return [r["sample_id"] for r in await conn.fetch(q, *args)]
 
 
 async def backlog_count(conn: asyncpg.Connection, workflow: str, version: str) -> int:

--- a/src/nextflow_telemetry/etl/watermark.py
+++ b/src/nextflow_telemetry/etl/watermark.py
@@ -1,0 +1,93 @@
+"""Telemetry-side state: which completed samples still need ingesting, and the
+``etl_ingested`` watermark. Reads pending as ``completed jobs`` anti-joined
+against ``etl_ingested`` — restart- and re-run-safe, and the source of the
+backlog count that drives the tick trigger.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+
+import asyncpg  # type: ignore[import-untyped]
+
+
+def _uri() -> str:
+    return re.sub(r"\+asyncpg", "", os.environ["SQLALCHEMY_URI"])
+
+
+async def connect() -> asyncpg.Connection:
+    return await asyncpg.connect(_uri())
+
+
+async def ensure_table(conn: asyncpg.Connection) -> None:
+    await conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS etl_ingested (
+            sample_id        text NOT NULL,
+            workflow_id      text NOT NULL,
+            workflow_version text NOT NULL,
+            ingested_at      timestamptz NOT NULL DEFAULT now(),
+            row_counts       jsonb,
+            PRIMARY KEY (sample_id, workflow_id, workflow_version)
+        )
+        """
+    )
+
+
+async def pending(conn: asyncpg.Connection, workflow: str, version: str,
+                  limit: int | None = None) -> list[str]:
+    q = """
+        SELECT j.sample_id
+        FROM jobs j
+        WHERE j.status = 'completed' AND j.workflow_id = $1 AND j.workflow_version = $2
+          AND NOT EXISTS (
+              SELECT 1 FROM etl_ingested e
+              WHERE e.sample_id = j.sample_id AND e.workflow_id = j.workflow_id
+                AND e.workflow_version = j.workflow_version)
+        ORDER BY j.completed_at
+    """
+    if limit:
+        q += f" LIMIT {int(limit)}"
+    return [r["sample_id"] for r in await conn.fetch(q, workflow, version)]
+
+
+async def backlog_count(conn: asyncpg.Connection, workflow: str, version: str) -> int:
+    return await conn.fetchval(
+        """
+        SELECT count(*) FROM jobs j
+        WHERE j.status = 'completed' AND j.workflow_id = $1 AND j.workflow_version = $2
+          AND NOT EXISTS (SELECT 1 FROM etl_ingested e
+              WHERE e.sample_id = j.sample_id AND e.workflow_id = j.workflow_id
+                AND e.workflow_version = j.workflow_version)
+        """,
+        workflow, version,
+    )
+
+
+async def study_map(conn: asyncpg.Connection, sample_ids: list[str]) -> dict[str, str]:
+    """sample_id → a study label. Prefers a study-type collection; falls back to
+    any collection's label/id. (Sample↔study is many-to-many; one is picked.)"""
+    rows = await conn.fetch(
+        """
+        SELECT DISTINCT ON (cs.sample_id) cs.sample_id, coalesce(c.label, c.collection_id) AS study
+        FROM collection_samples cs JOIN collections c ON c.collection_id = cs.collection_id
+        WHERE cs.sample_id = ANY($1::text[])
+        ORDER BY cs.sample_id, (c.type = 'study') DESC NULLS LAST
+        """,
+        sample_ids,
+    )
+    return {r["sample_id"]: r["study"] for r in rows}
+
+
+async def mark_ingested(conn: asyncpg.Connection, sample_id: str, workflow: str,
+                        version: str, row_counts: dict) -> None:
+    await conn.execute(
+        """
+        INSERT INTO etl_ingested (sample_id, workflow_id, workflow_version, row_counts)
+        VALUES ($1, $2, $3, $4)
+        ON CONFLICT (sample_id, workflow_id, workflow_version)
+        DO UPDATE SET ingested_at = now(), row_counts = EXCLUDED.row_counts
+        """,
+        sample_id, workflow, version, json.dumps(row_counts),
+    )

--- a/src/nextflow_telemetry/migrations/versions/20260707_c7d8e9fa_etl_ingested.py
+++ b/src/nextflow_telemetry/migrations/versions/20260707_c7d8e9fa_etl_ingested.py
@@ -1,0 +1,40 @@
+"""etl_ingested watermark
+
+Revision ID: c7d8e9fa
+Revises: b6c7d8e9
+Create Date: 2026-07-07
+
+Adds the output-catalog ETL watermark: one row per (sample, workflow, version)
+whose published outputs have been ingested into the DuckLake. The ETL reads
+"pending" as completed jobs anti-joined against this table, so it's restart- and
+re-run-safe. See src/nextflow_telemetry/etl/.
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+revision: str = "c7d8e9fa"
+down_revision: Union[str, Sequence[str], None] = "b6c7d8e9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "etl_ingested",
+        sa.Column("sample_id", sa.String(), primary_key=True),
+        sa.Column("workflow_id", sa.String(), primary_key=True),
+        sa.Column("workflow_version", sa.String(), primary_key=True),
+        sa.Column("ingested_at", sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text("now()")),
+        sa.Column("row_counts", JSONB(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("etl_ingested")

--- a/tests/test_etl_parsers.py
+++ b/tests/test_etl_parsers.py
@@ -1,0 +1,77 @@
+"""Parser unit checks against 2.2.1 file shapes (no network, no DB).
+
+Locks the three transforms that forced code over declarative config:
+percent->fraction normalization, degenerate-presence collapse, and
+taxid/rank/SGB extraction from metaphlan's ``|``-delimited lineage.
+"""
+from nextflow_telemetry.etl import parsers as P
+
+METAPHLAN = (
+    b"#mpa_vJan25_CHOCOPhlAnSGB_202503\n"
+    b"#/usr/local/bin/metaphlan ... -t rel_ab_w_read_stats\n"
+    b"#100 reads processed\n"
+    b"#SampleID\tMetaphlan_Analysis\n"
+    b"UNCLASSIFIED\t-1\t16.5\t-\t700\n"
+    b"k__Bacteria\t2\t83.5\t-\t8000\n"
+    b"k__Bacteria|p__Bacteroidota|s__Segatella_copri\t2|976|165179\t34.9\t-\t500\n"
+    b"k__Bacteria|p__Bacteroidota|s__Segatella_copri|t__SGB1836\t2|976|165179|\t10.0\t-\t100\n"
+)
+
+BRACKEN = (
+    b"name\ttaxonomy_id\ttaxonomy_lvl\tkraken_assigned_reads\tadded_reads\tnew_est_reads\tfraction_total_reads\n"
+    b"Segatella copri\t165179\tS\t10545248\t682838\t11228086\t0.34937\n"
+)
+
+RESISTOME = (
+    b"#Template\tScore\tExpected\tTemplate_length\tTemplate_Identity\tTemplate_Coverage\t"
+    b"Query_Identity\tQuery_Coverage\tDepth\tq_value\tp_value\n"
+    b"ARO:3002999|CblA-1\t   12616\t     550\t     891\t   99.21\t  100.00\t   99.21\t  100.00\t   13.90\t11057.25\t1.0e-26\n"
+)
+
+PRESENCE = b"#mpa_vJan25\n#SampleID\tMetaphlan_Analysis\nUniRef90_A0A1\t1\nUniRef90_B0B2\t1\n"
+
+MANIFEST = (
+    b'{"read_accounting":{"raw":{"number_reads":48137590,"number_bases":7268776090},'
+    b'"decontaminated":{"number_reads":47184000,"number_bases":7100000000},'
+    b'"reads_surviving_fraction":0.9802,"bases_surviving_fraction":0.9527},'
+    b'"parameters":{"metaphlan_index":"mpa_vJan25_CHOCOPhlAnSGB_202503"},'
+    b'"provenance":{"pipeline_version":"2.2.1","git_commit":"deadbeef","input_ids":["SRR1","SRR2"]}}'
+)
+
+
+def test_metaphlan_normalizes_and_extracts():
+    rows = list(P.parse_metaphlan_profile(METAPHLAN))
+    assert len(rows) == 4
+    kingdom = rows[1]
+    assert kingdom["rank"] == "kingdom"
+    assert abs(kingdom["relative_abundance"] - 0.835) < 1e-9  # percent -> fraction
+    species = rows[2]
+    assert species["rank"] == "species" and species["ncbi_taxid"] == 165179
+    assert species["sgb_id"] is None
+    sgb = rows[3]
+    assert sgb["sgb_id"] == "t__SGB1836" and sgb["rank"] == "strain"
+    assert rows[0]["ncbi_taxid"] is None  # UNCLASSIFIED / -1 -> None
+
+
+def test_bracken_fraction_and_rank():
+    (row,) = list(P.parse_bracken(BRACKEN))
+    assert row["rank"] == "species" and row["ncbi_taxid"] == 165179
+    assert row["relative_abundance"] == 0.34937  # already a fraction, unchanged
+
+
+def test_resistome_padded_numerics():
+    (row,) = list(P.parse_resistome(RESISTOME))
+    assert row["gene"] == "ARO:3002999|CblA-1"
+    assert row["template_coverage"] == 100.0 and row["depth"] == 13.90
+
+
+def test_presence_is_membership_no_value():
+    rows = list(P.parse_marker_presence(PRESENCE))
+    assert rows == [{"marker_name": "UniRef90_A0A1"}, {"marker_name": "UniRef90_B0B2"}]
+
+
+def test_qc_maps_number_reads():
+    (qc,) = list(P.parse_qc(MANIFEST))
+    assert qc["reads_raw"] == 48137590 and qc["reads_decontaminated"] == 47184000
+    assert qc["metaphlan_index"].startswith("mpa_vJan25")
+    assert qc["run_ids"] == "SRR1;SRR2" and qc["pipeline_version"] == "2.2.1"

--- a/uv.lock
+++ b/uv.lock
@@ -765,6 +765,11 @@ dependencies = [
     { name = "uvicorn" },
 ]
 
+[package.optional-dependencies]
+etl = [
+    { name = "duckdb" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "click" },
@@ -782,6 +787,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.13.0,<2.0.0" },
     { name = "asyncpg", specifier = ">=0.29.0,<1.0.0" },
     { name = "authlib", specifier = ">=1.3.0,<2.0.0" },
+    { name = "duckdb", marker = "extra == 'etl'", specifier = ">=1.0.0,<2.0.0" },
     { name = "fastapi", specifier = ">=0.115.0,<0.116.0" },
     { name = "httpx", specifier = ">=0.27.0,<0.28.0" },
     { name = "itsdangerous", specifier = ">=2.2.0,<3.0.0" },
@@ -792,6 +798,7 @@ requires-dist = [
     { name = "uuid7", specifier = ">=0.1.0" },
     { name = "uvicorn", specifier = ">=0.30.0,<0.31.0" },
 ]
+provides-extras = ["etl"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Implements the output-catalog ETL (issue #57, Phases 1–4 of `docs/output-catalog-etl-plan.md`): an in-repo module that ingests completed `cmgd_nextflow` 2.2.1 outputs from GCS into a DuckLake, driven by a telemetry watermark. **Plain scripts, no orchestrator. Verified end-to-end against real 2.2.1 output on onclappc02.**

## What's here
- **`specs.py`** — frozen `OutputSpec` registry per `(workflow, version)`.
- **`parsers.py`** — `bytes→rows` for metaphlan profile, bracken, resistome, and qc (manifest). Does the three transforms that forced code over declarative config: metaphlan %→fraction, degenerate-presence collapse, and taxid/rank/SGB extraction from the `|`-lineage. Marker tables are spec'd but **deferred** (~89% of rows — the design's marker-store decision).
- **`source.py`** — rclone fetch + `MARK_COMPLETE` gate; never LISTs (paths rebuilt from keys).
- **`lake.py`** — DuckLake connect/schema/write. Data path configurable (local for dev, `s3://cmgd-data/lake` on R2 for prod); R2 creds read from the rclone config, never printed.
- **`watermark.py` + migration `c7d8e9fa`** — `etl_ingested`; pending = completed jobs anti-joined against it (restart/re-run safe).
- **`engine.py`** — fetch→gate→parse→attach common cols→write→watermark, one txn per sample, idempotent `replace_sample`.
- **`cli.py`** (`nf-etl`) — `status | parse | ingest | tick | freeze`. `tick` = 500-sample threshold + 24h age fallback.

## Verification (real data)
- `nf-etl parse` on a real sample → per-table counts from live GCS.
- Ingested 2 present samples into a DuckLake and queried back: both `full_data`/`rarefied_data` branches, both `metaphlan`/`bracken` methods, rel_ab as 0–1 fraction, resistome + qc rows. Watermark advanced correctly; test rows cleaned from prod.
- `mypy` clean (56 files), parser tests pass.

## Deferred (noted in code)
Marker-store decision, `taxon` dimension, partitioning, and a Postgres catalog for concurrent internal readers. `freeze`'s `data_path` rewrite needs validation once there's data on R2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EyZad3U7YthLPfWq9PN8ZW