### PR TITLE
feat(samples): single collection-membership write seam; retire metadata.cohort

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,45 @@
+# Nextflow Telemetry
+
+Telemetry and pull-mode HPC orchestration backend for running Nextflow workflows
+across many samples and reporting on their progress. This glossary pins the terms
+that are easy to conflate; it is not a spec.
+
+## Language
+
+**Collection**:
+A named, many-to-many set of samples — the canonical grouping concept. A collection
+may be *study-based* (derived from an accession such as a BioProject/SRA study) or
+*logical* (an arbitrary curated set). "Collection" is deliberately neutral: it carries
+no biological or medical interpretation, which is why it subsumes the others. A
+collection is identified by an exact-string natural key (its name; for study-based
+collections, the accession) — there is no surrogate id, so two references to the same
+string are the same collection.
+Purpose is operational, not analytic: a collection exists so the team can watch how
+close a set of samples is to completion. Nothing computes on collections, so membership
+overlap (a sample in several collections) is fine and expected.
+_Avoid_: cohort, study (as a top-level concept), curated study
+
+**Study**:
+Not a first-class concept — a *source* of a collection. A study-based collection is a
+collection whose provenance is an accession. Use "collection" for the thing itself.
+
+**Sample**:
+The content-addressed unit of work: identity is the md5 of its sorted, deduplicated
+SRR set, so the same SRRs always resolve to the same sample. A sample can belong to
+many collections. The sample row is *identity only* (sample_id, SRR accessions) — it
+is not a place to hang descriptive attributes. Anything descriptive (cohort labels,
+curated annotations) lives in a separate table keyed by sample, never as a column or
+`metadata` key on the sample.
+_Avoid_: run, dataset
+
+**Curated metadata**:
+Descriptive per-sample annotations (originating from curated TSV imports), kept in
+their own table, many-to-one with Sample. Deliberately outside the sample row so the
+telemetry/jobs core stays lean. Currently a partial island (`curated_sample_annotations`);
+future work joins it in.
+
+**Membership**:
+The link between a sample and a collection (`collection_samples`). Many-to-many: one
+sample in several collections, one collection over many samples. The single source of
+truth for "what collection is this sample in" — not `metadata.cohort`, which is a
+legacy scalar shadow being retired.

