### PR TITLE
feat(etl): split taxonomic_profile into per-method tables (#57)

### DIFF
--- a/docs/data-access.md
+++ b/docs/data-access.md
@@ -26,7 +26,7 @@ You need [DuckDB](https://duckdb.org) ≥ 1.0 (CLI, Python, R, or Node). Nothing
 INSTALL httpfs; LOAD httpfs;
 ATTACH 'https://data.cmgd.cancerdatasci.org/cmgd.duckdb' AS cmgd (READ_ONLY);   -- (pending)
 SHOW TABLES;                    -- see the tables below
-SELECT * FROM cmgd.taxonomic_profile LIMIT 5;
+SELECT * FROM cmgd.taxonomic_profile_metaphlan LIMIT 5;
 ```
 
 That single file is a **catalog** — the actual data is fetched from the shared Parquet store over HTTPS on demand (range GETs), so attaching is instant and you only download the columns/rows your query touches.
@@ -38,7 +38,7 @@ import duckdb
 con = duckdb.connect()
 con.sql("INSTALL httpfs; LOAD httpfs;")
 con.sql("ATTACH 'https://data.cmgd.cancerdatasci.org/cmgd.duckdb' AS cmgd (READ_ONLY)")  # (pending)
-df = con.sql("SELECT * FROM cmgd.taxonomic_profile WHERE study_name = 'ArtachoA_2021'").df()
+df = con.sql("SELECT * FROM cmgd.taxonomic_profile_metaphlan WHERE study_name = 'ArtachoA_2021'").df()
 ```
 
 R (via `duckdb`/`DBI`):
@@ -59,12 +59,12 @@ If you don't want the catalog, you can read Parquet straight from HTTPS — but 
   ```sql
   INSTALL httpfs; LOAD httpfs;
   SELECT clade_name, relative_abundance
-  FROM read_parquet('https://data.cmgd.cancerdatasci.org/parquet/taxonomic_profile/version=2.2.1/method=metaphlan/data_type=full_data/part-0.parquet')  -- (pending, one file)
+  FROM read_parquet('https://data.cmgd.cancerdatasci.org/parquet/taxonomic_profile_metaphlan/version=2.2.1/data_type=full_data/part-0.parquet')  -- (pending, one file)
   WHERE rank = 'species' LIMIT 20;
   ```
 - **Many files / whole tables** — **attach the catalog** instead (top of this page). The catalog *enumerates* every Parquet file, so DuckDB never needs to list a directory — this is the supported way to query across files over HTTPS. (If you have S3/R2 credentials for the bucket, globbing works over the `s3://` endpoint, where LIST is available.)
 
-The Parquet is partitioned by `workflow` / `version` / `method` / `data_type`, so once files are enumerated (via the catalog) those filters prune to the relevant files.
+The Parquet is partitioned by `workflow` / `version` / `data_type`, so once files are enumerated (via the catalog) those filters prune to the relevant files.
 
 ## The tables
 
@@ -74,16 +74,17 @@ Every row carries the identity keys: **`sample_id`** (the join key — `md5` of 
 
 | table | kind | one row per | columns beyond the identity keys |
 |---|---|---|---|
-| `taxonomic_profile` | fact | sample × method × taxon × `data_type` | `method` (`metaphlan`\|`bracken`), **`clade_name`** (label as the profiler reported it), `rank`, `ncbi_taxid`, `sgb_id` (metaphlan only), `relative_abundance` |
+| `taxonomic_profile_metaphlan` | fact | sample × taxon × `data_type` | **`clade_name`** (label as reported), `rank`, `ncbi_taxid`, `sgb_id`, `relative_abundance` (percent), `coverage`, `estimated_reads` |
+| `taxonomic_profile_bracken` | fact | sample × taxon × `data_type` | **`clade_name`**, `rank`, `ncbi_taxid`, `fraction_total_reads` (0–1), `estimated_reads` |
 | `marker_abundance` | fact | sample × marker × `data_type` | `marker_name`, `value` |
 | `marker_presence` | fact | sample × present marker × `data_type` | `marker_name` (membership — a row exists iff the marker is present) |
 | `resistome` | fact | sample × AMR gene × `data_type` | `gene` (CARD reference), `template_coverage`, `template_identity`, `depth`, `score` (from KMA/CARD `card_kma.res`) |
 | `qc_metrics` | **dimension** | sample | `reads_raw`, `reads_decontaminated`, `bases_raw`, `bases_decontaminated`, `reads_surviving_fraction`, `bases_surviving_fraction`, `metaphlan_index` (reference DB version), `pipeline_version`, `git_commit` |
 | `taxon` | **dimension** | taxon × `db_version` | `taxon_key`, **`db_version`**, `ncbi_taxid`, `sgb_id`, `ncbi_species`, `rank`, `genus`, `family`, `phylum` |
 
-**`method` values.** In the current `2.2.1` snapshot, `method` is `metaphlan` or `bracken` — the pipeline does not run gtdb, so there is no `gtdb` method here. (Earlier design notes mention a unified metaphlan/bracken/gtdb table; gtdb applied to older pipeline versions. If a future version reintroduces it, it appears as another `method` value in the same table.)
+**One table per method — on purpose.** metaphlan and bracken are separate tables because their abundance columns carry **different value interpretations**: metaphlan `relative_abundance` is a **percent** (marker/genome-size-normalized), bracken `fraction_total_reads` is a **0–1 read-count fraction**. Keeping them apart means every column has a single meaning. (The 2.2.1 pipeline runs metaphlan + bracken only — no gtdb.)
 
-**Two name columns, on purpose.** `taxonomic_profile.clade_name` is the label *exactly as the profiler reported it* (metaphlan's SGB lineage, bracken's binomial). For a canonical / cross-method name, or to roll up to `genus`/`family`/`phylum`, join the **`taxon`** dimension. `metaphlan` rows carry both `sgb_id` and `ncbi_taxid` (join on `sgb_id` for the most precise match); `bracken` rows carry `ncbi_taxid` only.
+**`clade_name` is as-reported.** Both tables' `clade_name` is the label *exactly as the profiler reported it* (metaphlan's SGB lineage, bracken's binomial). For a canonical name or to roll up to `genus`/`family`/`phylum`, join the **`taxon`** dimension. `taxonomic_profile_metaphlan` carries both `sgb_id` and `ncbi_taxid` (join on `sgb_id` for the most precise match); `taxonomic_profile_bracken` carries `ncbi_taxid` only.
 
 **Joining `taxon` correctly.** `taxon` has one row per taxon *per `db_version`*, so join on **both** the taxon key **and** `db_version`, or rows fan out. A sample's `db_version` is its `qc_metrics.metaphlan_index`. If a snapshot has a single `db_version` (common), filter `taxon` to that one value once and forget it.
 
@@ -94,8 +95,8 @@ Every row carries the identity keys: **`sample_id`** (the join key — `md5` of 
 First, discover what's in the snapshot:
 
 ```sql
-SELECT DISTINCT study_name FROM cmgd.taxonomic_profile ORDER BY 1;   -- studies
-SELECT DISTINCT version    FROM cmgd.taxonomic_profile;              -- pipeline versions present
+SELECT DISTINCT study_name FROM cmgd.taxonomic_profile_metaphlan ORDER BY 1;   -- studies
+SELECT DISTINCT version    FROM cmgd.taxonomic_profile_metaphlan;              -- pipeline versions present
 ```
 
 Find the `sample_id` for a run accession you care about (the join key isn't the SRR — look it up):
@@ -110,9 +111,9 @@ Top 10 species in a study (metaphlan, full-read, one pipeline version):
 
 ```sql
 SELECT clade_name, avg(relative_abundance) AS mean_rel_ab
-FROM cmgd.taxonomic_profile
+FROM cmgd.taxonomic_profile_metaphlan
 WHERE study_name = 'ArtachoA_2021'
-  AND method = 'metaphlan' AND rank = 'species'
+  AND rank = 'species'
   AND data_type = 'full_data'
   AND version = '2.2.1'                          -- pin the version, or you aggregate across versions
 GROUP BY clade_name ORDER BY mean_rel_ab DESC LIMIT 10;
@@ -127,12 +128,12 @@ WITH s AS (
   WHERE sample_id = '04835269dd64216afea75569f36f2f6c'
 )
 SELECT p.relative_abundance, t.ncbi_species, t.genus, t.phylum
-FROM cmgd.taxonomic_profile p
+FROM cmgd.taxonomic_profile_metaphlan p
 JOIN cmgd.taxon t
   ON t.sgb_id = p.sgb_id
  AND t.db_version = (SELECT db_version FROM s)   -- both keys, or rows fan out
 WHERE p.sample_id = '04835269dd64216afea75569f36f2f6c'
-  AND p.method = 'metaphlan' AND p.data_type = 'full_data'
+  AND p.data_type = 'full_data'
 ORDER BY p.relative_abundance DESC;
 ```
 
@@ -145,7 +146,7 @@ FROM cmgd.qc_metrics GROUP BY study_name ORDER BY n_samples DESC;
 
 ## Two things to know before you compute
 
-1. **Abundances are not directly comparable across methods.** `relative_abundance` is stored as a **0–1 fraction** for both methods (metaphlan's native percent is normalized ÷100), so the *scale* matches — but the *definitions* differ: metaphlan is marker/genome-size-normalized, `bracken` is a read-count fraction. The `method` column tells you which. Matching a *taxon* across methods (via `taxon`) unifies *who*, not *how much*.
+1. **Abundances are not comparable across methods** — which is why they're separate tables. `taxonomic_profile_metaphlan.relative_abundance` is a **percent** (marker/genome-size-normalized); `taxonomic_profile_bracken.fraction_total_reads` is a **0–1 read-count fraction**. Both are stored in their native units. Matching a *taxon* across the two (via `taxon`) unifies *who*, not *how much*.
 2. **`data_type` matters.** `full_data` uses all reads; `rarefied_data` is a 1M-read subsample (for depth-controlled comparisons). Pick one — don't mix them in an aggregate. Most analyses want `full_data`.
 
 ## Citing / reproducibility

--- a/docs/data-access.md
+++ b/docs/data-access.md
@@ -64,7 +64,7 @@ If you don't want the catalog, you can read Parquet straight from HTTPS — but 
   ```
 - **Many files / whole tables** — **attach the catalog** instead (top of this page). The catalog *enumerates* every Parquet file, so DuckDB never needs to list a directory — this is the supported way to query across files over HTTPS. (If you have S3/R2 credentials for the bucket, globbing works over the `s3://` endpoint, where LIST is available.)
 
-The Parquet is partitioned by `workflow` / `version` / `data_type`, so once files are enumerated (via the catalog) those filters prune to the relevant files.
+The Parquet is partitioned by `version` / `data_type` (the table name already encodes the method), so once files are enumerated (via the catalog) those filters prune to the relevant files.
 
 ## The tables
 

--- a/docs/output-catalog-etl-design.md
+++ b/docs/output-catalog-etl-design.md
@@ -81,7 +81,7 @@ The part that varies per workflow version is small and declarative; the machiner
 |---|---|---|
 | marker_abundance | 197,482 | ~8B |
 | marker_presence | 184,065 | ~8B |
-| taxonomic_profile | 47,560 | ~2B |
+| taxonomic_profile_metaphlan + _bracken | 47,560 | ~2B |
 | resistome | 1,643 | ~70M |
 | qc_metrics | 12 | 500k |
 
@@ -89,7 +89,7 @@ The part that varies per workflow version is small and declarative; the machiner
 
 ## Physical layout: partitioning
 
-Partition `taxonomic_profile` (and siblings) by **`workflow / version / method / data_type`** — all low-cardinality, all commonly filtered: `1 × few × 3 × 2` ≈ a dozen partitions per version. Coarse and healthy.
+Partition the fact tables by **`workflow / version / data_type`** — all low-cardinality, all commonly filtered (method is now the table, not a partition column). A handful of partitions per version. Coarse and healthy.
 
 - **Never partition by `sample_id` or `clade_name`.** High cardinality → 500k partitions → the small-files catastrophe this whole effort exists to avoid. `sample_id` is a **sort/clustering key within** partitions, so min-max stats prune files by sample without a directory explosion.
 - Order the hierarchy to match query patterns and the bucket layout; partition coarse, sort fine, **compact many files per partition** (DuckLake handles this).
@@ -120,7 +120,7 @@ The profilers speak different nomenclatures. There is not one crosswalk — ther
 **Form: a `taxon` dimension table**, star-schema.
 - One row per taxon node, **versioned by `db_version`** (`mpa_vJan25_CHOCOPhlAnSGB_202503` — exactly why the ETL captures it; a new mpa release redefines SGBs, so the crosswalk is version-scoped).
 - Columns: surrogate `taxon_key` + native ids per system (`sgb_id, ncbi_taxid, ncbi_species, ncbi_lineage, gtdb_species, gtdb_lineage`) + `rank` + rollups (`genus, family, phylum`).
-- Fact tables store only the **method-native key they have** (metaphlan/bracken → `ncbi_taxid`, metaphlan also `sgb_id`; gtdb → `gtdb_lineage`/`sgb_id`). Queries join `taxonomic_profile ⋈ taxon ON (db_version, native_key)`.
+- Fact tables store only the **method-native key they have** (metaphlan/bracken → `ncbi_taxid`, metaphlan also `sgb_id`; gtdb → `gtdb_lineage`/`sgb_id`). Queries join `taxonomic_profile_metaphlan ⋈ taxon ON (db_version, sgb_id)` (or `taxonomic_profile_bracken ⋈ taxon ON (db_version, ncbi_taxid)`).
 - Built **once per db_version** as its own small step (parse mpa metadata + taxdump), never per sample. Tiny next to the facts.
 
 **Two caveats to state up front:**

--- a/docs/output-catalog-etl-design.md
+++ b/docs/output-catalog-etl-design.md
@@ -63,13 +63,14 @@ The part that varies per workflow version is small and declarative; the machiner
 
 | table | grain | populated from | discriminators | notes |
 |---|---|---|---|---|
-| `taxonomic_profile` | clade | metaphlan + bracken + gtdb | `method`, `data_type` | unified; keep it **narrow** (see below) |
+| `taxonomic_profile_metaphlan` | clade | metaphlan | `data_type` | native percent + coverage/estimated_reads |
+| `taxonomic_profile_bracken` | clade | bracken | `data_type` | native read-count fraction + estimated_reads |
 | `marker_abundance` | marker | metaphlan marker_abundance | `data_type` | float value |
 | `marker_presence` | marker | metaphlan marker_presence | `data_type` | **degenerate** — see below |
 | `resistome` | AMR gene | rgi_bwt | `data_type` | wide, own shape |
 | `qc_metrics` | sample | `manifest.read_accounting` | — | one row/sample (dimension) |
 
-- **`taxonomic_profile` stays a single table**, with a `method` column, because metaphlan/gtdb/bracken share grain and core datatype (float relative abundance). Splitting into three buys nothing and loses cross-method ergonomics. Keep it **narrow**: `keys + method + data_type + taxon key(s) + rank + relative_abundance`. `coverage`/`est_reads` are metaphlan-only and mostly null — move them to a metaphlan sidecar or accept nullable; partitioning by `method` (below) means a gtdb partition simply has no such columns, so the null sprawl compresses away.
+- **Separate per-method tables** (`taxonomic_profile_metaphlan`, `taxonomic_profile_bracken`), *not* one unified table. (Supersedes the earlier single-table-with-`method`-column proposal.) The deciding factor: the abundance columns carry **different value interpretations** — metaphlan `relative_abundance` is a percent, bracken `fraction_total_reads` is a read-count fraction — and mixing interpretations in one column is a footgun. Separation also lets each table keep its **native units** (no lossy %→fraction normalization) and its **method-specific columns** (metaphlan `coverage`/`estimated_reads`; bracken `estimated_reads`) without null sprawl. Cross-method comparison is a deliberate `UNION`/join, not an accidental `avg()` over mixed semantics.
 - **Do NOT denormalize provenance onto every clade row.** At 270–1,200 clade rows/sample × 500k samples, repeating `accessions`/`db_version`/read counts is enormous waste. Per-sample provenance lives once in `qc_metrics` (the dimension), joined on `sample_id`.
 - **`marker_presence` is degenerate as published** — every row is `present=true` (the metaphlan presence table only emits present markers). Presence is encoded by *row existence*; the boolean column carries no information. Store it as `(sample_id, marker_name, data_type)` membership and drop the boolean. (Lesson: can't pick the column — or know you don't need it — until you've seen the values.)
 - **full/rarefied is a column (`data_type`), not a table.** Same grain, same datatype — just computed on all reads vs a subsample. It's a discriminator, and an excellent partition key (below).

--- a/src/nextflow_telemetry/etl/lake.py
+++ b/src/nextflow_telemetry/etl/lake.py
@@ -46,9 +46,15 @@ _ID = {"sample_id": "VARCHAR", "study_name": "VARCHAR", "run_ids": "VARCHAR",
 _BRANCH = {"data_type": "VARCHAR"}
 
 SCHEMAS: dict[str, dict[str, str]] = {
-    "taxonomic_profile": {**_ID, **_BRANCH, "method": "VARCHAR", "clade_name": "VARCHAR",
-                          "rank": "VARCHAR", "ncbi_taxid": "INTEGER", "sgb_id": "VARCHAR",
-                          "relative_abundance": "DOUBLE"},
+    # Separate per-method profiles — one value interpretation per table.
+    "taxonomic_profile_metaphlan": {**_ID, **_BRANCH, "clade_name": "VARCHAR", "rank": "VARCHAR",
+                          "ncbi_taxid": "INTEGER", "sgb_id": "VARCHAR",
+                          "relative_abundance": "DOUBLE",  # metaphlan percent (native)
+                          "coverage": "DOUBLE", "estimated_reads": "BIGINT"},
+    "taxonomic_profile_bracken": {**_ID, **_BRANCH, "clade_name": "VARCHAR", "rank": "VARCHAR",
+                          "ncbi_taxid": "INTEGER",
+                          "fraction_total_reads": "DOUBLE",  # bracken read-count fraction (native)
+                          "estimated_reads": "BIGINT"},
     "resistome": {**_ID, **_BRANCH, "gene": "VARCHAR", "template_coverage": "DOUBLE",
                   "template_identity": "DOUBLE", "depth": "DOUBLE", "score": "DOUBLE"},
     "qc_metrics": {**_ID, "reads_raw": "BIGINT", "reads_decontaminated": "BIGINT",

--- a/src/nextflow_telemetry/etl/parsers.py
+++ b/src/nextflow_telemetry/etl/parsers.py
@@ -47,14 +47,23 @@ def _as_int(s: str) -> int | None:
     return int(s) if s.lstrip("-").isdigit() and s != "-1" else None
 
 
+def _as_float(s: str) -> float | None:
+    try:
+        return float(s)
+    except ValueError:
+        return None
+
+
 def parse_metaphlan_profile(raw: bytes) -> Iterator[dict]:
-    """metaphlan marker_rel_ab_w_read_stats → taxonomic_profile rows.
+    """metaphlan marker_rel_ab_w_read_stats → taxonomic_profile_metaphlan rows.
 
     Columns (no real header — every leading line is a ``#`` comment):
-    clade_name, clade_taxid (lineage of NCBI taxids), relative_abundance (%),
-    coverage, est_reads. rel_ab is normalized %→fraction so it shares a scale
-    with bracken. The terminal taxid is the row's NCBI taxid; a ``t__SGB`` leaf
-    carries the SGB id.
+    clade_name, clade_taxid (lineage of NCBI taxids), relative_abundance,
+    coverage, estimated_reads. **Native units**: metaphlan `relative_abundance`
+    is a percent (sums to ~100 within a rank) — kept as-reported, not normalized,
+    since it lives in its own table now. The terminal taxid is the row's NCBI
+    taxid; a ``t__SGB`` leaf carries the SGB id. ``coverage`` is ``-`` above the
+    SGB leaves (→ None).
     """
     for f in _rows(raw):
         if len(f) < 3:
@@ -62,9 +71,8 @@ def parse_metaphlan_profile(raw: bytes) -> Iterator[dict]:
         clade = f[0]
         last = clade.split("|")[-1]
         rank = _RANK.get(last[0]) if len(last) > 2 and last[1] == "_" else None
-        try:
-            rel = float(f[2]) / 100.0
-        except ValueError:
+        rel = _as_float(f[2])
+        if rel is None:
             continue
         yield {
             "clade_name": clade,
@@ -72,12 +80,16 @@ def parse_metaphlan_profile(raw: bytes) -> Iterator[dict]:
             "ncbi_taxid": _as_int(f[1].split("|")[-1]),
             "sgb_id": last if last.startswith("t__SGB") else None,
             "relative_abundance": rel,
+            "coverage": _as_float(f[3]) if len(f) > 3 else None,
+            "estimated_reads": int(float(f[4])) if len(f) > 4 and f[4].strip() not in ("", "-") else None,
         }
 
 
 def parse_bracken(raw: bytes) -> Iterator[dict]:
-    """bracken.species/genus → taxonomic_profile rows. Normal header row;
-    ``fraction_total_reads`` is already a 0–1 fraction."""
+    """bracken.species/genus → taxonomic_profile_bracken rows. Normal header row;
+    ``fraction_total_reads`` is a read-count fraction (0–1, native) — a different
+    interpretation from metaphlan's percent, which is why bracken has its own
+    table."""
     rows = _rows(raw, comment=None)
     header = next(rows, None)
     if not header:
@@ -90,8 +102,8 @@ def parse_bracken(raw: bytes) -> Iterator[dict]:
             "clade_name": f[idx["name"]],
             "rank": _BRACKEN_LVL.get(f[idx["taxonomy_lvl"]].strip()),
             "ncbi_taxid": _as_int(f[idx["taxonomy_id"]]),
-            "sgb_id": None,
-            "relative_abundance": float(f[idx["fraction_total_reads"]]),
+            "fraction_total_reads": float(f[idx["fraction_total_reads"]]),
+            "estimated_reads": _as_int(f[idx["new_est_reads"]]),
         }
 
 

--- a/src/nextflow_telemetry/etl/parsers.py
+++ b/src/nextflow_telemetry/etl/parsers.py
@@ -54,6 +54,12 @@ def _as_float(s: str) -> float | None:
         return None
 
 
+def _as_bigint(s: str) -> int | None:
+    """Tolerant int for read-count columns that may be '-'/'' or float-formatted."""
+    v = _as_float(s)
+    return int(v) if v is not None else None
+
+
 def parse_metaphlan_profile(raw: bytes) -> Iterator[dict]:
     """metaphlan marker_rel_ab_w_read_stats → taxonomic_profile_metaphlan rows.
 
@@ -81,7 +87,7 @@ def parse_metaphlan_profile(raw: bytes) -> Iterator[dict]:
             "sgb_id": last if last.startswith("t__SGB") else None,
             "relative_abundance": rel,
             "coverage": _as_float(f[3]) if len(f) > 3 else None,
-            "estimated_reads": int(float(f[4])) if len(f) > 4 and f[4].strip() not in ("", "-") else None,
+            "estimated_reads": _as_bigint(f[4]) if len(f) > 4 else None,
         }
 
 

--- a/src/nextflow_telemetry/etl/specs.py
+++ b/src/nextflow_telemetry/etl/specs.py
@@ -29,17 +29,19 @@ class OutputSpec:
 
 SPECS: dict[tuple[str, str], list[OutputSpec]] = {
     ("cmgd_nextflow", "2.2.1"): [
+        # Separate per-method tables — metaphlan (percent) and bracken (read-count
+        # fraction) are different value interpretations, so they don't share a column.
         OutputSpec(
             "metaphlan_markers/marker_rel_ab_w_read_stats.tsv.gz",
-            "taxonomic_profile", parsers.parse_metaphlan_profile, {"method": "metaphlan"},
+            "taxonomic_profile_metaphlan", parsers.parse_metaphlan_profile,
         ),
         OutputSpec(
             "kraken/bracken.species.txt.gz",
-            "taxonomic_profile", parsers.parse_bracken, {"method": "bracken"},
+            "taxonomic_profile_bracken", parsers.parse_bracken,
         ),
         OutputSpec(
             "kraken/bracken.genus.txt.gz",
-            "taxonomic_profile", parsers.parse_bracken, {"method": "bracken"},
+            "taxonomic_profile_bracken", parsers.parse_bracken,
         ),
         OutputSpec(
             "resistome/card_kma.res.gz",

--- a/tests/test_etl_parsers.py
+++ b/tests/test_etl_parsers.py
@@ -39,12 +39,13 @@ MANIFEST = (
 )
 
 
-def test_metaphlan_normalizes_and_extracts():
+def test_metaphlan_native_units_and_extraction():
     rows = list(P.parse_metaphlan_profile(METAPHLAN))
     assert len(rows) == 4
     kingdom = rows[1]
     assert kingdom["rank"] == "kingdom"
-    assert abs(kingdom["relative_abundance"] - 0.835) < 1e-9  # percent -> fraction
+    assert kingdom["relative_abundance"] == 83.5   # native percent, not normalized
+    assert kingdom["coverage"] is None and kingdom["estimated_reads"] == 8000
     species = rows[2]
     assert species["rank"] == "species" and species["ncbi_taxid"] == 165179
     assert species["sgb_id"] is None
@@ -53,10 +54,12 @@ def test_metaphlan_normalizes_and_extracts():
     assert rows[0]["ncbi_taxid"] is None  # UNCLASSIFIED / -1 -> None
 
 
-def test_bracken_fraction_and_rank():
+def test_bracken_native_fraction_and_reads():
     (row,) = list(P.parse_bracken(BRACKEN))
     assert row["rank"] == "species" and row["ncbi_taxid"] == 165179
-    assert row["relative_abundance"] == 0.34937  # already a fraction, unchanged
+    assert row["fraction_total_reads"] == 0.34937  # native read-count fraction
+    assert row["estimated_reads"] == 11228086
+    assert "relative_abundance" not in row  # bracken doesn't share metaphlan's column
 
 
 def test_resistome_padded_numerics():


### PR DESCRIPTION
Per review feedback — **don't mix value interpretations in one column.** metaphlan `relative_abundance` is a percent (marker/genome-size-normalized); bracken `fraction_total_reads` is a 0–1 read-count fraction. So `taxonomic_profile` is split into **`taxonomic_profile_metaphlan`** and **`taxonomic_profile_bracken`**.

Benefits: every column has one meaning; native units are preserved (dropped the lossy %→fraction normalization); each table keeps its method-specific columns (metaphlan `coverage`/`estimated_reads`, bracken `estimated_reads`) with no null sprawl. Cross-method comparison becomes a deliberate `UNION`/join, not an accidental `avg()` over mixed semantics.

The generic engine is unchanged — only `specs.py` routes to the new table names and `lake.SCHEMAS` defines them (the payoff of the spec/engine split). Consumer guide + design doc updated; parser tests assert native units and the method columns. Verified end-to-end against real 2.2.1 output and against the live DuckLake (Postgres `cmgd_lake` catalog + R2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EyZad3U7YthLPfWq9PN8ZW