--- a/docs/adr/0005-single-collection-membership-seam.md
+++ b/docs/adr/0005-single-collection-membership-seam.md
@@ -1,0 +1,33 @@
+# Single write seam for collection membership; `metadata.cohort` retired
+
+## Context
+
+"Which collection is this sample in?" was written three ways — the accession
+path wrote `collections` + `collection_samples`, `POST /samples` wrote a scalar
+`metadata.cohort`, and curated import wrote its own island — and read two ways
+(the Cohorts dashboard read `collections`, the Samples page read
+`metadata.cohort`). The two surfaces therefore disagreed: a sample was visible
+to one and invisible to the other depending on how it was registered.
+
+## Decision
+
+Collection membership has **one write seam**: `add_to_collection(conn, …)` in
+`services/collection.py`. Every registration path (accession `_register`, single
+`POST /samples`, curated later) routes through it, and every reader reads the
+`collection_samples` join. `metadata.cohort` is retired as a membership encoding
+— backfilled into collections, then stripped from the sample row. A collection
+is identified by an exact-string natural key (its name / the accession); there
+is no surrogate id.
+
+## Notes
+
+- The seam is a plain `conn`-taking async function, **not** a
+  Service-with-its-own-engine (the repo's usual shape), so that "insert sample +
+  insert membership" stays inside the caller's single transaction. This is a
+  deliberate deviation from the `services/*.py` pattern — atomicity over
+  uniformity.
+- `metadata.cohort` is dropped, not kept as a derived cache: a Sample row is
+  identity only (see `CONTEXT.md`). Descriptive attributes move to a separate
+  many-to-one table later.
+- Membership is many-to-many and purely operational (completion monitoring), so
+  Samples-page collection chips are overlap-allowed, not a partition.

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -20,7 +20,7 @@ import type {
   DispatchabilityResult,
   SampleResponse,
   SampleListResponse,
-  CohortFacetsResponse,
+  CollectionFacetsResponse,
   SampleRegisterRequest,
   SubmittedRequest,
   DaemonAgentResponse,
@@ -92,13 +92,13 @@ export const api = {
   },
 
   samples: {
-    list:   (offset: number, limit: number, search?: string, cohort?: string) => {
+    list:   (offset: number, limit: number, search?: string, collection?: string) => {
       const params = new URLSearchParams({ offset: String(offset), limit: String(limit) })
       if (search) params.set('search', search)
-      if (cohort) params.set('cohort', cohort)
+      if (collection) params.set('collection', collection)
       return get<SampleListResponse>(`/samples?${params}`)
     },
-    cohortFacets: () => get<CohortFacetsResponse>('/samples/facets/cohorts'),
+    collectionFacets: () => get<CollectionFacetsResponse>('/samples/facets/collections'),
     create: (body: SampleRegisterRequest) => post<SampleResponse>('/samples', body),
   },
 

--- a/frontend/src/lib/mock-data.ts
+++ b/frontend/src/lib/mock-data.ts
@@ -200,7 +200,7 @@ export const MOCK_SAMPLE_COHORTS = ['IBD-PRISM','HMP2','PEDIATRIC-CD','HEALTHY-C
 export const MOCK_SAMPLE_PHENOTYPES = ['CD','UC','healthy','unclassified','T2D']
 export const MOCK_SAMPLE_SOURCES = ['stool','biopsy','saliva','blood']
 
-export function genSamplePage(page = 0, pageSize = 50, _search = '', cohort = ''): SampleResponse[] {
+export function genSamplePage(page = 0, pageSize = 50, _search = '', collection = ''): SampleResponse[] {
   const seed = page * 1000
   const lcg = (n: number) => ((n * 1664525 + 1013904223) & 0xffffffff) >>> 0
   const rows: SampleResponse[] = []
@@ -211,14 +211,15 @@ export function genSamplePage(page = 0, pageSize = 50, _search = '', cohort = ''
     const s2  = lcg(s1)
     const s3  = lcg(s2)
     const s4  = lcg(s3)
-    const cohortVal = MOCK_SAMPLE_COHORTS[s1 % MOCK_SAMPLE_COHORTS.length]!
+    const collectionVal = MOCK_SAMPLE_COHORTS[s1 % MOCK_SAMPLE_COHORTS.length]!
     const phenotype = MOCK_SAMPLE_PHENOTYPES[s2 % MOCK_SAMPLE_PHENOTYPES.length]!
     const source    = MOCK_SAMPLE_SOURCES[s3 % MOCK_SAMPLE_SOURCES.length]!
-    if (cohort && cohortVal !== cohort) continue
+    if (collection && collectionVal !== collection) continue
     rows.push({
       id: page * pageSize + i + 1,
       sample_id: `SRR${(10000000 + idx * 137) % 100000000}`,
-      metadata: { cohort: cohortVal, phenotype, source, read_count: 10_000_000 + (s4 % 110_000_000) },
+      metadata: { phenotype, source, read_count: 10_000_000 + (s4 % 110_000_000) },
+      collections: [collectionVal],
       created_at: new Date(Date.now() - (idx % 400) * 86_400_000).toISOString(),
       updated_at: new Date(Date.now() - (idx %  10) * 86_400_000).toISOString(),
     })

--- a/frontend/src/pages/SamplesPage.tsx
+++ b/frontend/src/pages/SamplesPage.tsx
@@ -18,11 +18,11 @@ function SampleFormModal({
   onClose, onSave,
 }: {
   onClose: () => void
-  onSave: (data: { sampleId: string; cohort: string; phenotype: string; source: string }) => void
+  onSave: (data: { sampleId: string; collection: string; phenotype: string; source: string }) => void
 }) {
-  const [sampleId,  setSampleId]  = useState('')
-  const [cohort,    setCohort]    = useState('')
-  const [phenotype, setPhenotype] = useState('')
+  const [sampleId,   setSampleId]   = useState('')
+  const [collection, setCollection] = useState('')
+  const [phenotype,  setPhenotype]  = useState('')
   const [source,    setSource]    = useState('')
   const valid = sampleId.trim().length > 0
 
@@ -41,7 +41,7 @@ function SampleFormModal({
         <div style={{ fontSize: 16, fontWeight: 700, color: T.text }}>Register Sample</div>
         <Input label="Sample ID" value={sampleId} onChange={setSampleId} placeholder="SRR1234567" mono />
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
-          <Input label="Cohort (optional)"    value={cohort}    onChange={setCohort}    placeholder="IBD-PRISM" />
+          <Input label="Collection (optional)" value={collection} onChange={setCollection} placeholder="IBD-PRISM" />
           <Input label="Phenotype (optional)" value={phenotype} onChange={setPhenotype} placeholder="CD" />
         </div>
         <Input label="Source (optional)" value={source} onChange={setSource} placeholder="stool" />
@@ -62,7 +62,7 @@ function SampleFormModal({
         </div>
         <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end' }}>
           <Btn variant="ghost" onClick={onClose}>Cancel</Btn>
-          <Btn disabled={!valid} onClick={() => valid && onSave({ sampleId, cohort, phenotype, source })}>Register</Btn>
+          <Btn disabled={!valid} onClick={() => valid && onSave({ sampleId, collection, phenotype, source })}>Register</Btn>
         </div>
       </div>
     </div>
@@ -73,10 +73,10 @@ export default function SamplesPage({ pollInterval = 30_000 }: { pollInterval?: 
   const [page,     setPage]     = useState(0)
   const [search,   setSearch]   = useState('')
   const [debouncedSearch, setDebouncedSearch] = useState('')
-  const [cohort,   setCohort]   = useState('')
+  const [collection, setCollection] = useState('')
   const [items,    setItems]    = useState<SampleResponse[]>([])
   const [total,    setTotal]    = useState(0)
-  const [facets,   setFacets]   = useState<{ total: number; cohorts: Array<{ cohort: string; count: number }> }>({ total: 0, cohorts: [] })
+  const [facets,   setFacets]   = useState<{ total: number; collections: Array<{ collection: string; count: number }> }>({ total: 0, collections: [] })
   const [showForm, setShowForm] = useState(false)
   const { tick, refresh, lastUpdated } = usePoll(pollInterval)
   const isAdmin = useRole('admin')
@@ -91,16 +91,16 @@ export default function SamplesPage({ pollInterval = 30_000 }: { pollInterval?: 
   // catalog stays correct past the old 1000-row client ceiling (#118).
   useEffect(() => {
     let ignore = false
-    api.samples.list(page * PAGE_SIZE, PAGE_SIZE, debouncedSearch || undefined, cohort || undefined)
+    api.samples.list(page * PAGE_SIZE, PAGE_SIZE, debouncedSearch || undefined, collection || undefined)
       .then(r => { if (!ignore) { setItems(r.items); setTotal(r.total) } })
       .catch(console.error)
     return () => { ignore = true }
-  }, [page, debouncedSearch, cohort, tick])
+  }, [page, debouncedSearch, collection, tick])
 
-  // Cohort chips + grand total come from a whole-catalog facet query, so they
+  // Collection chips + grand total come from a whole-catalog facet query, so they
   // don't shift as the user pages or filters.
   useEffect(() => {
-    api.samples.cohortFacets().then(setFacets).catch(console.error)
+    api.samples.collectionFacets().then(setFacets).catch(console.error)
   }, [tick])
 
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
@@ -111,8 +111,8 @@ export default function SamplesPage({ pollInterval = 30_000 }: { pollInterval?: 
     setPage(0)
   }, [])
 
-  const handleCohort = useCallback((c: string) => {
-    setCohort(prev => prev === c ? '' : c)
+  const handleCollection = useCallback((c: string) => {
+    setCollection(prev => prev === c ? '' : c)
     setPage(0)
   }, [])
 
@@ -135,14 +135,14 @@ export default function SamplesPage({ pollInterval = 30_000 }: { pollInterval?: 
       </div>
 
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(150px, 1fr))', gap: 10 }}>
-        {facets.cohorts.map(({ cohort: c, count }) => (
-          <button key={c} onClick={() => handleCohort(c)} style={{
-            background: cohort === c ? T.accentDim : T.surface,
-            border: `1px solid ${cohort === c ? T.accent : T.border}`,
+        {facets.collections.map(({ collection: c, count }) => (
+          <button key={c} onClick={() => handleCollection(c)} style={{
+            background: collection === c ? T.accentDim : T.surface,
+            border: `1px solid ${collection === c ? T.accent : T.border}`,
             borderRadius: 6, padding: '10px 14px', cursor: 'pointer',
             textAlign: 'left', transition: 'all 0.15s',
           }}>
-            <div style={{ fontSize: 11, color: cohort === c ? T.accent : T.muted,
+            <div style={{ fontSize: 11, color: collection === c ? T.accent : T.muted,
               fontWeight: 600, letterSpacing: '0.04em', textTransform: 'uppercase' }}>{c}</div>
             <div style={{ fontSize: 18, fontWeight: 700, color: T.text, marginTop: 4,
               fontFamily: 'DM Mono, monospace' }}>{fmtNum(count)}</div>
@@ -154,8 +154,8 @@ export default function SamplesPage({ pollInterval = 30_000 }: { pollInterval?: 
         <div style={{ flex: 1, minWidth: 220, maxWidth: 360 }}>
           <Input label="Search by sample ID" value={search} onChange={handleSearch} placeholder="SRR…" mono />
         </div>
-        {(search || cohort) && (
-          <Btn variant="ghost" small onClick={() => { setSearch(''); setCohort(''); setPage(0) }}>
+        {(search || collection) && (
+          <Btn variant="ghost" small onClick={() => { setSearch(''); setCollection(''); setPage(0) }}>
             Clear filters
           </Btn>
         )}
@@ -168,8 +168,13 @@ export default function SamplesPage({ pollInterval = 30_000 }: { pollInterval?: 
               render: v => <span style={{ color: T.muted }}>{(v as number).toLocaleString()}</span> },
             { key: 'sample_id',  label: 'Sample ID', mono: true,
               render: v => <span style={{ color: T.accent }}>{v as string}</span> },
-            { key: 'metadata',   label: 'Cohort',
-              render: v => <Badge label={(v as Record<string,string>)['cohort'] ?? ''} variant="neutral" /> },
+            { key: 'collections', label: 'Collection',
+              render: v => {
+                const cs = (v as string[]) ?? []
+                return cs.length
+                  ? <>{cs.map(c => <Badge key={c} label={c} variant="neutral" />)}</>
+                  : <span style={{ color: T.muted }}>—</span>
+              } },
             { key: 'metadata',   label: 'Phenotype', mono: true,
               render: v => (v as Record<string,string>)['phenotype'] ?? '—' },
             { key: 'metadata',   label: 'Source',    mono: true,
@@ -209,11 +214,11 @@ export default function SamplesPage({ pollInterval = 30_000 }: { pollInterval?: 
       {showForm && (
         <SampleFormModal
           onClose={() => setShowForm(false)}
-          onSave={({ sampleId, cohort: c, phenotype, source }) => {
-            const metadata: Record<string, string> = { cohort: c }
+          onSave={({ sampleId, collection: c, phenotype, source }) => {
+            const metadata: Record<string, string> = {}
             if (phenotype) metadata['phenotype'] = phenotype
             if (source)    metadata['source']    = source
-            api.samples.create({ sample_id: sampleId, metadata })
+            api.samples.create({ sample_id: sampleId, collection: c || undefined, metadata })
               .then(() => {
                 api.admin.reconcile().catch(console.error)
                 setShowForm(false)

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -8,6 +8,7 @@ export interface SampleResponse {
   id: number
   sample_id: string
   metadata: Record<string, unknown> | null
+  collections: string[]
   created_at: string
   updated_at: string
 }
@@ -19,9 +20,9 @@ export interface SampleListResponse {
   offset: number
 }
 
-export interface CohortFacetsResponse {
+export interface CollectionFacetsResponse {
   total: number
-  cohorts: Array<{ cohort: string; count: number }>
+  collections: Array<{ collection: string; count: number }>
 }
 
 export interface WorkflowResponse {
@@ -252,6 +253,7 @@ export interface JobTotals extends JobStats {
 export interface SampleRegisterRequest {
   sample_id: string
   metadata?: Record<string, unknown>
+  collection?: string
 }
 
 export interface SubmittedRequest {

--- a/src/nextflow_telemetry/migrations/versions/20260710_d8e9fa0b_backfill_cohort_to_collections.py
+++ b/src/nextflow_telemetry/migrations/versions/20260710_d8e9fa0b_backfill_cohort_to_collections.py
@@ -1,0 +1,63 @@
+"""backfill_cohort_to_collections
+
+Revision ID: d8e9fa0b
+Revises: c7d8e9fa
+Create Date: 2026-07-10
+
+Retire `metadata.cohort` as a collection-membership encoding (ADR-0005). The
+Samples page used to read a scalar `samples.metadata_->>'cohort'`, while the
+Cohorts dashboard read `collections`/`collection_samples`, so the two disagreed.
+
+This migration folds the legacy scalar into the single source of truth:
+
+  1. Each distinct `metadata_->>'cohort'` value becomes a collection
+     (source='legacy'; its exact string is the collection_id — see CONTEXT.md).
+     ON CONFLICT DO NOTHING so a value that already names a real collection
+     (e.g. an accession) merges into it rather than duplicating.
+  2. A membership row is created for every sample carrying that cohort value.
+  3. The now-dead `cohort` key is stripped from `samples.metadata_`. Other keys
+     (phenotype, source, provenance) are untouched — the sample row keeps its
+     metadata column, only this key goes.
+
+Irreversible: the pre-strip cohort strings can't be reconstructed, so downgrade
+leaves the derived collections/membership in place and is otherwise a no-op.
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "d8e9fa0b"
+down_revision: Union[str, Sequence[str], None] = "c7d8e9fa"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        INSERT INTO collections (collection_id, source, type, label, metadata_, created_at, updated_at)
+        SELECT DISTINCT metadata_->>'cohort', 'legacy', NULL, metadata_->>'cohort', NULL::jsonb, now(), now()
+        FROM samples
+        WHERE metadata_->>'cohort' IS NOT NULL AND metadata_->>'cohort' <> ''
+        ON CONFLICT (collection_id) DO NOTHING
+        """
+    )
+    op.execute(
+        """
+        INSERT INTO collection_samples (collection_id, sample_id)
+        SELECT metadata_->>'cohort', sample_id
+        FROM samples
+        WHERE metadata_->>'cohort' IS NOT NULL AND metadata_->>'cohort' <> ''
+        ON CONFLICT ON CONSTRAINT uq_collection_sample DO NOTHING
+        """
+    )
+    op.execute("UPDATE samples SET metadata_ = metadata_ - 'cohort' WHERE metadata_ ? 'cohort'")
+
+
+def downgrade() -> None:
+    # Irreversible: the stripped cohort strings are gone. The derived collections
+    # and membership rows are harmless, so we leave them and no-op.
+    pass

--- a/src/nextflow_telemetry/routers/samples.py
+++ b/src/nextflow_telemetry/routers/samples.py
@@ -17,6 +17,7 @@ class SampleRegisterRequest(BaseModel):
     ncbi_accession: str = Field(description="Semicolon-separated SRR accessions (e.g. 'SRR001;SRR002'). Must contain at least one non-empty accession. Normalised to sorted, deduplicated form on write.")
     biosample_id: str | None = Field(default=None, description="NCBI BioSample accession (e.g. 'SAMN12345678'). Annotation only — not used as identity.")
     metadata: dict[str, Any] | None = Field(default=None, description="Optional arbitrary JSON metadata. Replaced on upsert.")
+    collection: str | None = Field(default=None, description="Optional collection name to attach this sample to. The exact string is the collection id (see CONTEXT.md). Membership is the source of truth — not a metadata key.")
 
     @field_validator("ncbi_accession")
     @classmethod
@@ -33,6 +34,7 @@ class SampleResponse(BaseModel):
     ncbi_accession: str | None = Field(default=None, description="Canonical semicolon-separated SRR list.")
     biosample_id: str | None = Field(default=None, description="NCBI BioSample accession, if known.")
     metadata: dict[str, Any] | None = Field(default=None, description="Arbitrary JSON metadata.")
+    collections: list[str] = Field(default_factory=list, description="Collection ids this sample belongs to (membership is the source of truth).")
     created_at: Any = Field(description="UTC timestamp when this sample was first registered.")
     updated_at: Any = Field(description="UTC timestamp of the most recent update.")
 
@@ -47,14 +49,14 @@ class SampleListResponse(BaseModel):
     offset: int
 
 
-class CohortFacet(BaseModel):
-    cohort: str
+class CollectionFacet(BaseModel):
+    collection: str
     count: int
 
 
-class CohortFacetsResponse(BaseModel):
-    total: int = Field(description="Total samples in the catalog (all cohorts, incl. none).")
-    cohorts: list[CohortFacet] = Field(description="Per-cohort counts across the whole catalog, largest first.")
+class CollectionFacetsResponse(BaseModel):
+    total: int = Field(description="Total samples in the catalog (distinct samples).")
+    collections: list[CollectionFacet] = Field(description="Per-collection sample counts across the whole catalog, largest first. Overlap-allowed (a sample may be in several collections), so counts need not sum to total.")
 
 
 def _row_to_response(row: dict) -> SampleResponse:
@@ -64,6 +66,7 @@ def _row_to_response(row: dict) -> SampleResponse:
         ncbi_accession=row.get("ncbi_accession"),
         biosample_id=row.get("biosample_id"),
         metadata=row["metadata_"],
+        collections=row.get("collections", []),
         created_at=row["created_at"],
         updated_at=row["updated_at"],
     )
@@ -91,6 +94,7 @@ def create_samples_router(engine: AsyncEngine) -> APIRouter:
             ncbi_accession=req.ncbi_accession,
             biosample_id=req.biosample_id,
             metadata=req.metadata,
+            collection=req.collection,
         )
         return _row_to_response(row)
 
@@ -101,35 +105,36 @@ def create_samples_router(engine: AsyncEngine) -> APIRouter:
         description=(
             "Returns a page of samples plus the total matching count. Filter "
             "server-side with `search` (case-insensitive `sample_id` substring) "
-            "and `cohort` (exact `metadata.cohort`), so the catalog stays usable "
-            "well past the old client-side 1000-row ceiling (#118)."
+            "and `collection` (exact collection membership), so the catalog stays "
+            "usable well past the old client-side 1000-row ceiling (#118)."
         ),
     )
     async def list_samples(
         limit: int = Query(default=100, ge=1, le=1000, description="Maximum number of samples to return."),
         offset: int = Query(default=0, ge=0, description="Number of samples to skip."),
         search: str | None = Query(default=None, description="Case-insensitive substring match on sample_id."),
-        cohort: str | None = Query(default=None, description="Exact match on metadata.cohort."),
+        collection: str | None = Query(default=None, description="Exact collection id — returns samples that are members of that collection."),
     ):
-        rows, total = await svc.list_samples(limit=limit, offset=offset, search=search, cohort=cohort)
+        rows, total = await svc.list_samples(limit=limit, offset=offset, search=search, collection=collection)
         return SampleListResponse(
             items=[_row_to_response(r) for r in rows],
             total=total, limit=limit, offset=offset,
         )
 
     @router.get(
-        "/facets/cohorts",
-        response_model=CohortFacetsResponse,
-        summary="Cohort facet counts across the whole catalog",
+        "/facets/collections",
+        response_model=CollectionFacetsResponse,
+        summary="Collection facet counts across the whole catalog",
         description=(
-            "Per-cohort sample counts (from `metadata.cohort`) over ALL samples, "
-            "plus the grand total — powers the Samples-page cohort chips so they "
-            "stay correct regardless of the current page or filters."
+            "Per-collection sample counts (from collection membership) over ALL "
+            "samples, plus the grand total — powers the Samples-page collection "
+            "chips so they stay correct regardless of the current page or filters. "
+            "Reads the same source as the Cohorts dashboard, so the two agree."
         ),
     )
-    async def cohort_facets():
-        total, cohorts = await svc.cohort_facets()
-        return CohortFacetsResponse(total=total, cohorts=[CohortFacet(**c) for c in cohorts])
+    async def collection_facets():
+        total, collections = await svc.collection_facets()
+        return CollectionFacetsResponse(total=total, collections=[CollectionFacet(**c) for c in collections])
 
     @router.get(
         "/by-srr/{srr_accession}",

--- a/src/nextflow_telemetry/services/collection.py
+++ b/src/nextflow_telemetry/services/collection.py
@@ -1,0 +1,58 @@
+"""Collection membership — the single write seam for putting samples in a collection.
+
+Every registration path (accession submission, single-sample register, curated
+import later) routes its membership write through `add_to_collection`. See
+docs/adr/0005-single-collection-membership-seam.md and CONTEXT.md.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncConnection
+
+from ..db import collection_samples_tbl, collections_tbl
+
+
+async def add_to_collection(
+    conn: AsyncConnection,
+    collection_id: str,
+    *,
+    source: str,
+    type_: str | None = None,
+    label: str | None = None,
+    sample_ids: list[str],
+    metadata: dict[str, Any] | None = None,
+) -> None:
+    """Upsert a collection and attach samples to it, within the caller's transaction.
+
+    Takes a live connection (not an engine) so "insert samples + attach
+    membership" stays atomic in the caller's `engine.begin()` block. Idempotent:
+    re-attaching an existing (collection, sample) pair is a no-op; re-declaring a
+    collection only bumps `updated_at`. The samples must already be inserted in
+    the same transaction (FK on `collection_samples.sample_id`).
+    """
+    now = datetime.now(timezone.utc)
+    await conn.execute(
+        pg_insert(collections_tbl)
+        .values(
+            collection_id=collection_id,
+            source=source,
+            type=type_,
+            label=label if label is not None else collection_id,
+            metadata_=metadata,
+            created_at=now,
+            updated_at=now,
+        )
+        .on_conflict_do_update(
+            index_elements=[collections_tbl.c.collection_id],
+            set_={"updated_at": now},
+        )
+    )
+    if sample_ids:
+        await conn.execute(
+            pg_insert(collection_samples_tbl)
+            .values([{"collection_id": collection_id, "sample_id": sid} for sid in sample_ids])
+            .on_conflict_do_nothing(constraint="uq_collection_sample")
+        )

--- a/src/nextflow_telemetry/services/sample.py
+++ b/src/nextflow_telemetry/services/sample.py
@@ -69,6 +69,15 @@ class SampleService:
                 await add_to_collection(
                     conn, collection, source="manual", sample_ids=[sample_id]
                 )
+            # Reflect the sample's current membership in the response (all
+            # collections, not just one just-added — the sample may already
+            # belong to others), consistent with what list_samples returns.
+            mrows = await conn.execute(
+                select(collection_samples_tbl.c.collection_id)
+                .where(collection_samples_tbl.c.sample_id == sample_id)
+                .order_by(collection_samples_tbl.c.collection_id)
+            )
+            row["collections"] = [m[0] for m in mrows.all()]
             return row
 
     async def list_samples(

--- a/src/nextflow_telemetry/services/sample.py
+++ b/src/nextflow_telemetry/services/sample.py
@@ -9,8 +9,9 @@ from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncEngine
 
-from ..db import samples_tbl
+from ..db import collection_samples_tbl, samples_tbl
 from ..utils import normalize_srrs, parse_srrs
+from .collection import add_to_collection
 
 
 @dataclass
@@ -23,12 +24,15 @@ class SampleService:
         ncbi_accession: str | None = None,
         biosample_id: str | None = None,
         metadata: dict[str, Any] | None = None,
+        collection: str | None = None,
     ) -> dict:
         """Insert or update a sample; returns the row.
 
         ncbi_accession is normalised (sorted, deduplicated) before storage.
         metadata_ is replaced on conflict; ncbi_accession and biosample_id are
-        updated only when explicitly supplied.
+        updated only when explicitly supplied. When ``collection`` is given, the
+        sample is attached to that collection (the single membership write seam)
+        in the same transaction.
         """
         now = datetime.now(timezone.utc)
         normalised: str | None = None
@@ -60,7 +64,12 @@ class SampleService:
                 .returning(*samples_tbl.c)
             )
             result = await conn.execute(stmt)
-            return dict(result.mappings().one())
+            row = dict(result.mappings().one())
+            if collection:
+                await add_to_collection(
+                    conn, collection, source="manual", sample_ids=[sample_id]
+                )
+            return row
 
     async def list_samples(
         self,
@@ -68,20 +77,25 @@ class SampleService:
         offset: int = 0,
         *,
         search: str | None = None,
-        cohort: str | None = None,
+        collection: str | None = None,
     ) -> tuple[list[dict], int]:
         """Return (page_of_samples, total_matching_count).
 
+        Each returned row carries a ``collections`` list (its collection_ids).
         Filtering is server-side so the catalog is usable past the old
         client-side 1000-row ceiling (#118): ``search`` is a case-insensitive
-        substring match on ``sample_id``; ``cohort`` matches
-        ``metadata_->>'cohort'`` exactly.
+        substring match on ``sample_id``; ``collection`` matches membership in a
+        collection (via ``collection_samples``) — the single source of truth,
+        not the retired ``metadata.cohort`` scalar.
         """
         conds = []
         if search:
             conds.append(samples_tbl.c.sample_id.ilike(f"%{search}%"))
-        if cohort:
-            conds.append(samples_tbl.c.metadata_["cohort"].astext == cohort)
+        if collection:
+            conds.append(samples_tbl.c.sample_id.in_(
+                select(collection_samples_tbl.c.sample_id)
+                .where(collection_samples_tbl.c.collection_id == collection)
+            ))
 
         async with self.engine.connect() as conn:
             page = await conn.execute(
@@ -93,28 +107,45 @@ class SampleService:
             total = (await conn.execute(
                 select(func.count()).select_from(samples_tbl).where(*conds)
             )).scalar_one()
+
+            # Attach each sample's collection memberships (one extra query for
+            # the page, not a GROUP BY on the main list query).
+            sample_ids = [r["sample_id"] for r in rows]
+            memberships: dict[str, list[str]] = {}
+            if sample_ids:
+                mrows = await conn.execute(
+                    select(collection_samples_tbl.c.sample_id, collection_samples_tbl.c.collection_id)
+                    .where(collection_samples_tbl.c.sample_id.in_(sample_ids))
+                    .order_by(collection_samples_tbl.c.collection_id)
+                )
+                for m in mrows.mappings():
+                    memberships.setdefault(m["sample_id"], []).append(m["collection_id"])
+            for r in rows:
+                r["collections"] = memberships.get(r["sample_id"], [])
         return rows, total
 
-    async def cohort_facets(self) -> tuple[int, list[dict]]:
-        """Return (total_samples, [{cohort, count}]) across the whole catalog.
+    async def collection_facets(self) -> tuple[int, list[dict]]:
+        """Return (total_samples, [{collection, count}]) across the whole catalog.
 
-        Powers the Samples-page cohort chips at scale — global counts that don't
-        shift as the user pages. Uses the current free-text ``metadata_->>'cohort''``
-        representation; this becomes membership-driven once the Epic A
-        consolidation lands (docs/study-sample-version-identity.md).
+        Powers the Samples-page collection chips at scale — global counts that
+        don't shift as the user pages. Membership-driven (``collection_samples``),
+        the same source the Cohorts dashboard reads, so the two agree. Counts are
+        overlap-allowed: a sample in N collections contributes to N chips, so the
+        chip counts need not sum to ``total`` (many-to-many membership).
         """
-        cohort_expr = samples_tbl.c.metadata_["cohort"].astext
         async with self.engine.connect() as conn:
             total = (await conn.execute(
                 select(func.count()).select_from(samples_tbl)
             )).scalar_one()
             rows = (await conn.execute(
-                select(cohort_expr.label("cohort"), func.count().label("count"))
-                .where(cohort_expr.isnot(None))
-                .group_by(cohort_expr)
-                .order_by(func.count().desc(), cohort_expr)
+                select(
+                    collection_samples_tbl.c.collection_id.label("collection"),
+                    func.count().label("count"),
+                )
+                .group_by(collection_samples_tbl.c.collection_id)
+                .order_by(func.count().desc(), collection_samples_tbl.c.collection_id)
             )).mappings().all()
-        return total, [{"cohort": r["cohort"], "count": r["count"]} for r in rows]
+        return total, [{"collection": r["collection"], "count": r["count"]} for r in rows]
 
     async def get(self, sample_id: str) -> dict | None:
         async with self.engine.connect() as conn:

--- a/src/nextflow_telemetry/services/submission.py
+++ b/src/nextflow_telemetry/services/submission.py
@@ -15,11 +15,11 @@ from typing import Any
 
 import httpx
 from sqlalchemy import select
-from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncEngine
 
-from ..db import collection_samples_tbl, collections_tbl, samples_tbl, submissions_tbl
+from ..db import samples_tbl, submissions_tbl
 from ..utils import normalize_srrs, srrs_to_sample_id
+from .collection import add_to_collection
 
 ENA_FILEREPORT = "https://www.ebi.ac.uk/ena/portal/api/filereport"
 ENA_FIELDS = (
@@ -196,7 +196,7 @@ class SubmissionService:
 
     async def _register(
         self, *, submission_id: str, method: str, accession: str | None,
-        collection_id: str, source: str | None, type_: str | None,
+        collection_id: str, source: str, type_: str | None,
         submitted_by: str, samples: list[dict[str, Any]],
     ) -> dict[str, int]:
         """Shared core: upsert new samples, the collection, membership, and the submission row."""
@@ -224,22 +224,10 @@ class SubmissionService:
                     } for sid in new_ids],
                 )
 
-            await conn.execute(
-                pg_insert(collections_tbl)
-                .values(
-                    collection_id=collection_id, source=source, type=type_, label=collection_id,
-                    metadata_={"origin": "submission", "accession": accession},
-                    created_at=now, updated_at=now,
-                )
-                .on_conflict_do_update(
-                    index_elements=[collections_tbl.c.collection_id],
-                    set_={"updated_at": now},
-                )
-            )
-            await conn.execute(
-                pg_insert(collection_samples_tbl)
-                .values([{"collection_id": collection_id, "sample_id": sid} for sid in by_id])
-                .on_conflict_do_nothing(constraint="uq_collection_sample")
+            await add_to_collection(
+                conn, collection_id, source=source, type_=type_, label=collection_id,
+                sample_ids=list(by_id),
+                metadata={"origin": "submission", "accession": accession},
             )
 
             counts = {

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -453,9 +453,7 @@ def test_artacho_cohort_full_loop(live_server: LiveServer, db_asyncpg_url: str, 
             resp = client.post("/samples", json={
                 "sample_id": sid,
                 "ncbi_accession": ARTACHO_NCBI[sid],
-                "metadata": {
-                    "cohort": "ArtachoA_2021",
-                },
+                "collection": "ArtachoA_2021",
             })
             assert resp.status_code == 201, f"Failed to register {sid}: {resp.text}"
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -146,7 +146,9 @@ def test_list_samples_search_and_collection_filter(integration_client):
     coll = f"COLL-{tag}"
     ids = [f"SRR-{tag}-{i}" for i in range(3)]
     for i, sid in enumerate(ids):
-        client.post("/api/samples", json={"sample_id": sid, "ncbi_accession": f"SRR00000{i+1}", "collection": coll})
+        r = client.post("/api/samples", json={"sample_id": sid, "ncbi_accession": f"SRR00000{i+1}", "collection": coll})
+        # The register response reflects the membership just written.
+        assert coll in r.json()["collections"], r.json()
     client.post("/api/samples", json={"sample_id": f"OTHER-{tag}", "ncbi_accession": "SRR000009", "collection": "different"})
 
     by_search = client.get(f"/api/samples?search=SRR-{tag}").json()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -140,22 +140,22 @@ def test_list_samples(integration_client):
     assert body["limit"] == 100 and body["offset"] == 0
 
 
-def test_list_samples_search_and_cohort_filter(integration_client):
+def test_list_samples_search_and_collection_filter(integration_client):
     client, _ = integration_client
     tag = uuid.uuid4().hex[:8]
-    coh = f"COH-{tag}"
+    coll = f"COLL-{tag}"
     ids = [f"SRR-{tag}-{i}" for i in range(3)]
     for i, sid in enumerate(ids):
-        client.post("/api/samples", json={"sample_id": sid, "ncbi_accession": f"SRR00000{i+1}", "metadata": {"cohort": coh}})
-    client.post("/api/samples", json={"sample_id": f"OTHER-{tag}", "ncbi_accession": "SRR000009", "metadata": {"cohort": "different"}})
+        client.post("/api/samples", json={"sample_id": sid, "ncbi_accession": f"SRR00000{i+1}", "collection": coll})
+    client.post("/api/samples", json={"sample_id": f"OTHER-{tag}", "ncbi_accession": "SRR000009", "collection": "different"})
 
     by_search = client.get(f"/api/samples?search=SRR-{tag}").json()
     assert by_search["total"] == 3
     assert {x["sample_id"] for x in by_search["items"]} == set(ids)
 
-    by_cohort = client.get(f"/api/samples?cohort={coh}").json()
-    assert by_cohort["total"] == 3
-    assert all(x["metadata"]["cohort"] == coh for x in by_cohort["items"])
+    by_collection = client.get(f"/api/samples?collection={coll}").json()
+    assert by_collection["total"] == 3
+    assert all(coll in x["collections"] for x in by_collection["items"])
 
     # Pagination over the filtered set.
     p0 = client.get(f"/api/samples?search=SRR-{tag}&limit=2&offset=0").json()
@@ -164,19 +164,19 @@ def test_list_samples_search_and_cohort_filter(integration_client):
     assert len(p1["items"]) == 1
 
 
-def test_cohort_facets(integration_client):
+def test_collection_facets(integration_client):
     client, _ = integration_client
     tag = uuid.uuid4().hex[:8]
-    coh = f"FAC-{tag}"
+    coll = f"FAC-{tag}"
     for i in range(2):
-        client.post("/api/samples", json={"sample_id": f"SRR-fac-{tag}-{i}", "ncbi_accession": f"SRR00000{i+1}", "metadata": {"cohort": coh}})
+        client.post("/api/samples", json={"sample_id": f"SRR-fac-{tag}-{i}", "ncbi_accession": f"SRR00000{i+1}", "collection": coll})
 
-    resp = client.get("/api/samples/facets/cohorts")
+    resp = client.get("/api/samples/facets/collections")
     assert resp.status_code == 200
     body = resp.json()
     assert body["total"] >= 2
-    counts = {c["cohort"]: c["count"] for c in body["cohorts"]}
-    assert counts.get(coh) == 2
+    counts = {c["collection"]: c["count"] for c in body["collections"]}
+    assert counts.get(coll) == 2
 
 
 def test_get_sample_not_found(integration_client):


### PR DESCRIPTION
## Why

The Samples page read a scalar `samples.metadata_->>'cohort'` while the Cohorts dashboard read `collections`/`collection_samples`. The two disagreed: a sample was visible to one and invisible to the other depending on how it was registered. Root cause — collection membership had **three** writers and **two** readers.

Design settled in a grilling session; see the new `CONTEXT.md` (glossary) and `docs/adr/0005-single-collection-membership-seam.md`.

## What

- **`services/collection.py`** — `add_to_collection(conn, …)`, the single membership write seam. Takes a connection (not an engine) so "insert sample + attach membership" stays in one transaction. Accession `_register` and single `POST /samples` both route through it (curated import will, later).
- **`POST /samples`** gains an optional `collection` field; sample responses carry `collections`. `?cohort=`→`?collection=`, `/facets/cohorts`→`/facets/collections` — membership-driven and overlap-allowed (same source as the dashboard, so they now agree).
- **Migration `d8e9fa0b`** — backfill each distinct `metadata.cohort` → collection + membership (merge, not duplicate, on a name collision with an existing collection), then strip the dead key. **Forward-only** (`downgrade` is a no-op — values survive as `collection_id`s).
- **Frontend** — Samples page chips, filter, per-sample column, and register form moved onto collection membership.

## Verification

- `mypy` clean · frontend `tsc + vite build` clean · 59 Python tests pass.
- Migration SQL exercised on a real Postgres (backfill + name-collision **merge** + key-strip + other-metadata preservation). That run caught a real bug pre-merge: `NULL` → `NULL::jsonb` for the jsonb column.

## Deploy notes (forward-only, coordinated)

- Migration + API + frontend must ship together (response shape changed).
- `downgrade()` is a deliberate no-op — snapshot the DB before `just migrate`.
- **Do not re-run** the old seeders (`seed_from_tsv.py`, `seed_studies_from_cmd.py`, `load_bioproject.py`) after migrating — they still write the retired `metadata.cohort` key. Converting them is the next slice, not a blocker.

## Out of scope (deferred by design)

Curated-annotation island bridge; broader sample-table slimming; seed-script cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)